### PR TITLE
Fix trace_id/dotted_order validation errors in experiment run migration

### DIFF
--- a/langsmith_migrator/core/api_client.py
+++ b/langsmith_migrator/core/api_client.py
@@ -144,7 +144,18 @@ class EnhancedAPIClient:
         def get_error_detail() -> str:
             try:
                 error_data = response.json()
-                return error_data.get("detail", error_data.get("message", str(error_data)))
+                if isinstance(error_data, dict):
+                    # Handle various error response formats including validation errors
+                    detail = error_data.get("detail")
+                    if detail:
+                        # detail can be a string or a list of validation errors
+                        if isinstance(detail, list):
+                            # Format validation errors for readability
+                            errors = [str(e) for e in detail[:5]]  # Limit to first 5
+                            return "; ".join(errors)
+                        return str(detail)
+                    return error_data.get("message") or error_data.get("error") or str(error_data)
+                return str(error_data)
             except (ValueError, AttributeError):
                 return response.text[:500] if response.text else "No response body"
 

--- a/langsmith_migrator/core/migrators/experiment.py
+++ b/langsmith_migrator/core/migrators/experiment.py
@@ -2,12 +2,65 @@
 
 from typing import Dict, List, Any, Optional, Tuple
 import copy
+import uuid
 
 from .base import BaseMigrator
 
 
 class ExperimentMigrator(BaseMigrator):
     """Handles experiment and run migration."""
