### PR TITLE
Release v0.0.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.52] - 2026-03-30
+
+### Fixed
+- **Prompt workspace scoping**: Propagate `X-Tenant-Id` workspace headers to PromptMigrator SDK sessions so prompts land in the correct workspace during multi-workspace migrations
+- **Security workflow**: Pin trivy-action to safe SHA to mitigate supply chain attack risk
+
+### Changed
+- Dependency updates: langchain-core, requests, pyasn1
+
 ## [0.0.51] - 2026-03-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.51"
+version = "0.0.52"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- Bump version to 0.0.52
- Update CHANGELOG with prompt workspace scoping fix and security updates

## Changes in this release (since v0.0.51)
- **fix**: Propagate workspace context (`X-Tenant-Id`) to PromptMigrator SDK sessions so prompts land in the correct workspace during multi-workspace migrations (#41)
- **fix**: Pin trivy-action to safe SHA to mitigate supply chain attack (#36)
- Dependency updates: langchain-core, requests, pyasn1

## Test plan
- [ ] CI passes
- [ ] Merge, tag, and create GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)