### PR TITLE
Fix migrate-all rules enable defaults and docs parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,12 @@ uv run langsmith-migrator rules --map-projects                      # Interactiv
 uv run langsmith-migrator rules --create-enabled                    # Create rules enabled
 uv run langsmith-migrator charts       # Migrate charts
 uv run langsmith-migrator charts --map-projects                     # Charts with interactive project mapping
-uv run langsmith-migrator migrate_all  # Migrate everything
-uv run langsmith-migrator migrate_all --map-projects                # Migrate all with interactive project mapping
-uv run langsmith-migrator resume       # Resume a previous session
-uv run langsmith-migrator list_projects # List available projects
+uv run langsmith-migrator charts --same-instance                    # Reuse source session IDs
+uv run langsmith-migrator migrate-all  # Migrate everything
+uv run langsmith-migrator migrate-all --map-projects                # Migrate all with interactive project mapping
+uv run langsmith-migrator migrate-all --rules-create-enabled        # Create migrated rules enabled
+uv run langsmith-migrator resume       # Resume interrupted dataset migration
+uv run langsmith-migrator list-projects # List available projects
 uv run langsmith-migrator list_workspaces --source --dest           # List workspaces
 uv run langsmith-migrator clean        # Clean migration state
 
@@ -104,7 +106,7 @@ Environment variables (can also use CLI flags or a `.env` file — auto-loaded o
 1. **Streaming for large datasets**: Examples are processed in chunks to avoid memory issues
 2. **Retry with exponential backoff**: All API calls use retry logic in `utils/retry.py`
 3. **ID Mapping**: Migrators track source→destination ID mappings for cross-references
-4. **Rules disabled by default**: Rules are created disabled to avoid secrets validation issues
+4. **Rules disabled by default**: Rules are created disabled by default in all flows to avoid secrets validation issues; use explicit flags (`--create-enabled` / `--rules-create-enabled`) to create enabled rules
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ langsmith-migrator datasets
 - **Datasets**: Migrate datasets with examples and file attachments
 - **Experiments**: Migrate experiments with runs and feedback (`--include-experiments`)
 - **Annotation Queues**: Transfer queue configurations
-- **Project Rules**: Copy automation rules with automatic project creation
-- **Prompts**: Migrate prompts with version history
+- **Project Rules**: Copy automation rules with project mapping and optional project creation in interactive flows
+- **Prompts**: Migrate prompts (latest by default, full history with `--include-all-commits`)
 - **Charts**: Migrate monitoring charts with filter preservation
 - **Interactive CLI**: TUI-based selection with search/filter
 
@@ -104,6 +104,7 @@ langsmith-migrator test
 
 # Interactive wizard for all resources
 langsmith-migrator migrate-all
+langsmith-migrator migrate-all --rules-create-enabled   # Create migrated rules as enabled
 
 # Datasets
 langsmith-migrator datasets                    # Interactive selection
@@ -132,10 +133,12 @@ langsmith-migrator rules --create-enabled      # Create rules enabled (default: 
 langsmith-migrator charts
 langsmith-migrator charts --session "project-name"
 langsmith-migrator charts --map-projects        # Interactive TUI project mapping
+langsmith-migrator charts --same-instance       # Reuse source project/session IDs on destination
 
 # Utilities
 langsmith-migrator list-projects --source
-langsmith-migrator resume
+langsmith-migrator list_workspaces --source --dest
+langsmith-migrator resume  # Resume interrupted dataset migration
 langsmith-migrator clean
 ```
 
@@ -150,6 +153,7 @@ langsmith-migrator clean
 --batch-size INTEGER    Batch size (default: 100)
 --workers INTEGER       Concurrent workers (default: 4)
 --dry-run               Run without making changes
+--skip-existing         Skip existing resources instead of updating them
 --verbose, -v           Verbose output
 ```
 
@@ -170,6 +174,23 @@ langsmith-migrator clean
 --all                   Migrate all rules without interactive selection
 ```
 
+### Migrate-All Rules Options
+
+```bash
+--rules-create-enabled  Create migrated rules as enabled (default: disabled)
+```
+
+If `--rules-create-enabled` is omitted, `migrate-all` asks interactively whether to create rules enabled.
+The prompt default is `No` (rules are created disabled).
+
+### Chart Options
+
+```bash
+--session TEXT          Migrate charts for a specific session/project (by name or ID)
+--map-projects          Launch interactive TUI to map source projects to destination projects
+--same-instance         Reuse source project/session IDs on destination
+```
+
 ### Project Mapping
 
 Rules and charts reference projects by ID. When migrating between instances, project IDs differ.
@@ -177,7 +198,7 @@ Rules and charts reference projects by ID. When migrating between instances, pro
 - **Interactive TUI (`--map-projects`)**: Launch a visual TUI to map source projects to destination projects. Available on `rules`, `charts`, and `migrate-all` commands. Select a source project and type a destination name directly — existing projects appear as filterable suggestions below the input. Supports auto-match by name, skip, and custom name entry.
 - **Rules (`--project-mapping`)**: Supply an explicit source→destination project ID mapping as JSON or a file path. Use `list-projects --source` and `list-projects --dest` to get IDs. Mutually exclusive with `--map-projects`.
 - **Charts**: Without `--map-projects`, project mapping is built automatically by matching project names between source and destination.
-- **`migrate-all`**: Supports `--strip-projects` and `--map-projects` for rules. Use the standalone `rules` command for `--project-mapping` JSON mappings.
+- **`migrate-all`**: Supports `--strip-projects`, `--map-projects`, and `--rules-create-enabled` for rules. Use the standalone `rules` command for `--project-mapping` JSON mappings.
 
 ### Interactive Selection
 
@@ -212,6 +233,10 @@ langsmith-migrator datasets --source-workspace WS_ID --dest-workspace WS_ID
 ```
 
 When using `--map-workspaces`, each command iterates all mapped workspace pairs, running the full fetch/select/migrate flow per pair. For `rules` and `charts` with `--map-projects`, the project mapping TUI is shown per workspace pair so projects are correctly scoped.
+
+### Resume Scope
+
+`resume` currently resumes interrupted dataset migration flows. Experiment-only resume is not yet supported.
 
 ## SSL Certificate Issues
 

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -1028,9 +1028,16 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
 @click.option('--include-all-commits', is_flag=True, help='Include all prompt commit history')
 @click.option('--strip-projects', is_flag=True, help='Strip project associations from rules')
 @click.option('--map-projects', is_flag=True, help='Launch interactive TUI to map source projects to destination projects')
+@click.option(
+    '--rules-create-enabled',
+    'rules_create_enabled',
+    flag_value=True,
+    default=None,
+    help='Create migrated rules as enabled (default: disabled). If omitted, migrate-all asks interactively (default: No)'
+)
 @workspace_options
 @click.pass_context
-def migrate_all(ctx, skip_datasets, skip_experiments, skip_prompts, skip_queues, skip_rules, include_all_commits, strip_projects, map_projects, source_workspace, dest_workspace, map_workspaces):
+def migrate_all(ctx, skip_datasets, skip_experiments, skip_prompts, skip_queues, skip_rules, include_all_commits, strip_projects, map_projects, rules_create_enabled, source_workspace, dest_workspace, map_workspaces):
     """Migrate all resources interactively."""
     config = ctx.obj['config']
     state_manager = ctx.obj['state_manager']
@@ -1077,7 +1084,7 @@ def migrate_all(ctx, skip_datasets, skip_experiments, skip_prompts, skip_queues,
 
         _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_experiments,
                                    skip_prompts, skip_queues, skip_rules, include_all_commits,
-                                   strip_projects, map_projects, ws_project_mapping)
+                                   strip_projects, map_projects, rules_create_enabled, ws_project_mapping)
 
     if ws_result:
         orchestrator.clear_workspace_context()
