### PR TITLE
fix: propagate workspace context to PromptMigrator

### DIFF
--- a/langsmith_migrator/core/migrators/prompt.py
+++ b/langsmith_migrator/core/migrators/prompt.py
@@ -13,39 +13,47 @@ class PromptMigrator(BaseMigrator):
     def __init__(self, source_client, dest_client, state, config):
         super().__init__(source_client, dest_client, state, config)
 
-        # Create client kwargs with SSL verification settings
-        source_kwargs = {
-            "api_key": config.source.api_key,
-            "api_url": self._get_api_url(config.source.base_url),
-            "info": {}  # Skip automatic /info fetch to avoid compatibility issues
-        }
-        dest_kwargs = {
-            "api_key": config.destination.api_key,
-            "api_url": self._get_api_url(config.destination.base_url),
-            "info": {}  # Skip automatic /info fetch to avoid compatibility issues
-        }
+        # Create managed sessions so we can update workspace headers dynamically.
+        # The parent EnhancedAPIClient (self.source / self.dest) may have
+        # X-Tenant-Id set after init via orchestrator.set_workspace_context().
+        # We sync that header into these sessions before each operation.
+        self._source_session = requests.Session()
+        self._dest_session = requests.Session()
 
-        # Add custom session with SSL verification disabled if needed
-        # Note: verify_ssl is stored in config.source and config.destination, not config.migration
         if not config.source.verify_ssl or not config.destination.verify_ssl:
-            import requests
             import urllib3
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-            # Create sessions with SSL verification disabled
-            if not config.source.verify_ssl:
-                source_session = requests.Session()
-                source_session.verify = False
-                source_kwargs["session"] = source_session
+        if not config.source.verify_ssl:
+            self._source_session.verify = False
+        if not config.destination.verify_ssl:
+            self._dest_session.verify = False
 
-            if not config.destination.verify_ssl:
-                dest_session = requests.Session()
-                dest_session.verify = False
-                dest_kwargs["session"] = dest_session
+        # Create LangSmith SDK clients with our managed sessions
+        self.source_ls_client = Client(
+            api_key=config.source.api_key,
+            api_url=self._get_api_url(config.source.base_url),
+            session=self._source_session,
+            info={},
+        )
+        self.dest_ls_client = Client(
+            api_key=config.destination.api_key,
+            api_url=self._get_api_url(config.destination.base_url),
+            session=self._dest_session,
+            info={},
+        )
 
-        # Create LangSmith SDK clients for prompt operations
-        self.source_ls_client = Client(**source_kwargs)
-        self.dest_ls_client = Client(**dest_kwargs)
+    def _sync_workspace_headers(self):
+        """Sync X-Tenant-Id from parent API clients to SDK sessions."""
+        for session, client in [
+            (self._source_session, self.source),
+            (self._dest_session, self.dest),
+        ]:
+            ws_id = client.session.headers.get("X-Tenant-Id")
+            if ws_id:
+                session.headers["X-Tenant-Id"] = ws_id
+            else:
+                session.headers.pop("X-Tenant-Id", None)
 
     def check_prompts_api_available(self) -> tuple[bool, str]:
         """
@@ -55,6 +63,7 @@ class PromptMigrator(BaseMigrator):
         Returns:
             Tuple of (is_available, error_message)
         """
+        self._sync_workspace_headers()
         # Test 1: Check if we can list prompts (READ access)
         try:
             self.dest_ls_client.list_prompts(limit=1)
@@ -135,11 +144,7 @@ class PromptMigrator(BaseMigrator):
             url = f"{self._get_api_url(self.config.source.base_url)}{endpoint}"
             headers = {"x-api-key": self.config.source.api_key}
 
-            session = requests.Session()
-            if not self.config.source.verify_ssl:
-                session.verify = False
-
-            response = session.get(url, headers=headers, params=params, timeout=30)
+            response = self._source_session.get(url, headers=headers, params=params, timeout=30)
             response.raise_for_status()
 
             data = response.json()
@@ -168,11 +173,7 @@ class PromptMigrator(BaseMigrator):
             url = f"{self._get_api_url(self.config.destination.base_url)}/commits/{owner_path}/{repo}/latest"
             headers = {"x-api-key": self.config.destination.api_key}
 
-            session = requests.Session()
-            if not self.config.destination.verify_ssl:
-                session.verify = False
-
-            response = session.get(url, headers=headers, timeout=30)
+            response = self._dest_session.get(url, headers=headers, timeout=30)
             if response.status_code == 404:
                 return None
             response.raise_for_status()
@@ -252,11 +253,7 @@ class PromptMigrator(BaseMigrator):
                 "Content-Type": "application/json"
             }
 
-            session = requests.Session()
-            if not self.config.destination.verify_ssl:
-                session.verify = False
-
-            response = session.post(url, headers=headers, json=payload, timeout=30)
+            response = self._dest_session.post(url, headers=headers, json=payload, timeout=30)
             response.raise_for_status()
 
             data = response.json()
@@ -354,6 +351,7 @@ class PromptMigrator(BaseMigrator):
 
     def list_prompts(self, is_archived: bool = False) -> List[Dict[str, Any]]:
         """List all prompts from source instance."""
+        self._sync_workspace_headers()
         prompts = []
         try:
             offset = 0
@@ -448,6 +446,7 @@ class PromptMigrator(BaseMigrator):
         Returns:
             True if the prompt exists, False otherwise
         """
+        self._sync_workspace_headers()
         try:
             # Try to list prompts and find a match by repo_handle
             response = self.dest_ls_client.list_prompts(limit=100)
@@ -476,6 +475,7 @@ class PromptMigrator(BaseMigrator):
         Returns:
             The prompt identifier in the destination instance, or None if failed
         """
+        self._sync_workspace_headers()
         if self.config.migration.dry_run:
             self.log(f"[DRY RUN] Would migrate prompt: {prompt_identifier}")
             return prompt_identifier

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,9 @@ def mock_api_client():
     client = Mock(spec=EnhancedAPIClient)
     client.base_url = "https://api.test.langsmith.com/api/v1"
     client.headers = {"X-API-Key": "test-key"}
+    # Provide a real session mock so _sync_workspace_headers can read X-Tenant-Id
+    client.session = Mock()
+    client.session.headers = {}
     return client
 
 


### PR DESCRIPTION
## Summary

* **PromptMigrator ignored workspace scoping** (`X-Tenant-Id` header) because it created bare `requests.Session` objects and SDK `Client` instances that never carried the header set by `orchestrator.set_workspace_context()`. Prompt operations always hit the API key's default workspace, even when `--source-workspace` / `--dest-workspace` were provided.
* **Use managed sessions** (`_source_session`, `_dest_session`) for both SDK clients and raw HTTP calls, with a `_sync_workspace_headers()` method that copies `X-Tenant-Id` from the parent `EnhancedAPIClient` before each operation.
* **Cross-instance migration is unchanged**: when no workspace is set, `_sync_workspace_headers` is a no-op.

## Test plan

- [x] Existing unit tests pass (30/30), covering the cross-instance (no workspace) path
- [x] Live tested: migrated `test-prompt` from `jessie-test` workspace to `jessie-migration` workspace on the same LangSmith instance using `--source-workspace` / `--dest-workspace`
- [x] Verified via API that the prompt landed in the correct destination workspace (`tenant_id` matches dest workspace ID)
- [x] Verified source workspace prompts are unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)