### PR TITLE
fix: pin trivy-action to safe SHA (supply chain attack mitigation)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,7 +56,7 @@ jobs:
 
       # Trivy Vulnerability Scan
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
## Summary

- Pins `aquasecurity/trivy-action` from mutable `@master` to SHA `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.35.0)
- Mitigates exposure to the March 2026 Trivy supply chain attack ([GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23))
- 76 of 77 `trivy-action` tags were force-pushed to malicious commits during the attack window (March 19–20, 2026); v0.35.0 is the only clean tag

## Impact Assessment

This repo had **no workflow runs during the attack window** — last run was March 17, 2026. No active compromise detected. This is a preventative fix to block future exposure.

## Test plan

- [ ] Confirm `security.yml` workflow passes on this PR
- [ ] Verify Trivy scan output is unchanged from pre-fix behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)