@@ -1088,10 +1095,12 @@ def migrate_all(ctx, skip_datasets, skip_experiments, skip_prompts, skip_queues,
 
 def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_experiments,
                                 skip_prompts, skip_queues, skip_rules, include_all_commits,
-                                strip_projects, map_projects, ws_project_mapping=None):
+                                strip_projects, map_projects, rules_create_enabled=None, ws_project_mapping=None):
     """Run the full migrate_all flow for a single workspace pair (or no workspace).
 
     Args:
+        rules_create_enabled: If True, create rules enabled. If None, ask interactively
+            (default prompt answer is No, i.e. rules disabled).
         ws_project_mapping: Optional name-based project mapping from workspace TUI.
             If provided, --map-projects is skipped (already done at workspace level).
     """
@@ -1294,11 +1303,15 @@ def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_ex
             if Confirm.ask(f"Migrate {len(rules)} rule(s)?"):
                 strip = strip_projects
                 ensure_projects = False
+                create_enabled = rules_create_enabled
                 
                 if project_specific and not strip:
                     strip = Confirm.ask("Convert project-specific rules to global rules?")
                     if not strip:
                         ensure_projects = Confirm.ask("Create corresponding projects for project-specific rules?", default=True)
+                if create_enabled is None:
+                    create_enabled = Confirm.ask("Create migrated rules as enabled?", default=False)
+                create_disabled = not create_enabled
 
                 success_count = 0
                 failed_items = []
@@ -1316,7 +1329,8 @@ def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_ex
                             result = rules_migrator.create_rule(
                                 rule,
                                 strip_project_reference=strip,
-                                ensure_project=ensure_projects
+                                ensure_project=ensure_projects,
+                                create_disabled=create_disabled
                             )
                             if result:
                                 success_count += 1