+
+    def _regenerate_dotted_order(
+        self,
+        dotted_order: Optional[str],
+        id_mapping: Dict[str, str],
+        new_run_id: str
+    ) -> Optional[str]:
+        """
+        Regenerate dotted_order by replacing source UUIDs with new mapped UUIDs.
+
+        dotted_order format: {timestamp}Z{uuid}.{timestamp}Z{uuid}...
+        - Each part is {timestamp}Z{uuid}
+        - Parts are separated by '.'
+        - First part's UUID is the trace_id (for root) or parent chain
+        - Last part's UUID MUST be the run's own ID
+
+        Args:
+            dotted_order: Original dotted_order string from source
+            id_mapping: Mapping of source UUIDs to destination UUIDs
+            new_run_id: The new run ID - MUST be used for the last part
+
+        Returns:
+            Regenerated dotted_order with new UUIDs, or None if input is None
+        """
+        if not dotted_order:
+            return None
+
+        parts = dotted_order.split(".")
+        new_parts = []
+
+        for i, part in enumerate(parts):
+            # Find the Z separator between timestamp and UUID
+            # Format: 20260203T003519695988Zc9ba7a73-985a-4104-aad7-7e3c4fd27a5f
+            z_idx = part.rfind("Z")
+            if z_idx == -1 or z_idx == len(part) - 1:
+                # No Z found or Z is at the end, keep as-is
+                new_parts.append(part)
+                continue
+
+            timestamp = part[:z_idx + 1]  # Include the Z
+            old_uuid = part[z_idx + 1:]
+
+            # For the LAST part, always use the new_run_id
+            # This ensures run_id matches the last part of dotted_order (API requirement)
+            if i == len(parts) - 1:
+                new_parts.append(timestamp + new_run_id)
+            else:
+                # Map the UUID to its new value for parent chain
+                new_uuid = id_mapping.get(old_uuid, old_uuid)
+                new_parts.append(timestamp + new_uuid)
+
+        return ".".join(new_parts)
 
     def _ensure_evaluator_types(self, extra: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """
@@ -276,6 +329,9 @@ class ExperimentMigrator(BaseMigrator):
             where run_id_mapping maps source run IDs to destination run IDs
         """
         run_id_mapping: Dict[str, str] = {}
+        # Track trace_id mappings separately (trace_id is the root run's ID)
+        # All runs in the same trace share the same trace_id
+        trace_id_mapping: Dict[str, str] = {}
 
         if self.config.migration.dry_run:
             self.log("[DRY RUN] Would migrate runs")
@@ -311,6 +367,14 @@ class ExperimentMigrator(BaseMigrator):
                     break
 
                 runs = response.get("runs", [])
+
+                # Sort runs by dotted_order to ensure parents are processed before children
+                # dotted_order format: {timestamp}Z{uuid}.{timestamp}Z{uuid}...
+                # Shorter dotted_order = closer to root, so sorting alphabetically works
+                # This prevents "dotted_order must contain a single part for root runs" errors
+                # when a child run would otherwise be processed before its parent
+                runs.sort(key=lambda r: r.get("dotted_order", ""))
+
                 self.log(f"Experiment {experiment_id} page {page_num}: Retrieved {len(runs)} runs", "info")
 
                 if not runs:
@@ -334,13 +398,56 @@ class ExperimentMigrator(BaseMigrator):
                     dest_session_id = experiment_mapping[source_session_id]
 
                     # Map parent_run_id if present and already migrated
+                    # If parent not mapped yet, omit the field entirely to avoid 422 errors
                     parent_run_id = run.get("parent_run_id")
+                    mapped_parent_id = None
                     if parent_run_id and parent_run_id in run_id_mapping:
                         mapped_parent_id = run_id_mapping[parent_run_id]
+
+                    # Map reference_example_id if present
+                    source_example_id = run.get("reference_example_id")
+                    mapped_example_id = example_mapping.get(source_example_id) if source_example_id else None
+
+                    # Generate a new UUID for the destination run to avoid conflicts
+                    new_run_id = str(uuid.uuid4())
+
+                    # Handle trace_id mapping
+                    # trace_id identifies the root run of a trace - all runs in the same trace share it
+                    # API requirement: For root runs, trace_id MUST equal run_id
+                    # For child runs, trace_id is the root run's ID (shared across the trace)
+                    source_trace_id = run.get("trace_id")
+
+                    if not parent_run_id:
+                        # Root run: trace_id = run_id (API requirement)
+                        # Store mapping so children can look up the new trace_id
+                        new_trace_id = new_run_id
+                        if source_trace_id:
+                            trace_id_mapping[source_trace_id] = new_run_id
                     else:
-                        mapped_parent_id = parent_run_id  # Keep original if not mapped yet
+                        # Child run: use mapped trace_id from root
+                        if source_trace_id and source_trace_id in trace_id_mapping:
+                            new_trace_id = trace_id_mapping[source_trace_id]
+                        else:
+                            # Fallback: use run's own ID (shouldn't happen with sorted runs)
+                            new_trace_id = new_run_id
+
+                    # Store the run ID mapping before regenerating dotted_order
+                    run_id_mapping[source_run_id] = new_run_id
+
+                    # Build combined mapping for dotted_order regeneration
+                    # (includes both run IDs and trace IDs)
+                    combined_mapping = {**run_id_mapping, **trace_id_mapping}
+
+                    # Regenerate dotted_order with new IDs
+                    # Pass new_run_id to ensure the last part always matches the run's ID
+                    new_dotted_order = self._regenerate_dotted_order(
+                        run.get("dotted_order"),
+                        combined_mapping,
+                        new_run_id
+                    )
 
                     migrated_run = {
+                        "id": new_run_id,
                         "name": run["name"],
                         "inputs": run.get("inputs"),
                         "outputs": run.get("outputs"),
@@ -353,16 +460,16 @@ class ExperimentMigrator(BaseMigrator):
                         "parent_run_id": mapped_parent_id,
                         "events": run.get("events", []),
                         "tags": run.get("tags", []),
-                        "trace_id": run.get("trace_id"),
-                        "id": source_run_id,  # Preserve original run ID
-                        "dotted_order": run.get("dotted_order"),
+                        "trace_id": new_trace_id,
+                        "dotted_order": new_dotted_order,
                         "session_id": dest_session_id,
-                        "reference_example_id": example_mapping.get(run.get("reference_example_id"))
+                        "reference_example_id": mapped_example_id,
                     }
 
+                    # Remove None values to avoid API validation errors (422)
+                    migrated_run = {k: v for k, v in migrated_run.items() if v is not None}
+
                     batch.append(migrated_run)
-                    # Track the mapping (source ID -> destination ID, same for now)
-                    run_id_mapping[source_run_id] = source_run_id
 
                     # Process batch
                     if len(batch) >= self.config.migration.batch_size:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,8 @@ ignore = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.1",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -1519,6 +1519,12 @@ test = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "respx" },
+    { name = "ruff" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -1548,10 +1554,14 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31.0" },
     { name = "respx", marker = "extra == 'test'", specifier = ">=0.20.0" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "ruff", marker = "extra == 'test'", specifier = ">=0.4.0" },
     { name = "textual", specifier = ">=6.2.0" },
     { name = "urllib3", specifier = ">=2.6.0" },
 ]
 provides-extras = ["test", "models", "all"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.1" }]
 
 [[package]]
 name = "linkify-it-py"


### PR DESCRIPTION
## Summary
- Fixes "trace_id does not match first part of dotted_order" API validation errors when migrating experiment runs
- For root runs, `trace_id` must equal `run_id` (API requirement)
- Child runs now properly look up `trace_id` from the mapping set by their root run

## Changes
- Add `_regenerate_dotted_order()` method to properly remap UUIDs in dotted_order
- Fix trace_id logic: root runs use `run_id`, child runs look up from mapping
- Sort runs by dotted_order to ensure parents are processed before children
- Generate new UUIDs for destination runs to avoid conflicts
- Remove None values from run payloads to avoid 422 errors

## Test plan
- [x] All existing tests pass (35/35)
- [ ] Run `uv run langsmith-migrator datasets --include-experiments` against real instances
- [ ] Verify no "trace_id does not match first part of dotted_order" errors
- [ ] Verify no "run_id does not match last part of dotted_order" errors
- [ ] Verify runs are created with proper parent-child relationships

🤖 Generated with [Claude Code](https://claude.com/claude-code)