@@ -1335,6 +1349,11 @@ def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_ex
                         progress.advance(task)
 
                 console.print(f"Rules: {success_count} migrated, {len(skipped_items)} skipped, {len(failed_items)} failed")
+                if success_count > 0 and create_disabled:
+                    console.print(f"\n[cyan]Note:[/cyan] Rules were created as [yellow]disabled[/yellow] to bypass secrets validation.")
+                    console.print(f"  To enable rules:")
+                    console.print(f"  1. Configure required secrets (e.g., OPENAI_API_KEY) in destination workspace settings")
+                    console.print(f"  2. Enable each rule in the LangSmith UI or rerun with --rules-create-enabled")
                 if (failed_items or skipped_items) and config.migration.verbose:
                     for name, err in skipped_items:
                         console.print(f"  [yellow]⊘[/yellow] {name}: {err}")

--- a/tests/cli_migrate_all_rules_test.py
+++ b/tests/cli_migrate_all_rules_test.py
@@ -1,0 +1,96 @@
+"""Tests for migrate-all rule enable/disable behavior."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from langsmith_migrator.cli import main as cli_main
+
+
+class _DummyProgress:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    def add_task(self, *args, **kwargs):
+        return 1
+
+    def advance(self, task_id):
+        return None
+
+
+class _FakeRulesMigrator:
+    create_rule_calls = []
+
+    def __init__(self, source_client, dest_client, state, config):
+        self._dataset_id_map = {}
+        self._project_id_map = {}
+
+    def list_rules(self):
+        return [{"display_name": "Rule 1", "dataset_id": "dataset-1"}]
+
+    def create_rule(self, rule, **kwargs):
+        self.__class__.create_rule_calls.append(kwargs)
+        return "new-rule-id"
+
+
+def _make_config():
+    return SimpleNamespace(migration=SimpleNamespace(verbose=False))
+
+
+def _make_orchestrator():
+    return SimpleNamespace(source_client=object(), dest_client=object())
+
+
+def test_migrate_all_rules_create_enabled_flag_sets_create_disabled_false():
+    _FakeRulesMigrator.create_rule_calls = []
+
+    with patch("langsmith_migrator.core.migrators.RulesMigrator", _FakeRulesMigrator), patch(
+        "langsmith_migrator.cli.main.Progress", _DummyProgress
+    ), patch("langsmith_migrator.cli.main.Confirm.ask", side_effect=[True]):
+        cli_main._migrate_all_for_workspace(
+            ctx=None,
+            orchestrator=_make_orchestrator(),
+            config=_make_config(),
+            skip_datasets=True,
+            skip_experiments=True,
+            skip_prompts=True,
+            skip_queues=True,
+            skip_rules=False,
+            include_all_commits=False,
+            strip_projects=False,
+            map_projects=False,
+            rules_create_enabled=True,
+        )
+
+    assert _FakeRulesMigrator.create_rule_calls
+    assert _FakeRulesMigrator.create_rule_calls[0]["create_disabled"] is False
+
+
+def test_migrate_all_rules_prompt_defaults_to_disabled_when_flag_omitted():
+    _FakeRulesMigrator.create_rule_calls = []
+
+    with patch("langsmith_migrator.core.migrators.RulesMigrator", _FakeRulesMigrator), patch(
+        "langsmith_migrator.cli.main.Progress", _DummyProgress
+    ), patch("langsmith_migrator.cli.main.Confirm.ask", side_effect=[True, False]):
+        cli_main._migrate_all_for_workspace(
+            ctx=None,
+            orchestrator=_make_orchestrator(),
+            config=_make_config(),
+            skip_datasets=True,
+            skip_experiments=True,
+            skip_prompts=True,
+            skip_queues=True,
+            skip_rules=False,
+            include_all_commits=False,
+            strip_projects=False,
+            map_projects=False,
+            rules_create_enabled=None,
+        )
+
+    assert _FakeRulesMigrator.create_rule_calls
+    assert _FakeRulesMigrator.create_rule_calls[0]["create_disabled"] is True


### PR DESCRIPTION
## Summary
- align `migrate-all` rules behavior with the project default by adding `--rules-create-enabled` and treating disabled as the default
- keep interactive flows explicit: when no enable flag is provided, ask whether to create enabled rules and default to No
- sync README/CLAUDE command and flag docs (`migrate-all`, `list-projects`, `--skip-existing`, `--same-instance`, resume scope) and add regression tests for `create_disabled` wiring

## Test plan
- [x] `uv run pytest -o addopts='' tests/cli_migrate_all_rules_test.py -q`
- [x] `uv run pytest -o addopts='' tests/test_rules_migrator.py -q`
- [x] `uv run langsmith-migrator migrate-all --help | rg 'rules-create-enabled'`

Made with [Cursor](https://cursor.com)