### PR TITLE
Add comprehensive CLI functional test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,5 +158,6 @@ run_dataset_tests.py
 
 # Test files
 test_*.py
+!tests/**/test_*.py
 demo_*.py
 main.py

--- a/langsmith_migrator/__init__.py
+++ b/langsmith_migrator/__init__.py
@@ -1,3 +1,8 @@
 """LangSmith Migration Tool - A robust tool for migrating data between LangSmith instances."""
 
-__version__ = "2.0.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("langsmith-data-migration-tool")
+except PackageNotFoundError:
+    __version__ = "0.0.51"

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -161,6 +161,10 @@ def _ensure_migration_session(orchestrator, config):
             config.source.base_url,
             config.destination.base_url,
         )
+    elif not orchestrator.state.remediation_bundle_path:
+        orchestrator.state.remediation_bundle_path = str(
+            orchestrator.state_manager._default_bundle_path(orchestrator.state.session_id).resolve()
+        )
     config.state_manager = orchestrator.state_manager
     orchestrator.state_manager.current_state = orchestrator.state
     return orchestrator.state

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -1,6 +1,7 @@
 """Simplified CLI interface with improved architecture."""
 
 import functools
+from typing import Iterable
 import click
 import time
 from dotenv import load_dotenv
@@ -26,7 +27,7 @@ def ssl_option(f):
         # The global cli() already handles --no-ssl via the config object
         return f(*args, **kwargs)
     return wrapper
-from ..utils.state import StateManager, MigrationStatus
+from ..utils.state import MigrationStatus, ResolutionOutcome, StateManager, VerificationState
 from ..core.migrators import (
     MigrationOrchestrator,
     DatasetMigrator,
@@ -38,7 +39,12 @@ from ..core.migrators import (
 from .tui_selector import select_items
 from .tui_project_mapper import build_project_mapping_tui
 from .tui_workspace_mapper import WorkspaceProjectResult
-from ..utils.workspace import list_projects as _list_projects, list_workspaces as _list_workspaces, get_workspace_name
+from ..utils.workspace import (
+    discover_workspaces,
+    get_workspace_name,
+    list_projects as _list_projects,
+    list_workspaces as _list_workspaces,
+)
 from ..utils.workspace_resolver import resolve_workspace_context, display_workspaces
 
 
@@ -113,6 +119,330 @@ def _resolve_workspaces(orchestrator, source_workspace=None, dest_workspace=None
     return result
 
 
+def _workspace_scoped_project_id_map(orchestrator, ws_result, source_workspace_id):
+    """Resolve a workspace TUI name mapping into IDs for standalone commands."""
+    if not ws_result or not source_workspace_id:
+        return None
+
+    name_mapping = ws_result.project_mappings.get(source_workspace_id)
+    if not name_mapping:
+        return None
+
+    console.print("Fetching projects for workspace-scoped mapping... ", end="")
+    source_projects = _list_projects(orchestrator.source_client)
+    dest_projects = _list_projects(orchestrator.dest_client)
+    console.print(
+        f"[green]✓[/green] ({len(source_projects)} source, {len(dest_projects)} destination)"
+    )
+
+    id_map = _name_mapping_to_id_mapping(name_mapping, source_projects, dest_projects)
+    console.print(f"Using workspace-scoped project mapping with {len(id_map)} project(s)")
+    return id_map
+
+
+def _active_workspace_pair(orchestrator):
+    """Return the currently scoped workspace pair."""
+    return {
+        "source": orchestrator.source_client.session.headers.get("X-Tenant-Id"),
+        "dest": orchestrator.dest_client.session.headers.get("X-Tenant-Id"),
+    }
+
+
+def _state_item_id(item_type, source_id, source_workspace_id=None):
+    """Build a stable state item ID, scoped by source workspace when available."""
+    workspace_part = source_workspace_id or "default"
+    return f"{item_type}_{workspace_part}_{source_id}"
+
+
+def _ensure_migration_session(orchestrator, config):
+    """Create a migration session lazily for non-dataset flows."""
+    if orchestrator.state is None:
+        orchestrator.state = orchestrator.state_manager.create_session(
+            config.source.base_url,
+            config.destination.base_url,
+        )
+    config.state_manager = orchestrator.state_manager
+    orchestrator.state_manager.current_state = orchestrator.state
+    return orchestrator.state
+
+
+def _ensure_state_item(orchestrator, config, item_type, source_id, name, metadata=None):
+    """Ensure a CLI-selected item is tracked in migration state."""
+    state = _ensure_migration_session(orchestrator, config)
+    workspace_pair = _active_workspace_pair(orchestrator)
+    item_id = _state_item_id(item_type, source_id, workspace_pair["source"])
+    state.ensure_item(
+        item_id,
+        item_type,
+        name,
+        source_id,
+        stage="selected",
+        workspace_pair=workspace_pair,
+        metadata=metadata or {},
+    )
+    orchestrator.state_manager.save()
+    return item_id
+
+
+def _mark_state_item_started(orchestrator, item_id):
+    """Mark a tracked CLI item as in progress."""
+    if not orchestrator.state:
+        return
+    orchestrator.state.update_item_status(
+        item_id,
+        MigrationStatus.IN_PROGRESS,
+        stage="migrating",
+    )
+    orchestrator.state_manager.save()
+
+
+def _mark_state_item_completed(orchestrator, item_id, destination_id=None, metadata=None):
+    """Mark a tracked CLI item as completed."""
+    if not orchestrator.state:
+        return
+    orchestrator.state.update_item_status(
+        item_id,
+        MigrationStatus.COMPLETED,
+        destination_id=destination_id,
+        stage="completed",
+    )
+    if metadata:
+        orchestrator.state.update_item_checkpoint(item_id, metadata=metadata)
+    item = orchestrator.state.get_item(item_id)
+    if item and not item.terminal_state:
+        orchestrator.state.mark_terminal(
+            item_id,
+            ResolutionOutcome.MIGRATED,
+            f"{item.type}_migrated",
+            verification_state=VerificationState.VERIFIED,
+            evidence={"destination_id": destination_id} if destination_id else None,
+        )
+    orchestrator.state_manager.save()
+
+
+def _mark_state_item_failed(orchestrator, item_id, error):
+    """Mark a tracked CLI item as failed."""
+    if not orchestrator.state:
+        return
+    orchestrator.state.update_item_status(
+        item_id,
+        MigrationStatus.FAILED,
+        error=str(error),
+        stage="failed",
+    )
+    item = orchestrator.state.get_item(item_id)
+    if item and not item.terminal_state:
+        orchestrator.state.mark_terminal(
+            item_id,
+            ResolutionOutcome.BLOCKED_WITH_CHECKPOINT,
+            f"{item.type}_blocked",
+            verification_state=VerificationState.BLOCKED,
+            next_action="Review the remediation bundle, resolve the issue, and run `langsmith-migrator resume`.",
+            evidence={"error": str(error)},
+            error=str(error),
+        )
+    orchestrator.state_manager.save()
+
+
+def _apply_item_workspace(orchestrator, item):
+    """Restore the recorded workspace scope for a resumed item."""
+    workspace_pair = getattr(item, "workspace_pair", {}) or {}
+    source_ws = workspace_pair.get("source")
+    dest_ws = workspace_pair.get("dest")
+    if source_ws and dest_ws:
+        orchestrator.set_workspace_context(source_ws, dest_ws)
+    else:
+        orchestrator.clear_workspace_context()
+
+
+def _confirm_action(config: Config, prompt: str, *, default: bool = False, non_interactive_value: bool | None = None) -> bool:
+    """Ask for confirmation unless the command is running in non-interactive mode."""
+    if config.migration.non_interactive:
+        return default if non_interactive_value is None else non_interactive_value
+    return Confirm.ask(prompt, default=default)
+
+
+def _select_or_all(config: Config, items: list, *, select_all: bool, title: str, columns: list[dict]) -> list:
+    """Return interactive selections or all items in non-interactive mode."""
+    if select_all or config.migration.non_interactive:
+        return items
+    return select_items(items=items, title=title, columns=columns)
+
+
+def _workspace_scope_key(orchestrator) -> str:
+    """Build a stable preflight scope key for the active workspace pair."""
+    pair = _active_workspace_pair(orchestrator)
+    source_ws = pair["source"] or "default"
+    dest_ws = pair["dest"] or "default"
+    return f"{source_ws}->{dest_ws}"
+
+
+def _probe_lookup_capability(client, endpoint: str) -> tuple[bool, str]:
+    """Probe a paginated lookup endpoint without mutating state."""
+    try:
+        list(client.get_paginated(endpoint, page_size=1))
+        return True, "ok"
+    except Exception as e:  # noqa: BLE001
+        return False, str(e)
+
+
+def _run_preflight(orchestrator, config: Config, resources: Iterable[str]) -> None:
+    """Run a read-only capability and dependency preflight for the active workspace pair."""
+    state = _ensure_migration_session(orchestrator, config)
+    scope_key = _workspace_scope_key(orchestrator)
+    resource_list = sorted(set(resources))
+    workspace_pair = _active_workspace_pair(orchestrator)
+
+    state.record_inventory(
+        f"preflight:{scope_key}:workspace_pair",
+        workspace_pair,
+    )
+    state.record_inventory(
+        f"preflight:{scope_key}:resources",
+        resource_list,
+    )
+
+    source_workspace_probe = discover_workspaces(orchestrator.source_client)
+    dest_workspace_probe = discover_workspaces(orchestrator.dest_client)
+    state.record_inventory(f"preflight:{scope_key}:source_workspaces", source_workspace_probe)
+    state.record_inventory(f"preflight:{scope_key}:dest_workspaces", dest_workspace_probe)
+    state.record_capability(
+        f"workspaces:{scope_key}",
+        "source_discovery",
+        supported=bool(source_workspace_probe.get("workspaces"))
+        or any(probe.get("supported") for probe in source_workspace_probe.get("probes", [])),
+        detail="ok" if source_workspace_probe.get("workspaces") else "workspace_probe_completed",
+        evidence=source_workspace_probe,
+        probe="workspace_discovery",
+    )
+    state.record_capability(
+        f"workspaces:{scope_key}",
+        "dest_discovery",
+        supported=bool(dest_workspace_probe.get("workspaces"))
+        or any(probe.get("supported") for probe in dest_workspace_probe.get("probes", [])),
+        detail="ok" if dest_workspace_probe.get("workspaces") else "workspace_probe_completed",
+        evidence=dest_workspace_probe,
+        probe="workspace_discovery",
+    )
+
+    for label, endpoint in (
+        ("project_lookup", "/sessions"),
+        ("dataset_lookup", "/datasets"),
+    ):
+        source_supported, source_detail = _probe_lookup_capability(orchestrator.source_client, endpoint)
+        dest_supported, dest_detail = _probe_lookup_capability(orchestrator.dest_client, endpoint)
+        state.record_capability(
+            f"preflight:{scope_key}",
+            f"source_{label}",
+            supported=source_supported,
+            detail=source_detail,
+            probe=f"GET {endpoint}",
+        )
+        state.record_capability(
+            f"preflight:{scope_key}",
+            f"dest_{label}",
+            supported=dest_supported,
+            detail=dest_detail,
+            probe=f"GET {endpoint}",
+        )
+
+    if "prompts" in resource_list or "rules" in resource_list:
+        PromptMigrator(
+            orchestrator.source_client,
+            orchestrator.dest_client,
+            state,
+            config,
+        ).probe_capabilities()
+    if "rules" in resource_list:
+        RulesMigrator(
+            orchestrator.source_client,
+            orchestrator.dest_client,
+            state,
+            config,
+        ).probe_capabilities()
+    if "charts" in resource_list:
+        ChartMigrator(
+            orchestrator.source_client,
+            orchestrator.dest_client,
+            state,
+            config,
+        ).probe_capabilities()
+
+    dependency_edges = {
+        f"experiments:{scope_key}": [f"datasets:{scope_key}"],
+        f"runs:{scope_key}": [f"experiments:{scope_key}"],
+        f"feedback:{scope_key}": [f"runs:{scope_key}"],
+        f"rules:{scope_key}": [
+            f"project_lookup:{scope_key}",
+            f"dataset_lookup:{scope_key}",
+            f"prompts:{scope_key}",
+        ],
+        f"charts:{scope_key}": [
+            f"project_lookup:{scope_key}",
+            f"section_scoped_create:{scope_key}",
+        ],
+        f"workspace_scoped_resources:{scope_key}": [f"workspaces:{scope_key}"],
+    }
+    for node, dependencies in dependency_edges.items():
+        for dependency in dependencies:
+            state.add_dependency(node, dependency)
+
+    orchestrator.state_manager.save()
+
+
+def _display_resolution_summary(orchestrator) -> None:
+    """Print a consistent migration resolution summary."""
+    if not orchestrator.state:
+        return
+
+    stats = orchestrator.state.get_statistics()
+    terminal = stats.get("terminal", {})
+    bundle_path = orchestrator.state.write_remediation_bundle()
+    bundle_display = str(bundle_path.resolve()) if bundle_path else orchestrator.state.remediation_bundle_path
+
+    console.print("\n[bold]Resolution Summary[/bold]")
+    console.print(f"  Migrated: {terminal.get(ResolutionOutcome.MIGRATED.value, 0)}")
+    console.print(
+        f"  Verified downgrade: {terminal.get(ResolutionOutcome.MIGRATED_WITH_VERIFIED_DOWNGRADE.value, 0)}"
+    )
+    console.print(
+        f"  Blocked: {terminal.get(ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value, 0)}"
+    )
+    console.print(
+        f"  Exported/manual apply: {terminal.get(ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY.value, 0)}"
+    )
+    if bundle_display:
+        console.print(f"  Remediation bundle: {bundle_display}")
+    console.print("  Resume command: langsmith-migrator resume")
+
+    actionable_items = orchestrator.state.get_checkpoint_items()
+    if actionable_items:
+        console.print("\n[bold]Actionable Next Steps[/bold]")
+        for item in actionable_items[:5]:
+            console.print(f"  • {item.name}: {item.next_action or item.outcome_code or 'needs attention'}")
+
+
+def _needs_operator_action(state) -> bool:
+    """Return True when the session requires manual remediation or follow-up."""
+    if state is None:
+        return False
+    terminal = state.get_terminal_counts()
+    return bool(
+        terminal.get(ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value)
+        or terminal.get(ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY.value)
+        or state.remediation_queue
+    )
+
+
+def _exit_for_remediation_if_needed(ctx, config: Config, orchestrator) -> None:
+    """Exit with code 2 in non-interactive mode when manual action is required."""
+    if config.migration.non_interactive and orchestrator.state and _needs_operator_action(orchestrator.state):
+        console.print(
+            "\n[yellow]Manual or external follow-up is required. Review the remediation bundle and run `langsmith-migrator resume` after resolving the blockers.[/yellow]"
+        )
+        ctx.exit(2)
+
+
 
 def display_banner():
     """Display minimal banner."""
@@ -158,9 +488,10 @@ def ensure_config(config: Config) -> bool:
 @click.option('--workers', type=click.IntRange(min=1, max=10), help='Number of concurrent workers (1-10, default: 4)')
 @click.option('--dry-run', is_flag=True, help='Run in dry-run mode (no changes)')
 @click.option('--skip-existing', is_flag=True, help='Skip existing resources instead of updating them')
+@click.option('--non-interactive', is_flag=True, help='Disable prompts and emit exit code 2 when remediation is required')
 @click.option('--verbose', '-v', is_flag=True, help='Enable verbose output')
 @click.pass_context
-def cli(ctx, source_key, dest_key, source_url, dest_url, no_ssl, batch_size, workers, dry_run, skip_existing, verbose):
+def cli(ctx, source_key, dest_key, source_url, dest_url, no_ssl, batch_size, workers, dry_run, skip_existing, non_interactive, verbose):
     """LangSmith Migration Tool - Migrate data between LangSmith instances."""
     ctx.ensure_object(dict)
 
@@ -175,11 +506,13 @@ def cli(ctx, source_key, dest_key, source_url, dest_url, no_ssl, batch_size, wor
         concurrent_workers=workers,
         dry_run=dry_run,
         skip_existing=skip_existing if skip_existing else None,
+        non_interactive=non_interactive,
         verbose=verbose
     )
 
     ctx.obj['config'] = config
     ctx.obj['state_manager'] = StateManager()
+    config.state_manager = ctx.obj['state_manager']
 
 
 @cli.command()
@@ -203,6 +536,7 @@ def test(ctx):
         console.print("[green]✓[/green]")
     else:
         console.print("[red]✗[/red]")
+        orchestrator.cleanup()
         ctx.exit(1)
         return
 
@@ -275,6 +609,12 @@ def datasets(ctx, include_experiments, select_all, source_workspace, dest_worksp
                 orchestrator.set_workspace_context(src_ws, dst_ws)
                 console.print(f"\n[bold cyan]Workspace: {src_ws} -> {dst_ws}[/bold cyan]")
 
+            _run_preflight(
+                orchestrator,
+                config,
+                ["datasets", "experiments"] if include_experiments else ["datasets"],
+            )
+
             # Get datasets
             console.print("Fetching datasets... ", end="")
             ds = dataset_migrator.list_datasets()
@@ -286,19 +626,18 @@ def datasets(ctx, include_experiments, select_all, source_workspace, dest_worksp
             console.print(f"found {len(ds)}\n")
 
             # Select datasets
-            if select_all:
-                selected = ds
-            else:
-                selected = select_items(
-                    items=ds,
-                    title="Select Datasets to Migrate",
-                    columns=[
-                        {"key": "name", "title": "Name", "width": 40},
-                        {"key": "id", "title": "ID", "width": 36},
-                        {"key": "description", "title": "Description", "width": 50},
-                        {"key": "example_count", "title": "Examples", "width": 10}
-                    ]
-                )
+            selected = _select_or_all(
+                config,
+                ds,
+                select_all=select_all,
+                title="Select Datasets to Migrate",
+                columns=[
+                    {"key": "name", "title": "Name", "width": 40},
+                    {"key": "id", "title": "ID", "width": 36},
+                    {"key": "description", "title": "Description", "width": 50},
+                    {"key": "example_count", "title": "Examples", "width": 10},
+                ],
+            )
 
             if not selected:
                 console.print("[yellow]No datasets selected[/yellow]")
@@ -306,7 +645,12 @@ def datasets(ctx, include_experiments, select_all, source_workspace, dest_worksp
 
             inc_exp = include_experiments
             if not inc_exp:
-                inc_exp = Confirm.ask("\nInclude experiments with datasets?", default=False)
+                inc_exp = _confirm_action(
+                    config,
+                    "\nInclude experiments with datasets?",
+                    default=False,
+                    non_interactive_value=False,
+                )
 
             console.print(f"\nSelected {len(selected)} dataset(s)")
             if inc_exp:
@@ -314,7 +658,7 @@ def datasets(ctx, include_experiments, select_all, source_workspace, dest_worksp
             if config.migration.dry_run:
                 console.print("[dim]Mode: Dry Run (no changes)[/dim]")
 
-            if not Confirm.ask("\nProceed?"):
+            if not _confirm_action(config, "\nProceed?", default=True, non_interactive_value=True):
                 console.print("[yellow]Cancelled[/yellow]")
                 continue
 
@@ -344,6 +688,8 @@ def datasets(ctx, include_experiments, select_all, source_workspace, dest_worksp
 
         if ws_result:
             orchestrator.clear_workspace_context()
+        _display_resolution_summary(orchestrator)
+        _exit_for_remediation_if_needed(ctx, config, orchestrator)
     except Exception as e:
         console.print(f"\n[red]Migration failed: {e}[/red]")
         ctx.exit(1)
@@ -392,7 +738,10 @@ def resume(ctx):
     console.print(table)
 
     # Select session
-    choice = console.input("\nEnter session number to resume (or 'q' to quit): ")
+    if ctx.obj["config"].migration.non_interactive:
+        choice = "1"
+    else:
+        choice = console.input("\nEnter session number to resume (or 'q' to quit): ")
 
     if choice.lower() == 'q':
         return
@@ -422,49 +771,40 @@ def resume(ctx):
     console.print(f"  Session: {resume_info['session_id']}")
     console.print(f"  Pending: {resume_info['pending']}")
     console.print(f"  Failed: {resume_info['failed']}")
+    console.print(f"  Blocked: {resume_info['blocked']}")
+    console.print(f"  Exported: {resume_info['exported']}")
+    if resume_info.get("remediation_bundle_path"):
+        console.print(f"  Remediation bundle: {resume_info['remediation_bundle_path']}")
     console.print(f"  Can resume: {'Yes' if resume_info['can_resume'] else 'No'}")
 
     if not resume_info['can_resume']:
         console.print("[yellow]Nothing to resume in this session[/yellow]")
         return
 
-    if not Confirm.ask("Resume this migration?"):
+    if not _confirm_action(ctx.obj["config"], "Resume this migration?", default=True, non_interactive_value=True):
         return
 
     # Resume migration
     config = ctx.obj['config']
     orchestrator = MigrationOrchestrator(config, state_manager)
     orchestrator.state = state
+    config.state_manager = state_manager
 
     # Get items that need processing
-    pending_items = state.get_pending_items()
-    failed_items = state.get_failed_items()
-    items_to_process = pending_items + failed_items
+    items_to_process = state.get_resume_items()
 
     console.print(f"\n[bold]Resuming migration of {len(items_to_process)} items...[/bold]")
-
-    # Process dataset items
-    dataset_ids = [
-        item.source_id for item in items_to_process
-        if item.type == "dataset"
-    ]
-
-    # Process experiment items separately
-    experiment_ids = [
-        item.source_id for item in items_to_process
-        if item.type == "experiment"
-    ]
-
-    if dataset_ids:
-        try:
-            orchestrator.migrate_datasets_parallel(dataset_ids, include_examples=True)
-            console.print("\n[green]✓ Migration resumed and completed[/green]")
-        except Exception as e:
-            console.print(f"\n[red]Resume failed: {e}[/red]")
-    elif experiment_ids:
-        console.print("[yellow]Note: Experiment-only resume not yet supported - please resume full dataset migration[/yellow]")
+    if not items_to_process:
+        console.print("[yellow]No resumable items to process[/yellow]")
     else:
-        console.print("[yellow]No datasets to process[/yellow]")
+        results = orchestrator.resume_items(items_to_process)
+        console.print("\n[green]✓ Resume processing completed[/green]")
+        console.print(f"  Resumed: {len(results['resumed'])}")
+        console.print(f"  Remaining blocked/exported: {len(results['blocked'])}")
+
+    _display_resolution_summary(orchestrator)
+    _exit_for_remediation_if_needed(ctx, config, orchestrator)
+    orchestrator.cleanup()
 
 
 @cli.command()
@@ -486,12 +826,14 @@ def queues(ctx, source_workspace, dest_workspace, map_workspaces):
     # Test connections
     if not orchestrator.test_connections():
         console.print("\n[red]Cannot proceed without valid connections[/red]")
+        orchestrator.cleanup()
         return
 
     # Resolve workspace context
     ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces)
     if ws_result is _WS_CANCELLED:
         console.print("[yellow]Cancelled[/yellow]")
+        orchestrator.cleanup()
         return
 
     ws_pairs = list(ws_result.workspace_mapping.items()) if ws_result else [(None, None)]
@@ -508,6 +850,8 @@ def queues(ctx, source_workspace, dest_workspace, map_workspaces):
             orchestrator.set_workspace_context(src_ws, dst_ws)
             console.print(f"\n[bold cyan]Workspace: {src_ws} -> {dst_ws}[/bold cyan]")
 
+        _run_preflight(orchestrator, config, ["queues"])
+
         # Get queues
         console.print("\n[bold]Fetching annotation queues from source...[/bold]")
 
@@ -517,14 +861,16 @@ def queues(ctx, source_workspace, dest_workspace, map_workspaces):
             console.print("[yellow]No annotation queues found[/yellow]")
             continue
 
-        selected_queues = select_items(
-            items=queues,
+        selected_queues = _select_or_all(
+            config,
+            queues,
+            select_all=config.migration.non_interactive,
             title="Select Annotation Queues to Migrate",
             columns=[
                 {"key": "name", "title": "Name", "width": 40},
                 {"key": "id", "title": "ID", "width": 36},
-                {"key": "description", "title": "Description", "width": 50}
-            ]
+                {"key": "description", "title": "Description", "width": 50},
+            ],
         )
 
         if not selected_queues:
@@ -532,6 +878,8 @@ def queues(ctx, source_workspace, dest_workspace, map_workspaces):
             continue
 
         console.print(f"\n[bold]Migrating {len(selected_queues)} annotation queue(s)...[/bold]")
+        _ensure_migration_session(orchestrator, config)
+        queue_migrator.state = orchestrator.state
 
         # Perform migration
         success_count = 0
@@ -540,11 +888,22 @@ def queues(ctx, source_workspace, dest_workspace, map_workspaces):
         with Progress(console=console) as progress:
             task = progress.add_task("Migrating queues...", total=len(selected_queues))
             for queue in selected_queues:
+                item_id = _ensure_state_item(
+                    orchestrator,
+                    config,
+                    "queue",
+                    queue["id"],
+                    queue["name"],
+                    metadata={"queue": queue},
+                )
                 try:
+                    _mark_state_item_started(orchestrator, item_id)
                     new_id = queue_migrator.create_queue(queue)
                     success_count += 1
+                    _mark_state_item_completed(orchestrator, item_id, destination_id=new_id)
                 except Exception as e:
                     failed_items.append((queue['name'], str(e)))
+                    _mark_state_item_failed(orchestrator, item_id, e)
                 progress.advance(task)
 
         console.print(f"Queues: {success_count} migrated, {len(failed_items)} failed")
@@ -554,6 +913,10 @@ def queues(ctx, source_workspace, dest_workspace, map_workspaces):
 
     if ws_result:
         orchestrator.clear_workspace_context()
+
+    _display_resolution_summary(orchestrator)
+    _exit_for_remediation_if_needed(ctx, config, orchestrator)
+    orchestrator.cleanup()
 
 
 @cli.command()
@@ -578,9 +941,11 @@ def prompts(ctx, select_all, include_all_commits, source_workspace, dest_workspa
     source_ok, dest_ok, source_error, dest_error = orchestrator.test_connections_detailed()
     if not source_ok:
         console.print("[red]✗ Source connection failed[/red]")
+        orchestrator.cleanup()
         return
     if not dest_ok:
         console.print("[red]✗ Destination connection failed[/red]")
+        orchestrator.cleanup()
         return
     console.print("[green]✓[/green]")
 
@@ -588,6 +953,7 @@ def prompts(ctx, select_all, include_all_commits, source_workspace, dest_workspa
     ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces)
     if ws_result is _WS_CANCELLED:
         console.print("[yellow]Cancelled[/yellow]")
+        orchestrator.cleanup()
         return
 
     ws_pairs = list(ws_result.workspace_mapping.items()) if ws_result else [(None, None)]
@@ -604,6 +970,8 @@ def prompts(ctx, select_all, include_all_commits, source_workspace, dest_workspa
         if src_ws and dst_ws:
             orchestrator.set_workspace_context(src_ws, dst_ws)
             console.print(f"\n[bold cyan]Workspace: {src_ws} -> {dst_ws}[/bold cyan]")
+
+        _run_preflight(orchestrator, config, ["prompts"])
 
         # Check if prompts API is available on destination
         console.print("Checking prompts API availability... ", end="")
@@ -633,19 +1001,18 @@ def prompts(ctx, select_all, include_all_commits, source_workspace, dest_workspa
         console.print("[dim]Some prompts (especially those created via API) may not be accessible via the SDK.[/dim]")
         console.print("[dim]If all prompts fail, they may need to be recreated manually in the destination.[/dim]\n")
 
-        if select_all:
-            selected_prompts = prompts
-        else:
-            selected_prompts = select_items(
-                items=prompts,
-                title="Select Prompts to Migrate",
-                columns=[
-                    {"key": "repo_handle", "title": "Handle", "width": 40},
-                    {"key": "description", "title": "Description", "width": 50},
-                    {"key": "num_commits", "title": "Commits", "width": 10},
-                    {"key": "is_public", "title": "Public", "width": 8}
-                ]
-            )
+        selected_prompts = _select_or_all(
+            config,
+            prompts,
+            select_all=select_all,
+            title="Select Prompts to Migrate",
+            columns=[
+                {"key": "repo_handle", "title": "Handle", "width": 40},
+                {"key": "description", "title": "Description", "width": 50},
+                {"key": "num_commits", "title": "Commits", "width": 10},
+                {"key": "is_public", "title": "Public", "width": 8},
+            ],
+        )
 
         if not selected_prompts:
             console.print("[yellow]No prompts selected[/yellow]")
@@ -659,9 +1026,12 @@ def prompts(ctx, select_all, include_all_commits, source_workspace, dest_workspa
         if include_all_commits:
             console.print("[dim]Including all commit history[/dim]")
 
-        if not Confirm.ask("\nProceed?"):
+        if not _confirm_action(config, "\nProceed?", default=True, non_interactive_value=True):
             console.print("[yellow]Cancelled[/yellow]")
             continue
+
+        _ensure_migration_session(orchestrator, config)
+        prompt_migrator.state = orchestrator.state
 
         success_count = 0
         has_405_error = False
@@ -701,6 +1071,8 @@ def prompts(ctx, select_all, include_all_commits, source_workspace, dest_workspa
     if ws_result:
         orchestrator.clear_workspace_context()
 
+    _display_resolution_summary(orchestrator)
+    _exit_for_remediation_if_needed(ctx, config, orchestrator)
     orchestrator.cleanup()
 
 
@@ -811,9 +1183,11 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
     source_ok, dest_ok, source_error, dest_error = orchestrator.test_connections_detailed()
     if not source_ok:
         console.print("[red]✗ Source connection failed[/red]")
+        orchestrator.cleanup()
         return
     if not dest_ok:
         console.print("[red]✗ Destination connection failed[/red]")
+        orchestrator.cleanup()
         return
     console.print("[green]✓[/green]")
 
@@ -821,6 +1195,7 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
     ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces)
     if ws_result is _WS_CANCELLED:
         console.print("[yellow]Cancelled[/yellow]")
+        orchestrator.cleanup()
         return
 
     ws_pairs = list(ws_result.workspace_mapping.items()) if ws_result else [(None, None)]
@@ -828,6 +1203,7 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
     # --map-projects and --project-mapping are mutually exclusive
     if map_projects and project_mapping:
         console.print("[red]Error: --map-projects and --project-mapping are mutually exclusive[/red]")
+        orchestrator.cleanup()
         return
 
     # Parse custom project mapping once (outside loop, not workspace-scoped)
@@ -862,6 +1238,8 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
             orchestrator.set_workspace_context(src_ws, dst_ws)
             console.print(f"\n[bold cyan]Workspace: {src_ws} -> {dst_ws}[/bold cyan]")
 
+        _run_preflight(orchestrator, config, ["rules", "prompts"])
+
         rules_migrator = RulesMigrator(
             orchestrator.source_client,
             orchestrator.dest_client,
@@ -869,8 +1247,12 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
             config
         )
 
+        ws_project_id_map = _workspace_scoped_project_id_map(orchestrator, ws_result, src_ws)
+        if ws_project_id_map:
+            rules_migrator._project_id_map = ws_project_id_map
+
         # Launch interactive TUI project mapper (inside loop for workspace-scoped projects)
-        if map_projects:
+        if map_projects and not ws_project_id_map:
             console.print("Fetching projects from both instances... ", end="")
             source_projects = _list_projects(orchestrator.source_client)
             dest_projects = _list_projects(orchestrator.dest_client)
@@ -919,36 +1301,38 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
             console.print("[dim]  • Migrate projects first, then migrate rules[/dim]")
             console.print("[dim]  • Rules with dataset_id can be migrated without projects[/dim]\n")
 
-        if select_all:
+        # Enrich rules with association info for display
+        rules_for_display = []
+        for rule in rules:
+            rule_copy = rule.copy()
+            if rule.get('session_id') and rule.get('dataset_id'):
+                rule_copy['association'] = 'Project+Dataset'
+            elif rule.get('session_id'):
+                rule_copy['association'] = 'Project'
+            elif rule.get('dataset_id'):
+                rule_copy['association'] = 'Dataset'
+            else:
+                rule_copy['association'] = 'None'
+
+            if not rule_copy.get('name') and rule_copy.get('display_name'):
+                rule_copy['name'] = rule_copy['display_name']
+
+            rules_for_display.append(rule_copy)
+
+        if select_all or config.migration.non_interactive:
             selected_rules = rules
         else:
-            # Enrich rules with association info for display
-            rules_for_display = []
-            for rule in rules:
-                rule_copy = rule.copy()
-                if rule.get('session_id') and rule.get('dataset_id'):
-                    rule_copy['association'] = 'Project+Dataset'
-                elif rule.get('session_id'):
-                    rule_copy['association'] = 'Project'
-                elif rule.get('dataset_id'):
-                    rule_copy['association'] = 'Dataset'
-                else:
-                    rule_copy['association'] = 'None'
-
-                if not rule_copy.get('name') and rule_copy.get('display_name'):
-                    rule_copy['name'] = rule_copy['display_name']
-
-                rules_for_display.append(rule_copy)
-
-            selected_rules = select_items(
-                items=rules_for_display,
+            selected_rules = _select_or_all(
+                config,
+                rules_for_display,
+                select_all=False,
                 title="Select Rules to Migrate",
                 columns=[
                     {"key": "name", "title": "Name", "width": 30},
                     {"key": "rule_type", "title": "Type", "width": 25},
                     {"key": "association", "title": "Association", "width": 15},
                     {"key": "enabled", "title": "Enabled", "width": 10},
-                ]
+                ],
             )
 
         if not selected_rules:
@@ -963,9 +1347,12 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
         if strip_projects:
             console.print("[dim]Mode: Stripping project associations (creating as global rules)[/dim]")
 
-        if not Confirm.ask("\nProceed?"):
+        if not _confirm_action(config, "\nProceed?", default=True, non_interactive_value=True):
             console.print("[yellow]Cancelled[/yellow]")
             continue
+
+        _ensure_migration_session(orchestrator, config)
+        rules_migrator.state = orchestrator.state
 
         success_count = 0
         failed_items = []
@@ -974,8 +1361,22 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
         with Progress(console=console) as progress:
             task = progress.add_task("Migrating rules...", total=len(selected_rules))
             for rule in selected_rules:
+                rule_name = rule.get('display_name') or rule.get('name', 'unnamed')
+                item_id = _ensure_state_item(
+                    orchestrator,
+                    config,
+                    "rule",
+                    rule.get("id", rule_name),
+                    rule_name,
+                    metadata={
+                        "rule": rule,
+                        "strip_projects": strip_projects,
+                        "create_disabled": not create_enabled,
+                        "project_id_map": dict(rules_migrator._project_id_map or {}),
+                    },
+                )
                 try:
-                    rule_name = rule.get('display_name') or rule.get('name', 'unnamed')
+                    _mark_state_item_started(orchestrator, item_id)
                     has_project = bool(rule.get('session_id'))
                     has_dataset = bool(rule.get('dataset_id'))
                     has_evaluators = bool(rule.get('evaluators') or rule.get('evaluator_prompt_handle'))
@@ -984,18 +1385,23 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
                     result = rules_migrator.create_rule(rule, strip_project_reference=strip_projects, create_disabled=create_disabled)
                     if result:
                         success_count += 1
+                        _mark_state_item_completed(orchestrator, item_id, destination_id=result)
                     else:
                         if not has_dataset and not has_project:
                             skipped_items.append((rule_name, "no dataset or project"))
+                            _mark_state_item_failed(orchestrator, item_id, "no dataset or project")
                         elif has_project and not has_dataset:
                             skipped_items.append((rule_name, "project not found in destination"))
+                            _mark_state_item_failed(orchestrator, item_id, "project not found in destination")
                         elif has_evaluators:
                             failed_items.append((rule_name, "check prompts exist on destination"))
+                            _mark_state_item_failed(orchestrator, item_id, "check prompts exist on destination")
                         else:
                             failed_items.append((rule_name, "see verbose logs"))
+                            _mark_state_item_failed(orchestrator, item_id, "see verbose logs")
                 except Exception as e:
-                    rule_name = rule.get('display_name') or rule.get('name', 'unnamed')
                     failed_items.append((rule_name, str(e)))
+                    _mark_state_item_failed(orchestrator, item_id, e)
                 progress.advance(task)
 
         console.print(f"Rules: {success_count} migrated, {len(skipped_items)} skipped, {len(failed_items)} failed")
@@ -1015,6 +1421,8 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
     if ws_result:
         orchestrator.clear_workspace_context()
 
+    _display_resolution_summary(orchestrator)
+    _exit_for_remediation_if_needed(ctx, config, orchestrator)
     orchestrator.cleanup()
 
 
@@ -1047,9 +1455,11 @@ def migrate_all(ctx, skip_datasets, skip_experiments, skip_prompts, skip_queues,
     source_ok, dest_ok, source_error, dest_error = orchestrator.test_connections_detailed()
     if not source_ok:
         console.print("[red]✗ Source connection failed[/red]")
+        orchestrator.cleanup()
         return
     if not dest_ok:
         console.print("[red]✗ Destination connection failed[/red]")
+        orchestrator.cleanup()
         return
     console.print("[green]✓[/green]\n")
 
@@ -1057,6 +1467,7 @@ def migrate_all(ctx, skip_datasets, skip_experiments, skip_prompts, skip_queues,
     ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces)
     if ws_result is _WS_CANCELLED:
         console.print("[yellow]Cancelled[/yellow]")
+        orchestrator.cleanup()
         return
 
     console.print("[bold cyan]LangSmith Data Migration Wizard[/bold cyan]\n")
@@ -1069,6 +1480,20 @@ def migrate_all(ctx, skip_datasets, skip_experiments, skip_prompts, skip_queues,
         if src_ws and dst_ws:
             orchestrator.set_workspace_context(src_ws, dst_ws)
             console.print(f"\n[bold cyan]━━━ Workspace {ws_idx + 1}/{len(ws_pairs)}: {src_ws} -> {dst_ws} ━━━[/bold cyan]\n")
+
+        preflight_resources = []
+        if not skip_datasets:
+            preflight_resources.append("datasets")
+            if not skip_experiments:
+                preflight_resources.append("experiments")
+        if not skip_prompts:
+            preflight_resources.append("prompts")
+        if not skip_queues:
+            preflight_resources.append("queues")
+        if not skip_rules:
+            preflight_resources.append("rules")
+        preflight_resources.append("charts")
+        _run_preflight(orchestrator, config, preflight_resources)
 
         # Use per-workspace project mapping from the TUI if available
         ws_project_mapping = None
@@ -1083,6 +1508,8 @@ def migrate_all(ctx, skip_datasets, skip_experiments, skip_prompts, skip_queues,
         orchestrator.clear_workspace_context()
 
     console.print("\n[bold green]Migration wizard completed![/bold green]")
+    _display_resolution_summary(orchestrator)
+    _exit_for_remediation_if_needed(ctx, config, orchestrator)
     orchestrator.cleanup()
 
 
@@ -1139,10 +1566,15 @@ def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_ex
         if datasets:
             console.print(f"found {len(datasets)}")
 
-            if Confirm.ask(f"Migrate {len(datasets)} dataset(s)?"):
+            if _confirm_action(config, f"Migrate {len(datasets)} dataset(s)?", default=True, non_interactive_value=True):
                 include_exp = False
                 if not skip_experiments:
-                    include_exp = Confirm.ask("Include experiments with datasets?")
+                    include_exp = _confirm_action(
+                        config,
+                        "Include experiments with datasets?",
+                        default=True,
+                        non_interactive_value=True,
+                    )
 
                 try:
                     dataset_ids = [d["id"] for d in datasets]
@@ -1174,8 +1606,15 @@ def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_ex
             console.print(f"found {len(prompts)}")
             console.print("[dim]Note: Prompt migration uses the SDK. API-created prompts may not be accessible.[/dim]")
 
-            if Confirm.ask(f"Migrate {len(prompts)} prompt(s)?"):
-                include_history = include_all_commits or Confirm.ask("Include full commit history?")
+            if _confirm_action(config, f"Migrate {len(prompts)} prompt(s)?", default=True, non_interactive_value=True):
+                include_history = include_all_commits or _confirm_action(
+                    config,
+                    "Include full commit history?",
+                    default=False,
+                    non_interactive_value=include_all_commits,
+                )
+                _ensure_migration_session(orchestrator, config)
+                prompt_migrator.state = orchestrator.state
 
                 success_count = 0
                 failed_items = []
@@ -1224,18 +1663,31 @@ def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_ex
         if queues:
             console.print(f"found {len(queues)}")
 
-            if Confirm.ask(f"Migrate {len(queues)} annotation queue(s)?"):
+            if _confirm_action(config, f"Migrate {len(queues)} annotation queue(s)?", default=True, non_interactive_value=True):
+                _ensure_migration_session(orchestrator, config)
+                queue_migrator.state = orchestrator.state
                 success_count = 0
                 failed_items = []
 
                 with Progress(console=console) as progress:
                     task = progress.add_task("Migrating queues...", total=len(queues))
                     for queue in queues:
+                        item_id = _ensure_state_item(
+                            orchestrator,
+                            config,
+                            "queue",
+                            queue["id"],
+                            queue["name"],
+                            metadata={"queue": queue},
+                        )
                         try:
+                            _mark_state_item_started(orchestrator, item_id)
                             new_id = queue_migrator.create_queue(queue)
                             success_count += 1
+                            _mark_state_item_completed(orchestrator, item_id, destination_id=new_id)
                         except Exception as e:
                             failed_items.append((queue['name'], str(e)))
+                            _mark_state_item_failed(orchestrator, item_id, e)
                         progress.advance(task)
 
                 console.print(f"Queues: {success_count} migrated, {len(failed_items)} failed")
@@ -1291,27 +1743,53 @@ def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_ex
             if project_specific:
                 console.print(f"[yellow]Note: {len(project_specific)} rule(s) are project-specific[/yellow]")
 
-            if Confirm.ask(f"Migrate {len(rules)} rule(s)?"):
+            if _confirm_action(config, f"Migrate {len(rules)} rule(s)?", default=True, non_interactive_value=True):
                 strip = strip_projects
                 ensure_projects = False
                 
                 if project_specific and not strip:
-                    strip = Confirm.ask("Convert project-specific rules to global rules?")
+                    strip = _confirm_action(
+                        config,
+                        "Convert project-specific rules to global rules?",
+                        default=False,
+                        non_interactive_value=strip_projects,
+                    )
                     if not strip:
-                        ensure_projects = Confirm.ask("Create corresponding projects for project-specific rules?", default=True)
+                        ensure_projects = _confirm_action(
+                            config,
+                            "Create corresponding projects for project-specific rules?",
+                            default=True,
+                            non_interactive_value=True,
+                        )
 
                 success_count = 0
                 failed_items = []
                 skipped_items = []
+                _ensure_migration_session(orchestrator, config)
+                rules_migrator.state = orchestrator.state
 
                 with Progress(console=console) as progress:
                     task = progress.add_task("Migrating rules...", total=len(rules))
                     for rule in rules:
+                        rule_name = rule.get('display_name') or rule.get('name', 'unnamed')
+                        item_id = _ensure_state_item(
+                            orchestrator,
+                            config,
+                            "rule",
+                            rule.get("id", rule_name),
+                            rule_name,
+                            metadata={
+                                "rule": rule,
+                                "strip_projects": strip,
+                                "ensure_project": ensure_projects,
+                                "project_id_map": dict(rules_migrator._project_id_map or {}),
+                            },
+                        )
                         try:
+                            _mark_state_item_started(orchestrator, item_id)
                             has_project = bool(rule.get('session_id'))
                             has_dataset = bool(rule.get('dataset_id'))
                             has_evaluators = bool(rule.get('evaluators') or rule.get('evaluator_prompt_handle'))
-                            rule_name = rule.get('display_name') or rule.get('name', 'unnamed')
 
                             result = rules_migrator.create_rule(
                                 rule,
@@ -1320,18 +1798,23 @@ def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_ex
                             )
                             if result:
                                 success_count += 1
+                                _mark_state_item_completed(orchestrator, item_id, destination_id=result)
                             else:
                                 if not has_dataset and not has_project:
                                     skipped_items.append((rule_name, "no dataset or project"))
+                                    _mark_state_item_failed(orchestrator, item_id, "no dataset or project")
                                 elif has_project and not has_dataset and not ensure_projects:
                                     skipped_items.append((rule_name, "project not found in destination"))
+                                    _mark_state_item_failed(orchestrator, item_id, "project not found in destination")
                                 elif has_evaluators:
                                     failed_items.append((rule_name, "check prompts exist on destination"))
+                                    _mark_state_item_failed(orchestrator, item_id, "check prompts exist on destination")
                                 else:
                                     failed_items.append((rule_name, "see verbose logs"))
+                                    _mark_state_item_failed(orchestrator, item_id, "see verbose logs")
                         except Exception as e:
-                            rule_name = rule.get('display_name') or rule.get('name', 'unnamed')
                             failed_items.append((rule_name, str(e)))
+                            _mark_state_item_failed(orchestrator, item_id, e)
                         progress.advance(task)
 
                 console.print(f"Rules: {success_count} migrated, {len(skipped_items)} skipped, {len(failed_items)} failed")
@@ -1372,9 +1855,11 @@ def charts(ctx, session, same_instance, map_projects, source_workspace, dest_wor
     source_ok, dest_ok, source_error, dest_error = orchestrator.test_connections_detailed()
     if not source_ok:
         console.print("[red]✗ Source connection failed[/red]")
+        orchestrator.cleanup()
         return
     if not dest_ok:
         console.print("[red]✗ Destination connection failed[/red]")
+        orchestrator.cleanup()
         return
     console.print("[green]✓[/green]")
 
@@ -1382,6 +1867,7 @@ def charts(ctx, session, same_instance, map_projects, source_workspace, dest_wor
     ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces)
     if ws_result is _WS_CANCELLED:
         console.print("[yellow]Cancelled[/yellow]")
+        orchestrator.cleanup()
         return
 
     ws_pairs = list(ws_result.workspace_mapping.items()) if ws_result else [(None, None)]
@@ -1403,6 +1889,8 @@ def charts(ctx, session, same_instance, map_projects, source_workspace, dest_wor
             orchestrator.set_workspace_context(src_ws, dst_ws)
             console.print(f"\n[bold cyan]Workspace: {src_ws} -> {dst_ws}[/bold cyan]")
 
+        _run_preflight(orchestrator, config, ["charts"])
+
         chart_migrator = ChartMigrator(
             orchestrator.source_client,
             orchestrator.dest_client,
@@ -1410,8 +1898,12 @@ def charts(ctx, session, same_instance, map_projects, source_workspace, dest_wor
             config
         )
 
+        ws_project_id_map = _workspace_scoped_project_id_map(orchestrator, ws_result, src_ws)
+        if ws_project_id_map:
+            chart_migrator._project_id_map = ws_project_id_map
+
         # Launch interactive TUI project mapper (inside loop for workspace-scoped projects)
-        if map_projects:
+        if map_projects and not ws_project_id_map:
             console.print("Fetching projects from both instances... ", end="")
             source_projects = _list_projects(orchestrator.source_client)
             dest_projects = _list_projects(orchestrator.dest_client)
@@ -1461,7 +1953,11 @@ def charts(ctx, session, same_instance, map_projects, source_workspace, dest_wor
                 dest_session_id = source_session_id
                 console.print("[dim]Using same session ID for destination[/dim]\n")
             else:
-                dest_session_id = orchestrator.state.get_mapped_id('project', source_session_id)
+                dest_session_id = (
+                    orchestrator.state.get_mapped_id('project', source_session_id)
+                    if orchestrator.state
+                    else None
+                )
                 if not dest_session_id:
                     console.print(f"[red]No destination mapping found for session {session}[/red]")
                     console.print("\n[yellow]This means the project/session hasn't been migrated yet.[/yellow]")
@@ -1471,10 +1967,47 @@ def charts(ctx, session, same_instance, map_projects, source_workspace, dest_wor
                     continue
                 console.print(f"[dim]Mapped to destination session: {dest_session_id[:8]}...[/dim]\n")
 
+            _ensure_migration_session(orchestrator, config)
+            chart_migrator.state = orchestrator.state
+            tracked_chart_items = {}
+            for chart in chart_migrator.list_charts(source_session_id):
+                chart_id = chart.get("id")
+                if not chart_id:
+                    continue
+                chart_title = chart.get("title") or chart.get("name") or "Untitled Chart"
+                item_id = _ensure_state_item(
+                    orchestrator,
+                    config,
+                    "chart",
+                    chart_id,
+                    chart_title,
+                    metadata={
+                        "chart": chart,
+                        "dest_session_id": dest_session_id,
+                        "same_instance": same_instance,
+                    },
+                )
+                tracked_chart_items[chart_id] = item_id
+                _mark_state_item_started(orchestrator, item_id)
+
             chart_mappings = chart_migrator.migrate_session_charts(
                 source_session_id,
                 dest_session_id
             )
+
+            for chart_id, item_id in tracked_chart_items.items():
+                if chart_id in chart_mappings:
+                    _mark_state_item_completed(
+                        orchestrator,
+                        item_id,
+                        destination_id=chart_mappings[chart_id],
+                    )
+                else:
+                    _mark_state_item_failed(
+                        orchestrator,
+                        item_id,
+                        "chart migration returned None",
+                    )
 
             console.print(f"\n[green]✓[/green] Migrated {len(chart_mappings)} chart(s)")
 
@@ -1489,12 +2022,60 @@ def charts(ctx, session, same_instance, map_projects, source_workspace, dest_wor
 
             console.print()
 
-            if not Confirm.ask("Proceed with migration?"):
+            if not _confirm_action(config, "Proceed with migration?", default=True, non_interactive_value=True):
                 console.print("[yellow]Cancelled[/yellow]")
                 continue
 
             console.print()
+            _ensure_migration_session(orchestrator, config)
+            chart_migrator.state = orchestrator.state
+            tracked_chart_items = {}
+            source_charts = chart_migrator.list_charts()
+            if not same_instance:
+                chart_migrator._build_project_mapping()
+            for chart in source_charts:
+                chart_id = chart.get("id")
+                if not chart_id:
+                    continue
+                chart_title = chart.get("title") or chart.get("name") or "Untitled Chart"
+                source_session_id = chart_migrator._extract_session_id(chart)
+                dest_session_id = None
+                if source_session_id:
+                    if same_instance:
+                        dest_session_id = source_session_id
+                    elif chart_migrator._project_id_map:
+                        dest_session_id = chart_migrator._project_id_map.get(source_session_id)
+                item_id = _ensure_state_item(
+                    orchestrator,
+                    config,
+                    "chart",
+                    chart_id,
+                    chart_title,
+                    metadata={
+                        "chart": chart,
+                        "dest_session_id": dest_session_id,
+                        "same_instance": same_instance,
+                    },
+                )
+                tracked_chart_items[chart_id] = item_id
+                _mark_state_item_started(orchestrator, item_id)
             all_mappings = chart_migrator.migrate_all_charts(same_instance=same_instance)
+            flat_chart_map = {}
+            for session_chart_map in all_mappings.values():
+                flat_chart_map.update(session_chart_map)
+            for chart_id, item_id in tracked_chart_items.items():
+                if chart_id in flat_chart_map:
+                    _mark_state_item_completed(
+                        orchestrator,
+                        item_id,
+                        destination_id=flat_chart_map[chart_id],
+                    )
+                else:
+                    _mark_state_item_failed(
+                        orchestrator,
+                        item_id,
+                        "chart migration returned None",
+                    )
 
             if all_mappings:
                 console.print("\n[green]✓ Chart migration completed successfully[/green]")
@@ -1509,6 +2090,8 @@ def charts(ctx, session, same_instance, map_projects, source_workspace, dest_wor
     if ws_result:
         orchestrator.clear_workspace_context()
 
+    _display_resolution_summary(orchestrator)
+    _exit_for_remediation_if_needed(ctx, config, orchestrator)
     orchestrator.cleanup()
 
 

--- a/langsmith_migrator/core/migrators/base.py
+++ b/langsmith_migrator/core/migrators/base.py
@@ -1,10 +1,14 @@
 """Base migrator class with shared functionality."""
 
-from typing import Any
+from typing import Any, Dict, Optional
 from rich.console import Console
 
 from ..api_client import EnhancedAPIClient
-from ...utils.state import MigrationState
+from ...utils.state import (
+    MigrationState,
+    ResolutionOutcome,
+    VerificationState,
+)
 
 
 class BaseMigrator:
@@ -37,3 +41,251 @@ class BaseMigrator:
         }.get(level, "")
 
         self.console.print(f"[{style}]{message}[/{style}]")
+
+    def workspace_pair(self) -> Dict[str, Optional[str]]:
+        """Return the active workspace pair from request headers."""
+        return {
+            "source": self.source.session.headers.get("X-Tenant-Id"),
+            "dest": self.dest.session.headers.get("X-Tenant-Id"),
+        }
+
+    def persist_state(self) -> None:
+        """Persist state if a state manager is attached to the config."""
+        if not self.state:
+            return
+        state_manager = getattr(self.config, "state_manager", None)
+        if state_manager is None:
+            return
+        state_manager.current_state = self.state
+        state_manager.save()
+
+    def ensure_item(
+        self,
+        item_id: str,
+        item_type: str,
+        name: str,
+        source_id: str,
+        *,
+        stage: str = "pending",
+        strategy: Optional[str] = None,
+        dependencies: Optional[list[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
+        """Create a tracked item if state support is active."""
+        if not self.state:
+            return None
+        item = self.state.ensure_item(
+            item_id,
+            item_type,
+            name,
+            source_id,
+            stage=stage,
+            strategy=strategy,
+            dependencies=dependencies or [],
+            metadata=metadata or {},
+            workspace_pair=self.workspace_pair(),
+        )
+        self.persist_state()
+        return item
+
+    def checkpoint_item(self, item_id: str, **kwargs: Any) -> None:
+        """Persist checkpoint details for a tracked item."""
+        if not self.state:
+            return
+        if "workspace_pair" not in kwargs:
+            kwargs["workspace_pair"] = self.workspace_pair()
+        self.state.update_item_checkpoint(item_id, **kwargs)
+        self.persist_state()
+
+    def record_issue(
+        self,
+        issue_class: str,
+        code: str,
+        summary: str,
+        *,
+        item_id: Optional[str] = None,
+        next_action: Optional[str] = None,
+        evidence: Optional[Dict[str, Any]] = None,
+        export_path: Optional[str] = None,
+    ):
+        """Record a typed issue into the current session state."""
+        if not self.state:
+            return None
+        issue = self.state.add_issue(
+            issue_class,
+            code,
+            summary,
+            item_id=item_id,
+            next_action=next_action,
+            evidence=evidence,
+            workspace_pair=self.workspace_pair(),
+            export_path=export_path,
+        )
+        self.persist_state()
+        return issue
+
+    def queue_remediation(
+        self,
+        *,
+        issue_id: str,
+        next_action: str,
+        item_id: Optional[str] = None,
+        export_path: Optional[str] = None,
+        command: Optional[str] = None,
+        requires_interaction: bool = False,
+    ):
+        """Queue a remediation action in state."""
+        if not self.state:
+            return None
+        task = self.state.queue_remediation(
+            issue_id=issue_id,
+            next_action=next_action,
+            item_id=item_id,
+            export_path=export_path,
+            command=command,
+            requires_interaction=requires_interaction,
+        )
+        self.persist_state()
+        return task
+
+    def export_payload(
+        self,
+        item_id: str,
+        name: str,
+        payload: Any,
+        *,
+        extension: Optional[str] = None,
+    ) -> Optional[str]:
+        """Write a payload into the remediation bundle."""
+        if not self.state:
+            return None
+        path = self.state.export_artifact(item_id, name, payload, extension=extension)
+        self.persist_state()
+        return path
+
+    def mark_terminal(
+        self,
+        item_id: str,
+        terminal_state: ResolutionOutcome,
+        outcome_code: str,
+        *,
+        verification_state: VerificationState,
+        next_action: Optional[str] = None,
+        evidence: Optional[Dict[str, Any]] = None,
+        export_path: Optional[str] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        """Persist a terminal resolution state for an item."""
+        if not self.state:
+            return
+        self.state.mark_terminal(
+            item_id,
+            terminal_state,
+            outcome_code,
+            verification_state=verification_state,
+            next_action=next_action,
+            evidence=evidence,
+            export_path=export_path,
+            error=error,
+        )
+        self.persist_state()
+
+    def mark_migrated(
+        self,
+        item_id: str,
+        *,
+        outcome_code: str = "migrated",
+        evidence: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.mark_terminal(
+            item_id,
+            ResolutionOutcome.MIGRATED,
+            outcome_code,
+            verification_state=VerificationState.VERIFIED,
+            evidence=evidence,
+        )
+
+    def mark_degraded(
+        self,
+        item_id: str,
+        outcome_code: str,
+        *,
+        next_action: Optional[str] = None,
+        evidence: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.mark_terminal(
+            item_id,
+            ResolutionOutcome.MIGRATED_WITH_VERIFIED_DOWNGRADE,
+            outcome_code,
+            verification_state=VerificationState.DEGRADED,
+            next_action=next_action,
+            evidence=evidence,
+        )
+
+    def mark_blocked(
+        self,
+        item_id: str,
+        outcome_code: str,
+        *,
+        next_action: str,
+        evidence: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.mark_terminal(
+            item_id,
+            ResolutionOutcome.BLOCKED_WITH_CHECKPOINT,
+            outcome_code,
+            verification_state=VerificationState.BLOCKED,
+            next_action=next_action,
+            evidence=evidence,
+            error=outcome_code,
+        )
+
+    def mark_exported(
+        self,
+        item_id: str,
+        outcome_code: str,
+        *,
+        next_action: str,
+        export_path: Optional[str],
+        evidence: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.mark_terminal(
+            item_id,
+            ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY,
+            outcome_code,
+            verification_state=VerificationState.EXPORTED,
+            next_action=next_action,
+            export_path=export_path,
+            evidence=evidence,
+            error=outcome_code,
+        )
+
+    def record_capability(
+        self,
+        scope: str,
+        capability: str,
+        *,
+        supported: Optional[bool],
+        detail: Optional[str] = None,
+        evidence: Optional[Dict[str, Any]] = None,
+        probe: Optional[str] = None,
+    ) -> None:
+        """Persist a capability probe result."""
+        if not self.state:
+            return
+        self.state.record_capability(
+            scope,
+            capability,
+            supported=supported,
+            detail=detail,
+            evidence=evidence,
+            probe=probe,
+        )
+        self.persist_state()
+
+    def record_provenance(self, key: str, value: Any) -> None:
+        """Persist resolution provenance."""
+        if not self.state:
+            return
+        self.state.record_resolution_provenance(key, value)
+        self.persist_state()

--- a/langsmith_migrator/core/migrators/chart.py
+++ b/langsmith_migrator/core/migrators/chart.py
@@ -4,6 +4,7 @@ import datetime
 from typing import Dict, List, Any, Optional
 from .base import BaseMigrator
 from ..api_client import NotFoundError, APIError
+from ...utils.matching import unique_name_map
 
 
 class ChartMigrator(BaseMigrator):
@@ -15,6 +16,160 @@ class ChartMigrator(BaseMigrator):
         self._project_id_map = None  # Lazy-loaded cache
         self._dataset_id_map = None  # Lazy-loaded cache
         self._dest_section_map = None # Lazy-loaded cache for dest sections
+        self._section_strategy = None
+
+    def _chart_item_id(self, chart: Dict[str, Any]) -> str:
+        chart_id = chart.get("id") or chart.get("title") or chart.get("name") or "unknown"
+        return f"chart_{chart_id}"
+
+    def probe_capabilities(self) -> Dict[str, Dict[str, Any]]:
+        """Probe chart-related capabilities without mutating destination state."""
+        capabilities: Dict[str, Dict[str, Any]] = {}
+
+        def record(name: str, supported: Optional[bool], detail: str, probe: str) -> None:
+            capabilities[name] = {"supported": supported, "detail": detail, "probe": probe}
+            self.record_capability(
+                "charts",
+                name,
+                supported=supported,
+                detail=detail,
+                probe=probe,
+            )
+
+        try:
+            self._list_charts(self.source, side="source")
+            record("source_chart_list", True, "ok", "POST /charts")
+        except Exception as e:
+            record("source_chart_list", False, str(e), "POST /charts")
+
+        try:
+            destination_response = self._list_charts(self.dest, side="destination")
+            record("destination_chart_list", True, "ok", "POST /charts")
+            if isinstance(destination_response, list):
+                self._section_strategy = "sectioned"
+        except Exception as e:
+            record("destination_chart_list", False, str(e), "POST /charts")
+
+        record("section_scoped_create", None, "deferred_until_first_write", "POST /charts/section")
+        return capabilities
+
+    def _normalize_chart(self, chart_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize a chart payload for post-write verification."""
+        return {
+            "title": chart_data.get("title") or chart_data.get("name"),
+            "chart_type": chart_data.get("chart_type"),
+            "section_id": chart_data.get("section_id"),
+            "common_filters": chart_data.get("common_filters"),
+            "series": chart_data.get("series"),
+        }
+
+    def _build_chart_payload(self, chart_data: Dict[str, Any]) -> tuple[Dict[str, Any], bool]:
+        """Build a destination chart payload and report whether fidelity was downgraded."""
+        chart_title = chart_data.get("title") or chart_data.get("name") or "Untitled Chart"
+        payload = {
+            "title": chart_title,
+            "chart_type": chart_data.get("chart_type", "line"),
+            "series": chart_data.get("series", []),
+            "description": chart_data.get("description"),
+            "index": chart_data.get("index"),
+            "metadata": chart_data.get("metadata"),
+            "section_id": chart_data.get("section_id"),
+            "common_filters": chart_data.get("common_filters"),
+        }
+        payload = {k: v for k, v in payload.items() if v is not None}
+
+        downgraded = False
+        source_section_title = chart_data.get("_source_section_title")
+        source_section_desc = chart_data.get("_source_section_description")
+
+        if source_section_title and self._section_strategy != "unsectioned":
+            dest_section_id = self._ensure_dest_section(source_section_title, source_section_desc)
+            if dest_section_id:
+                payload["section_id"] = dest_section_id
+            else:
+                payload.pop("section_id", None)
+                downgraded = True
+
+        return payload, downgraded
+
+    def _verify_chart(self, chart_id: str, payload: Dict[str, Any]) -> tuple[bool, Dict[str, Any]]:
+        """Verify a chart by refetching destination charts and comparing normalized fields."""
+        mismatches = {}
+        chart = None
+        for existing in self._list_charts(self.dest, side="destination"):
+            if existing.get("id") == chart_id:
+                chart = existing
+                break
+        if chart is None:
+            return False, {"error": "chart_not_found_after_write"}
+
+        normalized_expected = self._normalize_chart(payload)
+        normalized_actual = self._normalize_chart(chart)
+        for key, expected in normalized_expected.items():
+            if normalized_actual.get(key) != expected:
+                mismatches[key] = {
+                    "expected": expected,
+                    "actual": normalized_actual.get(key),
+                }
+        return not mismatches, mismatches
+
+    def _export_chart_manual_apply(
+        self,
+        chart: Dict[str, Any],
+        *,
+        reason: str,
+        payload: Optional[Dict[str, Any]] = None,
+        analysis: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Export chart payload and analysis for manual apply."""
+        return self.export_payload(
+            self._chart_item_id(chart),
+            "manual_apply",
+            {
+                "chart_id": chart.get("id"),
+                "title": chart.get("title") or chart.get("name"),
+                "reason": reason,
+                "payload": payload or chart,
+                "analysis": analysis or {},
+                "manual_steps": [
+                    "Review the missing fields or destination capability mismatch.",
+                    "Create or update the chart manually with the exported payload.",
+                    "Re-run `langsmith-migrator resume` after the chart exists on destination.",
+                ],
+            },
+        )
+
+    def _enrich_chart(self, chart: Dict[str, Any]) -> Dict[str, Any]:
+        """Attempt one richer source fetch when chart metadata is incomplete."""
+        if chart.get("series"):
+            return chart
+
+        try:
+            start_time = (
+                datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
+            ).isoformat()
+            payload = {
+                "timezone": "UTC",
+                "omit_data": False,
+                "start_time": start_time,
+                "end_time": None,
+                "stride": {"days": 0, "hours": 0, "minutes": 15},
+                "after_index": None,
+                "tag_value_id": None,
+            }
+            response = self.source.post("/charts", payload)
+            candidate_charts = []
+            if isinstance(response, dict) and "charts" in response:
+                candidate_charts = response["charts"]
+            elif isinstance(response, list):
+                candidate_charts = response
+            for candidate in candidate_charts:
+                if candidate.get("id") == chart.get("id"):
+                    return candidate
+        except Exception as e:
+            self.log(f"Failed to enrich chart '{chart.get('title') or chart.get('name')}': {e}", "warning")
+
+        return chart
 
     def list_sessions(self) -> List[Dict[str, Any]]:
         """
@@ -34,20 +189,20 @@ class ChartMigrator(BaseMigrator):
             self.log(f"Failed to list sessions: {e}", "error")
             return []
 
-    def list_charts(self, session_id: Optional[str] = None) -> List[Dict[str, Any]]:
-        """
-        List charts from source using POST /api/v1/charts.
-
-        Args:
-            session_id: Optional session ID to filter by
-
-        Returns:
-            List of chart configurations
-        """
+    def _list_charts(
+        self,
+        client,
+        *,
+        session_id: Optional[str] = None,
+        side: str = "source",
+    ) -> List[Dict[str, Any]]:
+        """List charts from the requested instance using POST /api/v1/charts."""
         try:
             # Prepare request body for listing charts according to schema
             # Note: Some versions require start_time even if omit_data is True
-            start_time = (datetime.datetime.utcnow() - datetime.timedelta(days=1)).isoformat()
+            start_time = (
+                datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
+            ).isoformat()
 
             payload = {
                 "timezone": "UTC",
@@ -59,7 +214,7 @@ class ChartMigrator(BaseMigrator):
                 "tag_value_id": None
             }
 
-            response = self.source.post("/charts", payload)
+            response = client.post("/charts", payload)
             charts = []
 
             # Handle different response formats
@@ -127,17 +282,29 @@ class ChartMigrator(BaseMigrator):
             return charts
 
         except NotFoundError:
-            self.log("Charts API endpoint not found (404)", "error")
+            self.log(f"Charts API endpoint not found on {side} (404)", "error")
             return []
         except APIError as e:
             if e.status_code == 405:
-                self.log("Charts API method not allowed (405)", "error")
+                self.log(f"Charts API method not allowed on {side} (405)", "error")
             else:
-                self.log(f"Charts API error ({e.status_code}): {e}", "error")
+                self.log(f"Charts API error on {side} ({e.status_code}): {e}", "error")
             return []
         except Exception as e:
-            self.log(f"Unexpected error listing charts: {e}", "error")
+            self.log(f"Unexpected error listing charts on {side}: {e}", "error")
             return []
+
+    def list_charts(self, session_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """
+        List charts from source using POST /api/v1/charts.
+
+        Args:
+            session_id: Optional session ID to filter by
+
+        Returns:
+            List of chart configurations
+        """
+        return self._list_charts(self.source, session_id=session_id, side="source")
 
     def _ensure_dest_section(self, title: str, description: Optional[str] = None) -> Optional[str]:
         """
@@ -172,6 +339,14 @@ class ChartMigrator(BaseMigrator):
 
         except Exception as e:
             self.log(f"Failed to create section '{title}': {e}", "error")
+            self._section_strategy = "unsectioned"
+            self.record_capability(
+                "charts",
+                "section_scoped_create",
+                supported=False,
+                detail=str(e),
+                probe="POST /charts/section",
+            )
 
         return None
 
@@ -190,7 +365,9 @@ class ChartMigrator(BaseMigrator):
         self._dest_section_map = {}
         try:
             # We use the same payload as list_charts but against destination
-            start_time = (datetime.datetime.utcnow() - datetime.timedelta(days=1)).isoformat()
+            start_time = (
+                datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
+            ).isoformat()
             payload = {
                 "timezone": "UTC",
                 "omit_data": True,
@@ -225,8 +402,7 @@ class ChartMigrator(BaseMigrator):
             The chart ID if found, None otherwise
         """
         try:
-            # List all charts from destination
-            charts = self.list_charts()
+            charts = self._list_charts(self.dest, side="destination")
 
             for chart in charts:
                 chart_title = chart.get("title") or chart.get("name")
@@ -258,20 +434,7 @@ class ChartMigrator(BaseMigrator):
             self.log(f"[DRY RUN] Would update chart: {chart_title} ({chart_id})")
             return True
 
-        # Build update payload
-        payload = {
-            "title": chart_data.get("title") or chart_data.get("name"),
-            "chart_type": chart_data.get("chart_type"),
-            "series": chart_data.get("series"),
-            "description": chart_data.get("description"),
-            "index": chart_data.get("index"),
-            "metadata": chart_data.get("metadata"),
-            "section_id": chart_data.get("section_id"),
-            "common_filters": chart_data.get("common_filters")
-        }
-
-        # Remove None values
-        payload = {k: v for k, v in payload.items() if v is not None}
+        payload, _ = self._build_chart_payload(chart_data)
 
         try:
             # Use PATCH to update the chart
@@ -295,41 +458,68 @@ class ChartMigrator(BaseMigrator):
             The created/updated chart ID or None if failed
         """
         chart_title = chart_data.get("title") or chart_data.get("name") or "Untitled Chart"
+        item_id = self._chart_item_id(chart_data)
+        self.ensure_item(
+            item_id,
+            "chart",
+            chart_title,
+            str(chart_data.get("id") or chart_title),
+            stage="prepare_chart",
+            strategy=self._section_strategy or "sectioned",
+            metadata={"title": chart_title},
+        )
 
         if self.config.migration.dry_run:
             self.log(f"[DRY RUN] Would create chart: {chart_title}", "info")
             return f"dry-run-{chart_data.get('id', 'chart-id')}"
 
-        # Build payload based on schema
-        payload = {
-            "title": chart_title,
-            "chart_type": chart_data.get("chart_type", "line"),
-            "series": chart_data.get("series", []),
-            "description": chart_data.get("description"),
-            "index": chart_data.get("index"),
-            "metadata": chart_data.get("metadata"),
-            "section_id": chart_data.get("section_id"),
-            "common_filters": chart_data.get("common_filters")
-        }
+        chart_copy = self._enrich_chart(chart_data)
+        if chart_data.get("_source_section_title") and not chart_copy.get("_source_section_title"):
+            chart_copy["_source_section_title"] = chart_data.get("_source_section_title")
+        if chart_data.get("_source_section_description") and not chart_copy.get("_source_section_description"):
+            chart_copy["_source_section_description"] = chart_data.get("_source_section_description")
 
-        # Remove None values
-        payload = {k: v for k, v in payload.items() if v is not None}
-
-        # If we have a source section title, ensure it exists in destination
-        source_section_title = chart_data.get("_source_section_title")
-        source_section_desc = chart_data.get("_source_section_description")
-
-        if source_section_title:
-            dest_section_id = self._ensure_dest_section(source_section_title, source_section_desc)
-            if dest_section_id:
-                # payload["section_id"] = dest_section_id
-                # NOTE: We previously tried setting section_id directly, but if we have a valid
-                # section ID from the ensure step, we should use it.
-                payload["section_id"] = dest_section_id
+        payload, downgraded_to_unsectioned = self._build_chart_payload(chart_copy)
+        source_section_title = chart_copy.get("_source_section_title")
+        self.checkpoint_item(
+            item_id,
+            stage="ready_to_write",
+            strategy=self._section_strategy or "sectioned",
+            metadata={"source_chart_id": chart_data.get("id")},
+        )
 
         # Validate required fields
         if not payload["series"]:
-            self.log(f"Chart '{chart_title}' has no series, skipping", "warning")
+            export_path = self._export_chart_manual_apply(
+                chart_copy,
+                reason="missing_required_series",
+                payload=payload,
+                analysis={"missing_fields": ["series"]},
+            )
+            issue = self.record_issue(
+                "source_data_gap",
+                "missing_required_series",
+                f"Chart '{chart_title}' is missing series data after enrichment",
+                item_id=item_id,
+                next_action="Review the exported chart payload and missing fields, then re-run `langsmith-migrator resume`.",
+                evidence={"title": chart_title},
+                export_path=export_path,
+            )
+            if issue:
+                self.queue_remediation(
+                    issue_id=issue.id,
+                    item_id=item_id,
+                    next_action=issue.next_action or "Review chart payload.",
+                    export_path=export_path,
+                    command="langsmith-migrator resume",
+                )
+            self.mark_exported(
+                item_id,
+                "missing_required_series",
+                next_action="Review the exported chart payload and missing fields, then run `langsmith-migrator resume`.",
+                export_path=export_path,
+                evidence={"title": chart_title},
+            )
             return None
 
         # Check if chart already exists
@@ -338,21 +528,104 @@ class ChartMigrator(BaseMigrator):
         if existing_id:
             if self.config.migration.skip_existing:
                 self.log(f"Chart '{chart_title}' already exists, skipping", "warning")
+                self.mark_migrated(
+                    item_id,
+                    outcome_code="chart_already_exists",
+                    evidence={"chart_id": existing_id},
+                )
                 return existing_id
             else:
                 self.log(f"Chart '{chart_title}' exists, updating...", "info")
-                success = self.update_chart(existing_id, chart_data)
-                return existing_id if success else None
+                self.checkpoint_item(item_id, stage="update_chart")
+                success = self.update_chart(existing_id, chart_copy)
+                if not success:
+                    issue = self.record_issue(
+                        "transient",
+                        "chart_update_failed",
+                        f"Chart '{chart_title}' could not be updated on the destination instance",
+                        item_id=item_id,
+                        next_action="Review the chart payload and retry with `langsmith-migrator resume`.",
+                        evidence={"chart_id": existing_id},
+                    )
+                    if issue:
+                        self.queue_remediation(
+                            issue_id=issue.id,
+                            item_id=item_id,
+                            next_action=issue.next_action or "Retry chart update.",
+                            command="langsmith-migrator resume",
+                        )
+                    self.mark_blocked(
+                        item_id,
+                        "chart_update_failed",
+                        next_action="Review the chart payload and retry with `langsmith-migrator resume`.",
+                        evidence={"chart_id": existing_id},
+                    )
+                    return None
+                verified, mismatches = self._verify_chart(existing_id, payload)
+                if verified:
+                    if downgraded_to_unsectioned:
+                        self.mark_degraded(
+                            item_id,
+                            "chart_updated_without_section",
+                            next_action="Review chart placement if section grouping is required.",
+                            evidence={"chart_id": existing_id},
+                        )
+                    else:
+                        self.mark_migrated(
+                            item_id,
+                            outcome_code="chart_updated",
+                            evidence={"chart_id": existing_id},
+                        )
+                else:
+                    issue = self.record_issue(
+                        "post_write_verification",
+                        "chart_update_verification_failed",
+                        f"Chart '{chart_title}' did not match the requested payload after update",
+                        item_id=item_id,
+                        next_action="Review the chart mismatches in the remediation bundle.",
+                        evidence=mismatches,
+                    )
+                    if issue:
+                        self.queue_remediation(
+                            issue_id=issue.id,
+                            item_id=item_id,
+                            next_action=issue.next_action or "Review chart mismatches.",
+                            command="langsmith-migrator resume",
+                        )
+                    self.mark_degraded(
+                        item_id,
+                        "chart_update_verification_mismatch",
+                        next_action="Review chart field mismatches in the remediation bundle.",
+                        evidence=mismatches,
+                    )
+                return existing_id
 
         try:
+            self.checkpoint_item(item_id, stage="create_chart")
             # Try to create
             try:
                 response = self.dest.post("/charts/create", payload)
+                self.record_capability(
+                    "charts",
+                    "section_scoped_create",
+                    supported="section_id" in payload,
+                    detail="ok",
+                    probe="POST /charts/create",
+                )
             except APIError as e:
                 # If failed and we have section_id, try removing it
                 if "section_id" in payload:
                     self.log(f"First attempt failed ({e}), retrying without section_id", "info")
+                    self.record_capability(
+                        "charts",
+                        "section_scoped_create",
+                        supported=False,
+                        detail=str(e),
+                        probe="POST /charts/create",
+                    )
+                    self._section_strategy = "unsectioned"
                     del payload["section_id"]
+                    downgraded_to_unsectioned = True
                     response = self.dest.post("/charts/create", payload)
                 else:
                     raise e
@@ -364,15 +637,124 @@ class ChartMigrator(BaseMigrator):
                 chart_id = None
 
             if chart_id:
+                verified, mismatches = self._verify_chart(str(chart_id), payload)
+                if verified:
+                    if downgraded_to_unsectioned or (source_section_title and "section_id" not in payload):
+                        self.mark_degraded(
+                            item_id,
+                            "chart_created_without_section",
+                            next_action="Review the chart placement if section grouping is required.",
+                            evidence={"chart_id": chart_id},
+                        )
+                    else:
+                        self.mark_migrated(
+                            item_id,
+                            outcome_code="chart_migrated",
+                            evidence={"chart_id": chart_id},
+                        )
+                else:
+                    issue = self.record_issue(
+                        "post_write_verification",
+                        "chart_create_verification_failed",
+                        f"Chart '{chart_title}' did not match the requested payload after creation",
+                        item_id=item_id,
+                        next_action="Review the chart mismatches in the remediation bundle.",
+                        evidence=mismatches,
+                    )
+                    if issue:
+                        self.queue_remediation(
+                            issue_id=issue.id,
+                            item_id=item_id,
+                            next_action=issue.next_action or "Review chart mismatches.",
+                            command="langsmith-migrator resume",
+                        )
+                    self.mark_degraded(
+                        item_id,
+                        "chart_create_verification_mismatch",
+                        next_action="Review chart field mismatches in the remediation bundle.",
+                        evidence=mismatches,
+                    )
                 return str(chart_id)
 
+            issue = self.record_issue(
+                "post_write_verification",
+                "chart_create_missing_id",
+                f"Chart '{chart_title}' create response did not include a destination ID",
+                item_id=item_id,
+                next_action="Review the destination chart response and retry with `langsmith-migrator resume`.",
+                evidence={"response_type": type(response).__name__},
+            )
+            if issue:
+                self.queue_remediation(
+                    issue_id=issue.id,
+                    item_id=item_id,
+                    next_action=issue.next_action or "Review chart create response.",
+                    command="langsmith-migrator resume",
+                )
+            self.mark_blocked(
+                item_id,
+                "chart_create_missing_id",
+                next_action="Review the destination chart response and retry with `langsmith-migrator resume`.",
+                evidence={"response_type": type(response).__name__},
+            )
             return None
 
         except APIError as e:
             self.log(f"Failed to create chart '{chart_title}': {e}", "error")
+            export_path = self._export_chart_manual_apply(
+                chart_copy,
+                reason="chart_create_failed",
+                payload=payload,
+                analysis={"error": str(e)},
+            )
+            issue = self.record_issue(
+                "capability",
+                "chart_create_failed",
+                f"Chart '{chart_title}' could not be created on the destination instance",
+                item_id=item_id,
+                next_action="Review the exported chart payload and destination chart capabilities, then re-run `langsmith-migrator resume`.",
+                evidence={"error": str(e)},
+                export_path=export_path,
+            )
+            if issue:
+                self.queue_remediation(
+                    issue_id=issue.id,
+                    item_id=item_id,
+                    next_action=issue.next_action or "Review exported chart payload.",
+                    export_path=export_path,
+                    command="langsmith-migrator resume",
+                )
+            self.mark_exported(
+                item_id,
+                "chart_create_failed",
+                next_action="Review the exported chart payload, then run `langsmith-migrator resume`.",
+                export_path=export_path,
+                evidence={"error": str(e)},
+            )
             return None
         except Exception as e:
             self.log(f"Unexpected error creating chart '{chart_title}': {e}", "error")
+            issue = self.record_issue(
+                "transient",
+                "chart_migration_failed",
+                f"Chart '{chart_title}' failed during migration",
+                item_id=item_id,
+                next_action="Re-run `langsmith-migrator resume` after reviewing the error.",
+                evidence={"error": str(e)},
+            )
+            if issue:
+                self.queue_remediation(
+                    issue_id=issue.id,
+                    item_id=item_id,
+                    next_action=issue.next_action or "Retry chart migration.",
+                    command="langsmith-migrator resume",
+                )
+            self.mark_blocked(
+                item_id,
+                "chart_migration_failed",
+                next_action="Re-run `langsmith-migrator resume` after reviewing the error.",
+                evidence={"error": str(e)},
+            )
             return None
 
     def migrate_chart(self, chart: Dict[str, Any], dest_session_id: Optional[str] = None) -> Optional[str]:
@@ -388,9 +770,48 @@ class ChartMigrator(BaseMigrator):
         """
         chart_title = chart.get("title") or chart.get("name") or "Untitled"
         chart_id = chart.get("id")
+        item_id = self._chart_item_id(chart)
+        self.ensure_item(
+            item_id,
+            "chart",
+            chart_title,
+            str(chart_id or chart_title),
+            stage="map_dependencies",
+            strategy=self._section_strategy or "sectioned",
+            metadata={"dest_session_id": dest_session_id},
+        )
 
         if not chart_id:
             self.log(f"Chart '{chart_title}' missing ID, skipping", "warning")
+            export_path = self._export_chart_manual_apply(
+                chart,
+                reason="missing_chart_id",
+                analysis={"missing_fields": ["id"]},
+            )
+            issue = self.record_issue(
+                "source_data_gap",
+                "missing_chart_id",
+                f"Chart '{chart_title}' is missing its source identifier",
+                item_id=item_id,
+                next_action="Review the exported chart payload and migrate it manually before resuming.",
+                evidence={"title": chart_title},
+                export_path=export_path,
+            )
+            if issue:
+                self.queue_remediation(
+                    issue_id=issue.id,
+                    item_id=item_id,
+                    next_action=issue.next_action or "Review exported chart payload.",
+                    export_path=export_path,
+                    command="langsmith-migrator resume",
+                )
+            self.mark_exported(
+                item_id,
+                "missing_chart_id",
+                next_action="Review the exported chart payload and migrate it manually before resuming.",
+                export_path=export_path,
+                evidence={"title": chart_title},
+            )
             return None
 
         # Deep copy
@@ -399,6 +820,11 @@ class ChartMigrator(BaseMigrator):
 
         # Map IDs within chart config
         self._map_ids_in_chart(chart_copy, dest_session_id)
+        self.checkpoint_item(
+            item_id,
+            stage="mapped_dependencies",
+            metadata={"dest_session_id": dest_session_id},
+        )
 
         # Create in destination
         try:
@@ -625,22 +1051,39 @@ class ChartMigrator(BaseMigrator):
 
         self._project_id_map = {}
         try:
-            # Get all projects from source
-            source_projects = {}  # name -> id
+            source_records: List[Dict[str, Any]] = []
             for project in self.source.get_paginated("/sessions", page_size=100):
-                if isinstance(project, dict) and 'name' in project and 'id' in project:
-                    source_projects[project['name']] = project['id']
+                if isinstance(project, dict):
+                    source_records.append(project)
 
-            # Get all projects from destination
-            dest_projects = {}  # name -> id
+            dest_records: List[Dict[str, Any]] = []
             for project in self.dest.get_paginated("/sessions", page_size=100):
-                if isinstance(project, dict) and 'name' in project and 'id' in project:
-                    dest_projects[project['name']] = project['id']
+                if isinstance(project, dict):
+                    dest_records.append(project)
 
-            # Build mapping by matching names
-            for name, source_id in source_projects.items():
-                if name in dest_projects:
-                    self._project_id_map[source_id] = dest_projects[name]
+            _, source_duplicates = unique_name_map(source_records)
+            dest_unique, dest_duplicates = unique_name_map(dest_records)
+
+            for project in source_records:
+                source_id = project["id"]
+                project_name = project["name"]
+
+                if self.state and self.state.get_mapped_id("project", source_id):
+                    mapped_id = self.state.get_mapped_id("project", source_id)
+                    self._project_id_map[source_id] = mapped_id
+                    self.record_provenance(f"project:{source_id}", "state_mapping")
+                    continue
+
+                if project_name in source_duplicates or project_name in dest_duplicates:
+                    self.log(
+                        f"Project '{project_name}' is duplicated; skipping automatic exact-name mapping",
+                        "warning",
+                    )
+                    continue
+
+                if project_name in dest_unique:
+                    self._project_id_map[source_id] = dest_unique[project_name]
+                    self.record_provenance(f"project:{source_id}", "exact_name_match")
         except Exception as e:
             self.log(f"Failed to build project mapping: {e}", "error")
             self._project_id_map = {}
@@ -656,22 +1099,39 @@ class ChartMigrator(BaseMigrator):
 
         self._dataset_id_map = {}
         try:
-            # Get all datasets from source
-            source_datasets = {}  # name -> id
+            source_records: List[Dict[str, Any]] = []
             for dataset in self.source.get_paginated("/datasets", page_size=100):
-                if isinstance(dataset, dict) and 'name' in dataset and 'id' in dataset:
-                    source_datasets[dataset['name']] = dataset['id']
+                if isinstance(dataset, dict):
+                    source_records.append(dataset)
 
-            # Get all datasets from destination
-            dest_datasets = {}  # name -> id
+            dest_records: List[Dict[str, Any]] = []
             for dataset in self.dest.get_paginated("/datasets", page_size=100):
-                if isinstance(dataset, dict) and 'name' in dataset and 'id' in dataset:
-                    dest_datasets[dataset['name']] = dataset['id']
+                if isinstance(dataset, dict):
+                    dest_records.append(dataset)
 
-            # Build mapping by matching names
-            for name, source_id in source_datasets.items():
-                if name in dest_datasets:
-                    self._dataset_id_map[source_id] = dest_datasets[name]
+            _, source_duplicates = unique_name_map(source_records)
+            dest_unique, dest_duplicates = unique_name_map(dest_records)
+
+            for dataset in source_records:
+                source_id = dataset["id"]
+                dataset_name = dataset["name"]
+
+                if self.state and self.state.get_mapped_id("dataset", source_id):
+                    mapped_id = self.state.get_mapped_id("dataset", source_id)
+                    self._dataset_id_map[source_id] = mapped_id
+                    self.record_provenance(f"dataset:{source_id}", "state_mapping")
+                    continue
+
+                if dataset_name in source_duplicates or dataset_name in dest_duplicates:
+                    self.log(
+                        f"Dataset '{dataset_name}' is duplicated; skipping automatic exact-name mapping",
+                        "warning",
+                    )
+                    continue
+
+                if dataset_name in dest_unique:
+                    self._dataset_id_map[source_id] = dest_unique[dataset_name]
+                    self.record_provenance(f"dataset:{source_id}", "exact_name_match")
         except Exception as e:
             self.log(f"Failed to build dataset mapping: {e}", "error")
             self._dataset_id_map = {}

--- a/langsmith_migrator/core/migrators/experiment.py
+++ b/langsmith_migrator/core/migrators/experiment.py
@@ -10,6 +10,16 @@ from .base import BaseMigrator
 class ExperimentMigrator(BaseMigrator):
     """Handles experiment and run migration."""
 
+    _RUN_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_URL, "langsmith-data-migration-tool/runs")
+
+    def _deterministic_run_id(self, source_run_id: str) -> str:
+        """Generate a stable destination run ID for idempotent replay."""
+        return str(uuid.uuid5(self._RUN_NAMESPACE, source_run_id))
+
+    def _experiment_item_id(self, experiment_id: str) -> str:
+        """Return the tracked item id for an experiment."""
+        return f"experiment_{experiment_id}"
+
     def _regenerate_dotted_order(
         self,
         dotted_order: Optional[str],
@@ -57,7 +67,7 @@ class ExperimentMigrator(BaseMigrator):
                 new_parts.append(timestamp + new_run_id)
             else:
                 # Map the UUID to its new value for parent chain
-                new_uuid = id_mapping.get(old_uuid, old_uuid)
+                new_uuid = id_mapping.get(old_uuid, self._deterministic_run_id(old_uuid))
                 new_parts.append(timestamp + new_uuid)
 
         return ".".join(new_parts)
@@ -316,7 +326,7 @@ class ExperimentMigrator(BaseMigrator):
         self,
         experiment_ids: List[str],
         id_mappings: Dict[str, Dict[str, str]]
-    ) -> Tuple[int, Dict[str, str]]:
+    ) -> Tuple[int, Dict[str, str], int]:
         """
         Migrate runs for experiments using streaming.
 
@@ -325,17 +335,16 @@ class ExperimentMigrator(BaseMigrator):
             id_mappings: Dict containing "experiments" and "examples" mappings
 
         Returns:
-            Tuple of (total_runs_migrated, run_id_mapping)
+            Tuple of (total_runs_migrated, run_id_mapping, failed_run_count)
             where run_id_mapping maps source run IDs to destination run IDs
         """
         run_id_mapping: Dict[str, str] = {}
-        # Track trace_id mappings separately (trace_id is the root run's ID)
-        # All runs in the same trace share the same trace_id
-        trace_id_mapping: Dict[str, str] = {}
+        if self.state:
+            run_id_mapping.update(self.state.id_mappings.get("run", {}))
 
         if self.config.migration.dry_run:
             self.log("[DRY RUN] Would migrate runs")
-            return 0, run_id_mapping
+            return 0, run_id_mapping, 0
 
         experiment_mapping = id_mappings.get("experiments", {})
         example_mapping = id_mappings.get("examples", {})
@@ -345,17 +354,34 @@ class ExperimentMigrator(BaseMigrator):
 
         total_runs = 0
         total_skipped = 0
-        batch = []
+        total_failed = 0
 
         # Query runs for EACH experiment separately
         # The LangSmith /runs/query API only processes the first session ID when given a list
         for exp_idx, experiment_id in enumerate(experiment_ids, 1):
+            experiment_item_id = self._experiment_item_id(experiment_id)
+            experiment_item = self.state.get_item(experiment_item_id) if self.state else None
+            start_cursor = experiment_item.metadata.get("run_cursor") if experiment_item else None
+            pending_run_mapping: Dict[str, str] = {}
+            batch: List[Dict[str, Any]] = []
+            experiment_runs_created = 0
+            experiment_failed_runs = 0
+
             self.log(f"Fetching runs for experiment {exp_idx}/{len(experiment_ids)}: {experiment_id}", "info")
 
             payload = {
                 "session": [experiment_id],  # Single ID in a list (API requires list format)
                 "skip_pagination": False
             }
+            if start_cursor:
+                payload["cursor"] = start_cursor
+                self.log(f"Resuming runs for experiment {experiment_id} from cursor {start_cursor}", "info")
+            if experiment_item:
+                self.checkpoint_item(
+                    experiment_item_id,
+                    stage="migrate_runs",
+                    metadata={"run_cursor": start_cursor},
+                )
 
             page_num = 0
             while True:
@@ -385,6 +411,8 @@ class ExperimentMigrator(BaseMigrator):
                 for run in runs:
                     source_session_id = run.get("session_id")
                     source_run_id = run.get("id")
+                    if not source_run_id:
+                        continue
 
                     # Map IDs
                     if source_session_id not in experiment_mapping:
@@ -395,51 +423,35 @@ class ExperimentMigrator(BaseMigrator):
                         total_skipped += 1
                         continue
 
+                    if source_run_id in run_id_mapping:
+                        total_skipped += 1
+                        continue
+
                     dest_session_id = experiment_mapping[source_session_id]
 
                     # Map parent_run_id if present and already migrated
-                    # If parent not mapped yet, omit the field entirely to avoid 422 errors
                     parent_run_id = run.get("parent_run_id")
-                    mapped_parent_id = None
-                    if parent_run_id and parent_run_id in run_id_mapping:
-                        mapped_parent_id = run_id_mapping[parent_run_id]
+                    mapped_parent_id = (
+                        self._deterministic_run_id(parent_run_id) if parent_run_id else None
+                    )
 
                     # Map reference_example_id if present
                     source_example_id = run.get("reference_example_id")
                     mapped_example_id = example_mapping.get(source_example_id) if source_example_id else None
 
-                    # Generate a new UUID for the destination run to avoid conflicts
-                    new_run_id = str(uuid.uuid4())
-
-                    # Handle trace_id mapping
-                    # trace_id identifies the root run of a trace - all runs in the same trace share it
-                    # API requirement: For root runs, trace_id MUST equal run_id
-                    # For child runs, trace_id is the root run's ID (shared across the trace)
+                    # Deterministic IDs make interrupted batches safe to replay.
+                    new_run_id = self._deterministic_run_id(source_run_id)
                     source_trace_id = run.get("trace_id")
+                    new_trace_id = (
+                        self._deterministic_run_id(source_trace_id)
+                        if source_trace_id
+                        else new_run_id
+                    )
+                    pending_run_mapping[source_run_id] = new_run_id
 
-                    if not parent_run_id:
-                        # Root run: trace_id = run_id (API requirement)
-                        # Store mapping so children can look up the new trace_id
-                        new_trace_id = new_run_id
-                        if source_trace_id:
-                            trace_id_mapping[source_trace_id] = new_run_id
-                    else:
-                        # Child run: use mapped trace_id from root
-                        if source_trace_id and source_trace_id in trace_id_mapping:
-                            new_trace_id = trace_id_mapping[source_trace_id]
-                        else:
-                            # Fallback: use run's own ID (shouldn't happen with sorted runs)
-                            new_trace_id = new_run_id
-
-                    # Store the run ID mapping before regenerating dotted_order
-                    run_id_mapping[source_run_id] = new_run_id
-
-                    # Build combined mapping for dotted_order regeneration
-                    # (includes both run IDs and trace IDs)
-                    combined_mapping = {**run_id_mapping, **trace_id_mapping}
+                    combined_mapping = {**run_id_mapping, **pending_run_mapping}
 
                     # Regenerate dotted_order with new IDs
-                    # Pass new_run_id to ensure the last part always matches the run's ID
                     new_dotted_order = self._regenerate_dotted_order(
                         run.get("dotted_order"),
                         combined_mapping,
@@ -464,6 +476,7 @@ class ExperimentMigrator(BaseMigrator):
                         "dotted_order": new_dotted_order,
                         "session_id": dest_session_id,
                         "reference_example_id": mapped_example_id,
+                        "_source_run_id": source_run_id,
                     }
 
                     # Remove None values to avoid API validation errors (422)
@@ -473,37 +486,115 @@ class ExperimentMigrator(BaseMigrator):
 
                     # Process batch
                     if len(batch) >= self.config.migration.batch_size:
-                        success, created = self._create_runs_batch(batch)
-                        total_runs += created
-                        if success:
-                            self.log(f"Created batch of {created} runs (total: {total_runs})", "info")
-                        else:
-                            self.log(f"Failed to create batch of {len(batch)} runs", "error")
+                        created_mapping, failed_runs = self._create_runs_batch(batch)
+                        total_runs += len(created_mapping)
+                        total_failed += len(failed_runs)
+                        experiment_runs_created += len(created_mapping)
+                        experiment_failed_runs += len(failed_runs)
+                        if created_mapping:
+                            run_id_mapping.update(created_mapping)
+                            if self.state:
+                                for old_id, new_id in created_mapping.items():
+                                    self.state.set_mapped_id("run", old_id, new_id)
+                                self.persist_state()
+                            self.log(
+                                f"Created batch of {len(created_mapping)} runs (total: {total_runs})",
+                                "info",
+                            )
+                        if failed_runs:
+                            failed_ids = {entry["source_run_id"] for entry in failed_runs}
+                            for failed_id in failed_ids:
+                                pending_run_mapping.pop(failed_id, None)
+                            self.log(f"Failed to create {len(failed_runs)} run(s) in batch", "error")
+                            if experiment_item:
+                                issue = self.record_issue(
+                                    "transient",
+                                    "run_batch_failed",
+                                    f"Run batch creation failed for experiment {experiment_id}",
+                                    item_id=experiment_item_id,
+                                    next_action="Re-run `langsmith-migrator resume` to replay the failed runs.",
+                                    evidence={"failed_runs": failed_runs[:10], "failed_count": len(failed_runs)},
+                                )
+                                if issue:
+                                    self.queue_remediation(
+                                        issue_id=issue.id,
+                                        next_action=issue.next_action or "Resume experiment runs.",
+                                        item_id=experiment_item_id,
+                                        command="langsmith-migrator resume",
+                                    )
+                        for created_id in created_mapping:
+                            pending_run_mapping.pop(created_id, None)
                         batch.clear()
 
                 # Check for next page
                 cursors = response.get("cursors")
                 next_cursor = cursors.get("next") if cursors else None
 
+                if experiment_item:
+                    self.checkpoint_item(
+                        experiment_item_id,
+                        stage="migrate_runs",
+                        metadata={
+                            "run_cursor": next_cursor,
+                            "run_failures": experiment_failed_runs,
+                            "runs_migrated": experiment_runs_created,
+                        },
+                    )
                 if not next_cursor:
                     break
 
                 payload["cursor"] = next_cursor
                 self.log(f"Fetching next page with cursor: {next_cursor}", "info")
 
-        # Process remaining runs
-        if batch:
-            success, created = self._create_runs_batch(batch)
-            total_runs += created
-            if success:
-                self.log(f"Created final batch of {created} runs", "info")
-            else:
-                self.log(f"Failed to create final batch of {len(batch)} runs", "error")
+            if batch:
+                created_mapping, failed_runs = self._create_runs_batch(batch)
+                total_runs += len(created_mapping)
+                total_failed += len(failed_runs)
+                experiment_runs_created += len(created_mapping)
+                experiment_failed_runs += len(failed_runs)
+                if created_mapping:
+                    run_id_mapping.update(created_mapping)
+                    if self.state:
+                        for old_id, new_id in created_mapping.items():
+                            self.state.set_mapped_id("run", old_id, new_id)
+                        self.persist_state()
+                    self.log(f"Created final batch of {len(created_mapping)} runs", "info")
+                if failed_runs:
+                    self.log(f"Failed to create {len(failed_runs)} run(s) in final batch", "error")
+                    if experiment_item:
+                        issue = self.record_issue(
+                            "transient",
+                            "run_batch_failed",
+                            f"Final run batch creation failed for experiment {experiment_id}",
+                            item_id=experiment_item_id,
+                            next_action="Re-run `langsmith-migrator resume` to replay the failed runs.",
+                            evidence={"failed_runs": failed_runs[:10], "failed_count": len(failed_runs)},
+                        )
+                        if issue:
+                            self.queue_remediation(
+                                issue_id=issue.id,
+                                next_action=issue.next_action or "Resume experiment runs.",
+                                item_id=experiment_item_id,
+                                command="langsmith-migrator resume",
+                            )
+                if experiment_item:
+                    next_stage = "migrate_feedback" if experiment_failed_runs == 0 else "migrate_runs"
+                    self.checkpoint_item(
+                        experiment_item_id,
+                        stage=next_stage,
+                        metadata={
+                            "run_cursor": None,
+                            "run_failures": experiment_failed_runs,
+                            "runs_migrated": experiment_runs_created,
+                        },
+                    )
 
         self.log(f"Run migration complete: {total_runs} migrated, {total_skipped} skipped", "success")
-        return total_runs, run_id_mapping
+        return total_runs, run_id_mapping, total_failed
 
-    def _create_runs_batch(self, runs: List[Dict[str, Any]]) -> tuple[bool, int]:
+    def _create_runs_batch(
+        self, runs: List[Dict[str, Any]]
+    ) -> tuple[Dict[str, str], List[Dict[str, str]]]:
         """
         Create a batch of runs.
 
@@ -511,43 +602,52 @@ class ExperimentMigrator(BaseMigrator):
             runs: List of run dictionaries to create
 
         Returns:
-            Tuple of (success, count_created) - success is True if at least some runs were created
+            Tuple of (created_mapping, failed_runs).
         """
         if not runs:
-            return True, 0
+            return {}, []
 
-        payload = {"post": runs}
-        self.log(f"Creating batch of {len(runs)} runs via /runs/batch", "info")
+        created_mapping: Dict[str, str] = {}
+        failed_runs: List[Dict[str, str]] = []
 
-        try:
-            response = self.dest.post("/runs/batch", payload)
+        def strip_internal_fields(batch: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+            stripped = []
+            for run in batch:
+                stripped.append({k: v for k, v in run.items() if not k.startswith("_")})
+            return stripped
 
-            # Validate response
-            if isinstance(response, dict):
-                # The /runs/batch endpoint typically returns summary info
-                # Check for any error indicators
-                if response.get("errors"):
-                    error_count = len(response["errors"])
-                    self.log(f"Batch creation had {error_count} error(s)", "warning")
-                    for error in response["errors"][:3]:
-                        self.log(f"  Error: {error}", "warning")
-                    return error_count < len(runs), len(runs) - error_count
+        def post_recursive(batch: List[Dict[str, Any]]) -> None:
+            payload = {"post": strip_internal_fields(batch)}
+            self.log(f"Creating batch of {len(batch)} runs via /runs/batch", "info")
+            try:
+                response = self.dest.post("/runs/batch", payload)
+                if isinstance(response, dict) and response.get("errors"):
+                    raise ValueError(f"Batch creation had {len(response['errors'])} error(s)")
 
-                if self.config.migration.verbose:
-                    self.log(f"Batch creation response: {response}", "info")
-                return True, len(runs)
+                for run in batch:
+                    source_run_id = run.get("_source_run_id")
+                    if source_run_id:
+                        created_mapping[source_run_id] = run["id"]
+            except Exception as e:
+                if len(batch) == 1:
+                    source_run_id = batch[0].get("_source_run_id", "unknown")
+                    error_text = str(e)
+                    if "409" in error_text or "Conflict" in error_text:
+                        created_mapping[source_run_id] = batch[0]["id"]
+                        self.log(
+                            f"Run {source_run_id} already exists with deterministic ID; treating as replay success",
+                            "warning",
+                        )
+                        return
 
-            elif isinstance(response, list):
-                # Some versions return list of created runs
-                return True, len(response)
-            else:
-                self.log(f"Unexpected response type from /runs/batch: {type(response)}", "warning")
-                return True, len(runs)  # Assume success if no error raised
+                    failed_runs.append(
+                        {"source_run_id": source_run_id, "error": error_text}
+                    )
+                    return
 
-        except Exception as e:
-            self.log(f"Error creating runs batch: {e}", "error")
-            # Log the first run for debugging
-            if runs and self.config.migration.verbose:
-                import json
-                self.log(f"First run in failed batch: {json.dumps(runs[0], default=str)[:500]}", "error")
-            return False, 0
+                midpoint = len(batch) // 2
+                post_recursive(batch[:midpoint])
+                post_recursive(batch[midpoint:])
+
+        post_recursive(runs)
+        return created_mapping, failed_runs

--- a/langsmith_migrator/core/migrators/feedback.py
+++ b/langsmith_migrator/core/migrators/feedback.py
@@ -1,5 +1,7 @@
 """Feedback migration logic."""
 
+import hashlib
+import json
 from typing import Dict, List, Any, Tuple
 
 from .base import BaseMigrator
@@ -7,6 +9,25 @@ from .base import BaseMigrator
 
 class FeedbackMigrator(BaseMigrator):
     """Handles feedback migration for experiments."""
+
+    def _feedback_fingerprint(
+        self,
+        source_experiment_id: str,
+        feedback: Dict[str, Any],
+    ) -> str:
+        """Create a stable provenance fingerprint for feedback replay."""
+        payload = {
+            "source_experiment_id": source_experiment_id,
+            "source_feedback_id": feedback.get("id"),
+            "run_id": feedback.get("run_id"),
+            "key": feedback.get("key"),
+            "score": feedback.get("score"),
+            "value": feedback.get("value"),
+            "comment": feedback.get("comment"),
+            "correction": feedback.get("correction"),
+        }
+        serialized = json.dumps(payload, sort_keys=True, default=str)
+        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
     def list_feedback_for_session(self, session_id: str, limit: int = 100) -> List[Dict[str, Any]]:
         """
@@ -119,13 +140,14 @@ class FeedbackMigrator(BaseMigrator):
             return True
 
         try:
-            self.dest.post("/feedback", feedback)
+            payload = {k: v for k, v in feedback.items() if not k.startswith("_")}
+            self.dest.post("/feedback", payload)
             return True
         except Exception as e:
             self.log(f"Failed to create feedback '{feedback.get('key')}': {e}", "warning")
             return False
 
-    def create_feedback_batch(self, feedbacks: List[Dict[str, Any]]) -> int:
+    def create_feedback_batch(self, feedbacks: List[Dict[str, Any]]) -> Tuple[int, List[Dict[str, Any]]]:
         """
         Create feedback records in destination.
 
@@ -136,18 +158,20 @@ class FeedbackMigrator(BaseMigrator):
             feedbacks: List of feedback records to create
 
         Returns:
-            Number of successfully created feedback records
+            Tuple of (number_created, created_feedbacks)
         """
         if self.config.migration.dry_run:
             self.log(f"[DRY RUN] Would create {len(feedbacks)} feedback records", "info")
-            return len(feedbacks)
+            return len(feedbacks), list(feedbacks)
 
         created = 0
+        created_feedbacks: List[Dict[str, Any]] = []
         for feedback in feedbacks:
             if self.create_feedback(feedback):
                 created += 1
+                created_feedbacks.append(feedback)
 
-        return created
+        return created, created_feedbacks
 
     def migrate_feedback_for_experiments(
         self,
@@ -173,6 +197,9 @@ class FeedbackMigrator(BaseMigrator):
 
         for source_exp_id, dest_exp_id in experiment_id_mapping.items():
             self.log(f"Fetching feedback for experiment {source_exp_id}...", "info")
+            experiment_item_id = f"experiment_{source_exp_id}"
+            if self.state:
+                self.checkpoint_item(experiment_item_id, stage="migrate_feedback")
 
             # Fetch feedback for this experiment session
             feedbacks = self.list_feedback_for_session(source_exp_id)
@@ -189,6 +216,14 @@ class FeedbackMigrator(BaseMigrator):
             skipped = 0
 
             for fb in feedbacks:
+                fingerprint = self._feedback_fingerprint(source_exp_id, fb)
+                if self.state and self.state.get_mapped_id("feedback_fingerprint", fingerprint):
+                    self.log(
+                        f"Skipping feedback '{fb.get('key')}' - already replayed in a prior attempt",
+                        "warning",
+                    )
+                    continue
+
                 # Map run_id to destination
                 source_run_id = fb.get("run_id")
 
@@ -223,6 +258,7 @@ class FeedbackMigrator(BaseMigrator):
                 if fb.get("feedback_source"):
                     migrated_fb["feedback_source"] = fb["feedback_source"]
 
+                migrated_fb["_fingerprint"] = fingerprint
                 migrated_feedbacks.append(migrated_fb)
 
             if skipped > 0:
@@ -230,11 +266,48 @@ class FeedbackMigrator(BaseMigrator):
 
             # Create feedback in destination
             if migrated_feedbacks:
-                created = self.create_feedback_batch(migrated_feedbacks)
+                created, created_feedbacks = self.create_feedback_batch(migrated_feedbacks)
                 total_migrated += created
                 self.log(
                     f"Migrated {created}/{len(migrated_feedbacks)} feedback for experiment {source_exp_id}",
                     "success"
                 )
+                if self.state:
+                    for migrated_fb in created_feedbacks:
+                        fingerprint = migrated_fb.get("_fingerprint")
+                        if fingerprint:
+                            self.state.set_mapped_id(
+                                "feedback_fingerprint", fingerprint, fingerprint
+                            )
+                    if created == len(migrated_feedbacks):
+                        self.checkpoint_item(
+                            experiment_item_id,
+                            stage="completed",
+                            metadata={
+                                "feedback_found": len(feedbacks),
+                                "feedback_migrated": created,
+                                "feedback_verified": True,
+                            },
+                        )
+                    elif created < len(migrated_feedbacks):
+                        issue = self.record_issue(
+                            "transient",
+                            "feedback_partial_replay",
+                            f"Some feedback could not be replayed for experiment {source_exp_id}",
+                            item_id=experiment_item_id,
+                            next_action="Re-run `langsmith-migrator resume` to retry feedback creation.",
+                            evidence={
+                                "feedback_found": len(feedbacks),
+                                "feedback_migrated": created,
+                            },
+                        )
+                        if issue:
+                            self.queue_remediation(
+                                issue_id=issue.id,
+                                next_action=issue.next_action or "Retry feedback replay.",
+                                item_id=experiment_item_id,
+                                command="langsmith-migrator resume",
+                            )
+                    self.persist_state()
 
         return total_found, total_migrated

--- a/langsmith_migrator/core/migrators/orchestrator.py
+++ b/langsmith_migrator/core/migrators/orchestrator.py
@@ -7,7 +7,13 @@ from rich.console import Console
 from rich.progress import Progress
 
 from ..api_client import EnhancedAPIClient
-from ...utils.state import MigrationItem, MigrationStatus, StateManager
+from ...utils.state import (
+    MigrationItem,
+    MigrationStatus,
+    ResolutionOutcome,
+    StateManager,
+    VerificationState,
+)
 from .dataset import DatasetMigrator
 from .experiment import ExperimentMigrator
 from .feedback import FeedbackMigrator
@@ -48,6 +54,7 @@ class MigrationOrchestrator:
 
         # Initialize state
         self.state = None
+        self.config.state_manager = state_manager
 
     def _prepare_base_url(self, base_url: str) -> str:
         """Prepare base URL for API client."""
@@ -80,6 +87,23 @@ class MigrationOrchestrator:
         dest_ok, dest_error = self.dest_client.test_connection()
         return source_ok, dest_ok, source_error, dest_error
 
+    def ensure_state(self):
+        """Create a session state if one does not already exist."""
+        if not self.state:
+            self.state = self.state_manager.create_session(
+                self.config.source.base_url,
+                self.config.destination.base_url,
+            )
+        self.state_manager.current_state = self.state
+        return self.state
+
+    def workspace_pair(self) -> Dict[str, Optional[str]]:
+        """Return the active workspace pair for the orchestrator."""
+        return {
+            "source": self.source_client.session.headers.get("X-Tenant-Id"),
+            "dest": self.dest_client.session.headers.get("X-Tenant-Id"),
+        }
+
     def migrate_datasets_parallel(
         self,
         dataset_ids: List[str],
@@ -87,12 +111,7 @@ class MigrationOrchestrator:
         include_experiments: bool = False
     ) -> Dict[str, str]:
         """Migrate multiple datasets in parallel."""
-        # Create or load state
-        if not self.state:
-            self.state = self.state_manager.create_session(
-                self.config.source.base_url,
-                self.config.destination.base_url
-            )
+        self.ensure_state()
 
         # Add items to state
         dataset_migrator = DatasetMigrator(
@@ -104,13 +123,19 @@ class MigrationOrchestrator:
 
         for dataset_id in dataset_ids:
             dataset = dataset_migrator.get_dataset(dataset_id)
-            item = MigrationItem(
-                id=f"dataset_{dataset_id}",
-                type="dataset",
-                name=dataset["name"],
-                source_id=dataset_id
+            item = self.state.ensure_item(
+                f"dataset_{dataset_id}",
+                "dataset",
+                dataset["name"],
+                dataset_id,
+                stage="create_dataset",
+                workspace_pair=self.workspace_pair(),
             )
-            self.state.add_item(item)
+            self.state.update_item_checkpoint(
+                item.id,
+                metadata={"include_examples": include_examples},
+            )
+        self.state_manager.save()
 
         # Migrate with concurrency
         id_mapping = {}
@@ -119,12 +144,18 @@ class MigrationOrchestrator:
             futures = {}
 
             for dataset_id in dataset_ids:
+                self.state.update_item_status(
+                    f"dataset_{dataset_id}",
+                    MigrationStatus.IN_PROGRESS,
+                    stage="create_dataset",
+                )
                 future = executor.submit(
                     dataset_migrator.migrate_dataset,
                     dataset_id,
                     include_examples
                 )
                 futures[future] = dataset_id
+            self.state_manager.save()
 
             # Process completed migrations
             with Progress(console=self.console) as progress:
@@ -145,7 +176,15 @@ class MigrationOrchestrator:
                             self.state.update_item_status(
                                 item_id,
                                 MigrationStatus.COMPLETED,
-                                destination_id=new_id
+                                destination_id=new_id,
+                                stage="completed",
+                            )
+                            self.state.mark_terminal(
+                                item_id,
+                                ResolutionOutcome.MIGRATED,
+                                "dataset_migrated",
+                                verification_state=VerificationState.VERIFIED,
+                                evidence={"include_examples": include_examples},
                             )
 
                             # Store example mappings
@@ -170,6 +209,21 @@ class MigrationOrchestrator:
                                 MigrationStatus.FAILED,
                                 error=str(e)
                             )
+                            issue = self.state.add_issue(
+                                "transient",
+                                "dataset_migration_failed",
+                                f"Dataset migration failed for {dataset_id}",
+                                item_id=item_id,
+                                next_action="Re-run `langsmith-migrator resume` after reviewing the error.",
+                                evidence={"error": str(e)},
+                                workspace_pair=self.workspace_pair(),
+                            )
+                            self.state.queue_remediation(
+                                issue_id=issue.id,
+                                item_id=item_id,
+                                next_action=issue.next_action or "Resume dataset migration.",
+                                command="langsmith-migrator resume",
+                            )
 
                     progress.advance(task)
 
@@ -190,7 +244,14 @@ class MigrationOrchestrator:
         dataset_id_mapping: Dict[str, str]
     ):
         """Migrate experiments for the given datasets."""
+        self.ensure_state()
         experiment_migrator = ExperimentMigrator(
+            self.source_client,
+            self.dest_client,
+            self.state,
+            self.config
+        )
+        feedback_migrator = FeedbackMigrator(
             self.source_client,
             self.dest_client,
             self.state,
@@ -214,7 +275,6 @@ class MigrationOrchestrator:
         self.console.print(f"Found {len(all_experiments)} experiment(s)")
 
         # Create experiments in destination
-        experiment_id_mapping = {}
         success_count = 0
         failed_items = []
         skipped_items = []
@@ -223,44 +283,72 @@ class MigrationOrchestrator:
             task = progress.add_task("Migrating experiments...", total=len(all_experiments))
 
             for experiment in all_experiments:
-                source_dataset_id = experiment_to_dataset[experiment['id']]
+                source_experiment_id = experiment["id"]
+                source_dataset_id = experiment_to_dataset[source_experiment_id]
                 dest_dataset_id = dataset_id_mapping.get(source_dataset_id)
+                item_id = f"experiment_{source_experiment_id}"
+                item = self.state.ensure_item(
+                    item_id,
+                    "experiment",
+                    experiment["name"],
+                    source_experiment_id,
+                    stage="create_experiment",
+                    workspace_pair=self.workspace_pair(),
+                    metadata={
+                        "source_dataset_id": source_dataset_id,
+                        "dest_dataset_id": dest_dataset_id,
+                    },
+                )
 
-                if not dest_dataset_id:
-                    skipped_items.append((experiment['name'], "dataset not migrated"))
+                if item.terminal_state == ResolutionOutcome.MIGRATED.value:
+                    success_count += 1
                     progress.advance(task)
                     continue
 
-                try:
-                    # Add to state
-                    item = MigrationItem(
-                        id=f"experiment_{experiment['id']}",
-                        type="experiment",
-                        name=experiment['name'],
-                        source_id=experiment['id']
+                if not dest_dataset_id:
+                    skipped_items.append((experiment["name"], "dataset not migrated"))
+                    self.state.mark_terminal(
+                        item_id,
+                        ResolutionOutcome.BLOCKED_WITH_CHECKPOINT,
+                        "missing_dataset_dependency",
+                        verification_state=VerificationState.BLOCKED,
+                        next_action="Migrate the referenced dataset, then run `langsmith-migrator resume`.",
+                        evidence={"source_dataset_id": source_dataset_id},
+                        error="dataset not migrated",
                     )
-                    self.state.add_item(item)
-                    self.state.update_item_status(item.id, MigrationStatus.IN_PROGRESS)
-
-                    new_exp_id = experiment_migrator.create_experiment(experiment, dest_dataset_id)
-                    experiment_id_mapping[experiment['id']] = new_exp_id
-
-                    self.state.update_item_status(
-                        item.id,
-                        MigrationStatus.COMPLETED,
-                        destination_id=new_exp_id
+                    issue = self.state.add_issue(
+                        "dependency",
+                        "missing_dataset_dependency",
+                        f"Experiment {experiment['name']} depends on dataset {source_dataset_id}",
+                        item_id=item_id,
+                        next_action="Migrate the dataset and re-run resume.",
+                        evidence={"source_dataset_id": source_dataset_id},
+                        workspace_pair=self.workspace_pair(),
                     )
+                    self.state.queue_remediation(
+                        issue_id=issue.id,
+                        item_id=item_id,
+                        next_action=issue.next_action or "Migrate dataset dependency.",
+                        command="langsmith-migrator resume",
+                    )
+                    self.state_manager.save()
+                    progress.advance(task)
+                    continue
+
+                success, detail = self._resolve_experiment_item(
+                    experiment,
+                    source_dataset_id,
+                    dest_dataset_id,
+                    experiment_migrator,
+                    feedback_migrator,
+                )
+                if success:
                     success_count += 1
-
-                except Exception as e:
-                    failed_items.append((experiment['name'], str(e)))
-                    self.state.update_item_status(
-                        item.id,
-                        MigrationStatus.FAILED,
-                        error=str(e)
-                    )
+                else:
+                    failed_items.append((experiment["name"], detail))
 
                 progress.advance(task)
+                self.state_manager.save()
 
         # Summary
         self.console.print(f"Experiments: {success_count} migrated, {len(skipped_items)} skipped, {len(failed_items)} failed")
@@ -270,42 +358,378 @@ class MigrationOrchestrator:
             for name, err in failed_items:
                 self.console.print(f"  [red]✗[/red] {name}: {err}")
 
-        # Migrate runs if experiments were created
-        run_id_mapping = {}
-        if experiment_id_mapping:
-            self.console.print("\n[bold]Migrating experiment runs...[/bold]")
-            try:
-                total_runs, run_id_mapping = experiment_migrator.migrate_runs_streaming(
-                    list(experiment_id_mapping.keys()),
-                    {
-                        "experiments": experiment_id_mapping,
-                        "examples": self.state.id_mappings.get("examples", {})
-                    }
-                )
-                self.console.print(f"[green]✓[/green] Migrated {total_runs} run(s)")
-            except Exception as e:
-                self.console.print(f"[red]✗[/red] Failed to migrate runs: {e}")
+    def _resolve_experiment_item(
+        self,
+        experiment: Dict[str, str],
+        source_dataset_id: str,
+        dest_dataset_id: str,
+        experiment_migrator: ExperimentMigrator,
+        feedback_migrator: FeedbackMigrator,
+    ) -> tuple[bool, str]:
+        """Resolve experiment creation, run replay, and feedback replay."""
+        source_experiment_id = experiment["id"]
+        item_id = f"experiment_{source_experiment_id}"
+        item = self.state.get_item(item_id)
+        if item is None:
+            return False, "missing experiment state item"
 
-        # Migrate feedback if experiments and runs were created
-        if experiment_id_mapping and run_id_mapping:
-            self.console.print("\n[bold]Migrating experiment feedback...[/bold]")
-            try:
-                feedback_migrator = FeedbackMigrator(
-                    self.source_client,
-                    self.dest_client,
-                    self.state,
-                    self.config
+        dest_experiment_id = item.destination_id or item.metadata.get("destination_experiment_id")
+
+        try:
+            if not dest_experiment_id:
+                self.state.update_item_status(
+                    item_id,
+                    MigrationStatus.IN_PROGRESS,
+                    stage="create_experiment",
                 )
+                self.state.update_item_checkpoint(
+                    item_id,
+                    metadata={
+                        "source_dataset_id": source_dataset_id,
+                        "dest_dataset_id": dest_dataset_id,
+                    },
+                )
+                self.state_manager.save()
+                dest_experiment_id = experiment_migrator.create_experiment(
+                    experiment,
+                    dest_dataset_id,
+                )
+                self.state.update_item_status(
+                    item_id,
+                    MigrationStatus.IN_PROGRESS,
+                    destination_id=dest_experiment_id,
+                    stage="migrate_runs",
+                )
+                self.state.update_item_checkpoint(
+                    item_id,
+                    metadata={"destination_experiment_id": dest_experiment_id},
+                )
+                self.state_manager.save()
+
+            current_item = self.state.get_item(item_id)
+            if current_item and current_item.stage in {"pending", "create_experiment", "migrate_runs", "in_progress"}:
+                total_runs, _, failed_run_count = experiment_migrator.migrate_runs_streaming(
+                    [source_experiment_id],
+                    {
+                        "experiments": {source_experiment_id: dest_experiment_id},
+                        "examples": self.state.id_mappings.get("examples", {}),
+                    },
+                )
+                if failed_run_count > 0:
+                    detail = f"{failed_run_count} run(s) failed during replay"
+                    self.state.update_item_status(
+                        item_id,
+                        MigrationStatus.FAILED,
+                        error=detail,
+                        stage="migrate_runs",
+                    )
+                    self.state_manager.save()
+                    return False, detail
+
+                self.state.update_item_status(
+                    item_id,
+                    MigrationStatus.IN_PROGRESS,
+                    destination_id=dest_experiment_id,
+                    stage="migrate_feedback",
+                )
+                self.state.update_item_checkpoint(
+                    item_id,
+                    metadata={"runs_migrated": total_runs},
+                )
+                self.state_manager.save()
+
+            current_item = self.state.get_item(item_id)
+            if current_item and (
+                current_item.stage in {"migrate_feedback", "completed"}
+                and not current_item.metadata.get("feedback_verified")
+            ):
                 total_found, total_migrated = feedback_migrator.migrate_feedback_for_experiments(
-                    experiment_id_mapping,
-                    run_id_mapping
+                    {source_experiment_id: dest_experiment_id},
+                    self.state.id_mappings.get("run", {}),
                 )
-                if total_found > 0:
-                    self.console.print(f"[green]✓[/green] Migrated {total_migrated}/{total_found} feedback record(s)")
+                if total_found > total_migrated:
+                    detail = (
+                        f"feedback replay incomplete ({total_migrated}/{total_found} migrated)"
+                    )
+                    self.state.update_item_status(
+                        item_id,
+                        MigrationStatus.FAILED,
+                        error=detail,
+                        stage="migrate_feedback",
+                    )
+                    self.state_manager.save()
+                    return False, detail
+
+                self.state.update_item_checkpoint(
+                    item_id,
+                    stage="completed",
+                    metadata={
+                        "feedback_found": total_found,
+                        "feedback_migrated": total_migrated,
+                        "feedback_verified": True,
+                    },
+                )
+                self.state.mark_terminal(
+                    item_id,
+                    ResolutionOutcome.MIGRATED,
+                    "experiment_migrated",
+                    verification_state=VerificationState.VERIFIED,
+                    evidence={
+                        "destination_experiment_id": dest_experiment_id,
+                        "feedback_found": total_found,
+                        "feedback_migrated": total_migrated,
+                    },
+                )
+                self.state_manager.save()
+
+            return True, "migrated"
+        except Exception as e:
+            self.state.update_item_status(
+                item_id,
+                MigrationStatus.FAILED,
+                error=str(e),
+                stage=item.stage or "experiment_resolution",
+            )
+            issue = self.state.add_issue(
+                "transient",
+                "experiment_resolution_failed",
+                f"Experiment resolution failed for {experiment['name']}",
+                item_id=item_id,
+                next_action="Re-run `langsmith-migrator resume` after reviewing the error.",
+                evidence={"error": str(e)},
+                workspace_pair=self.workspace_pair(),
+            )
+            self.state.queue_remediation(
+                issue_id=issue.id,
+                item_id=item_id,
+                next_action=issue.next_action or "Resume experiment migration.",
+                command="langsmith-migrator resume",
+            )
+            self.state_manager.save()
+            return False, str(e)
+
+    def _apply_item_workspace(self, item: MigrationItem) -> None:
+        """Restore workspace scope for a tracked item."""
+        workspace_pair = getattr(item, "workspace_pair", {}) or {}
+        source_ws = workspace_pair.get("source")
+        dest_ws = workspace_pair.get("dest")
+        if source_ws and dest_ws:
+            self.set_workspace_context(source_ws, dest_ws)
+        else:
+            self.clear_workspace_context()
+
+    def resume_items(self, items_to_process: List[MigrationItem]) -> Dict[str, List[str]]:
+        """Resume pending and failed items using typed dispatch."""
+        self.ensure_state()
+        results = {"resumed": [], "blocked": []}
+
+        from .annotation_queue import AnnotationQueueMigrator
+        from .chart import ChartMigrator
+        from .prompt import PromptMigrator
+        from .rules import RulesMigrator
+
+        prompt_migrator = PromptMigrator(
+            self.source_client,
+            self.dest_client,
+            self.state,
+            self.config,
+        )
+        queue_migrator = AnnotationQueueMigrator(
+            self.source_client,
+            self.dest_client,
+            self.state,
+            self.config,
+        )
+        rules_migrator = RulesMigrator(
+            self.source_client,
+            self.dest_client,
+            self.state,
+            self.config,
+        )
+        chart_migrator = ChartMigrator(
+            self.source_client,
+            self.dest_client,
+            self.state,
+            self.config,
+        )
+        experiment_migrator = ExperimentMigrator(
+            self.source_client,
+            self.dest_client,
+            self.state,
+            self.config,
+        )
+        feedback_migrator = FeedbackMigrator(
+            self.source_client,
+            self.dest_client,
+            self.state,
+            self.config,
+        )
+
+        for item in items_to_process:
+            self._apply_item_workspace(item)
+            try:
+                self.state.update_item_status(
+                    item.id,
+                    MigrationStatus.IN_PROGRESS,
+                    stage=item.stage or "resume",
+                )
+                self.state_manager.save()
+
+                if item.type == "dataset":
+                    self.migrate_datasets_parallel([item.source_id], include_examples=True)
+                elif item.type == "experiment":
+                    experiment = self.source_client.get(f"/sessions/{item.source_id}")
+                    source_dataset_id = item.metadata.get("source_dataset_id")
+                    dest_dataset_id = item.metadata.get("dest_dataset_id") or (
+                        self.state.get_mapped_id("dataset", source_dataset_id)
+                        if source_dataset_id
+                        else None
+                    )
+                    if not source_dataset_id or not dest_dataset_id:
+                        self.state.mark_terminal(
+                            item.id,
+                            ResolutionOutcome.BLOCKED_WITH_CHECKPOINT,
+                            "missing_dataset_dependency",
+                            verification_state=VerificationState.BLOCKED,
+                            next_action="Migrate the referenced dataset, then run `langsmith-migrator resume`.",
+                            evidence={"source_dataset_id": source_dataset_id},
+                            error="dataset dependency missing",
+                        )
+                    else:
+                        self._resolve_experiment_item(
+                            experiment,
+                            source_dataset_id,
+                            dest_dataset_id,
+                            experiment_migrator,
+                            feedback_migrator,
+                        )
+                elif item.type == "prompt":
+                    prompt_migrator.migrate_prompt(
+                        item.source_id,
+                        include_all_commits=item.metadata.get("include_all_commits", False),
+                    )
+                elif item.type == "queue":
+                    queue_payload = item.metadata.get("queue") or queue_migrator.get_queue(item.source_id)
+                    destination_id = queue_migrator.create_queue(queue_payload)
+                    self.state.update_item_status(
+                        item.id,
+                        MigrationStatus.COMPLETED,
+                        destination_id=destination_id,
+                        stage="completed",
+                    )
+                    self.state.mark_terminal(
+                        item.id,
+                        ResolutionOutcome.MIGRATED,
+                        "queue_migrated",
+                        verification_state=VerificationState.VERIFIED,
+                        evidence={"destination_id": destination_id},
+                    )
+                elif item.type == "rule":
+                    rules_migrator._project_id_map = dict(item.metadata.get("project_id_map") or {})
+                    rule_payload = item.metadata.get("rule") or rules_migrator.get_rule(item.source_id)
+                    if rule_payload:
+                        destination_id = rules_migrator.create_rule(
+                            rule_payload,
+                            strip_project_reference=item.metadata.get("strip_projects", False),
+                            ensure_project=item.metadata.get("ensure_project", False),
+                            create_disabled=item.metadata.get("create_disabled", False),
+                        )
+                        if destination_id and not self.state.get_item(item.id).terminal_state:
+                            self.state.update_item_status(
+                                item.id,
+                                MigrationStatus.COMPLETED,
+                                destination_id=destination_id,
+                                stage="completed",
+                            )
+                            self.state.mark_terminal(
+                                item.id,
+                                ResolutionOutcome.MIGRATED,
+                                "rule_migrated",
+                                verification_state=VerificationState.VERIFIED,
+                                evidence={"destination_id": destination_id},
+                            )
+                elif item.type == "chart":
+                    chart_payload = item.metadata.get("chart")
+                    if chart_payload:
+                        destination_id = chart_migrator.migrate_chart(
+                            chart_payload,
+                            item.metadata.get("dest_session_id"),
+                        )
+                        if destination_id and not self.state.get_item(item.id).terminal_state:
+                            self.state.update_item_status(
+                                item.id,
+                                MigrationStatus.COMPLETED,
+                                destination_id=destination_id,
+                                stage="completed",
+                            )
+                            self.state.mark_terminal(
+                                item.id,
+                                ResolutionOutcome.MIGRATED,
+                                "chart_migrated",
+                                verification_state=VerificationState.VERIFIED,
+                                evidence={"destination_id": destination_id},
+                            )
                 else:
-                    self.console.print("[dim]No feedback records found[/dim]")
+                    issue = self.state.add_issue(
+                        "capability",
+                        "resume_not_yet_available",
+                        f"Automatic resume is not yet implemented for {item.type} items",
+                        item_id=item.id,
+                        next_action=f"Re-run the `{item.type}` command after reviewing the remediation bundle.",
+                        evidence={"item_type": item.type},
+                        workspace_pair=self.workspace_pair(),
+                    )
+                    self.state.queue_remediation(
+                        issue_id=issue.id,
+                        item_id=item.id,
+                        next_action=issue.next_action or "Retry the resource command.",
+                        command=f"langsmith-migrator {item.type}s",
+                    )
+
+                current_item = self.state.get_item(item.id)
+                if current_item and current_item.terminal_state in {
+                    ResolutionOutcome.MIGRATED.value,
+                    ResolutionOutcome.MIGRATED_WITH_VERIFIED_DOWNGRADE.value,
+                }:
+                    results["resumed"].append(f"{item.type}:{item.source_id}")
+                elif current_item and current_item.terminal_state in {
+                    ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value,
+                    ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY.value,
+                }:
+                    results["blocked"].append(f"{item.type}:{item.source_id}")
+                elif current_item and current_item.status == MigrationStatus.COMPLETED:
+                    results["resumed"].append(f"{item.type}:{item.source_id}")
+                else:
+                    results["blocked"].append(f"{item.type}:{item.source_id}")
+
+                self.state_manager.save()
             except Exception as e:
-                self.console.print(f"[red]✗[/red] Failed to migrate feedback: {e}")
+                self.state.update_item_status(
+                    item.id,
+                    MigrationStatus.FAILED,
+                    error=str(e),
+                    stage=item.stage or "resume",
+                )
+                issue = self.state.add_issue(
+                    "transient",
+                    "resume_dispatch_failed",
+                    f"Resume failed for {item.type} item {item.source_id}",
+                    item_id=item.id,
+                    next_action="Review the error and run `langsmith-migrator resume` again.",
+                    evidence={"error": str(e), "item_type": item.type},
+                    workspace_pair=self.workspace_pair(),
+                )
+                self.state.queue_remediation(
+                    issue_id=issue.id,
+                    item_id=item.id,
+                    next_action=issue.next_action or "Retry resume.",
+                    command="langsmith-migrator resume",
+                )
+                results["blocked"].append(f"{item.type}:{item.source_id}")
+                self.state_manager.save()
+
+        self.clear_workspace_context()
+        return results
 
     def set_workspace_context(self, source_ws_id: str, dest_ws_id: str) -> None:
         """Scope both clients to the given workspace pair."""

--- a/langsmith_migrator/core/migrators/orchestrator.py
+++ b/langsmith_migrator/core/migrators/orchestrator.py
@@ -94,6 +94,10 @@ class MigrationOrchestrator:
                 self.config.source.base_url,
                 self.config.destination.base_url,
             )
+        elif not self.state.remediation_bundle_path:
+            self.state.remediation_bundle_path = str(
+                self.state_manager._default_bundle_path(self.state.session_id).resolve()
+            )
         self.state_manager.current_state = self.state
         return self.state
 

--- a/langsmith_migrator/core/migrators/prompt.py
+++ b/langsmith_migrator/core/migrators/prompt.py
@@ -312,7 +312,6 @@ class PromptMigrator(BaseMigrator):
         if not commits:
             return []
 
-        commits_by_hash = {commit["commit_hash"]: commit for commit in commits}
         children: Dict[Optional[str], List[Dict[str, Any]]] = {}
         for commit in commits:
             children.setdefault(commit.get("parent_commit_hash"), []).append(commit)

--- a/langsmith_migrator/core/migrators/prompt.py
+++ b/langsmith_migrator/core/migrators/prompt.py
@@ -55,32 +55,155 @@ class PromptMigrator(BaseMigrator):
             else:
                 session.headers.pop("X-Tenant-Id", None)
 
+    def _iter_prompt_repos(
+        self,
+        client: Client,
+        *,
+        is_archived: bool = False,
+        is_public: Optional[bool] = None,
+        limit: int = 100,
+    ):
+        """Yield prompt repos from the SDK with pagination support."""
+        offset = 0
+
+        while True:
+            kwargs: Dict[str, Any] = {
+                "limit": limit,
+                "offset": offset,
+                "is_archived": is_archived,
+            }
+            if is_public is not None:
+                kwargs["is_public"] = is_public
+
+            response = client.list_prompts(**kwargs)
+            repos = list(getattr(response, "repos", []) or [])
+            if not repos:
+                break
+
+            yield from repos
+
+            if len(repos) < limit:
+                break
+            offset += len(repos)
+
+    def _prompt_item_id(self, prompt_identifier: str) -> str:
+        return f"prompt_{prompt_identifier.replace('/', '_').replace(':', '_')}"
+
+    def _probe_commit_endpoint(
+        self,
+        prompt_identifier: str,
+        *,
+        from_source: bool,
+        commit: str = "latest",
+    ) -> tuple[Optional[bool], str]:
+        """Probe whether commit read endpoints exist without mutating data."""
+        owner, repo, _ = self._parse_prompt_identifier(prompt_identifier)
+        owner_path = owner if owner else "-"
+        base_url = self.config.source.base_url if from_source else self.config.destination.base_url
+        api_key = self.config.source.api_key if from_source else self.config.destination.api_key
+        session = self._source_session if from_source else self._dest_session
+        url = f"{self._get_api_url(base_url)}/commits/{owner_path}/{repo}/{commit}"
+        headers = {"x-api-key": api_key}
+
+        try:
+            response = session.get(
+                url,
+                headers=headers,
+                params={"include_model": "true"},
+                timeout=30,
+            )
+            if response.status_code == 404:
+                return True, "endpoint_supported_resource_missing"
+            response.raise_for_status()
+            return True, "ok"
+        except requests.exceptions.HTTPError as e:
+            if e.response is not None and e.response.status_code in {404, 405}:
+                if e.response.status_code == 404:
+                    return True, "endpoint_supported_resource_missing"
+                return False, "405_not_allowed"
+            return False, str(e)
+        except Exception as e:
+            return False, str(e)
+
+    def probe_capabilities(
+        self,
+        prompt_identifier: str = "codex-capability-probe",
+    ) -> Dict[str, Dict[str, Any]]:
+        """Probe prompt-related capabilities without mutating destination data."""
+        self._sync_workspace_headers()
+        capabilities: Dict[str, Dict[str, Any]] = {}
+
+        def record(name: str, supported: Optional[bool], detail: str, probe: str) -> None:
+            capabilities[name] = {
+                "supported": supported,
+                "detail": detail,
+                "probe": probe,
+            }
+            self.record_capability(
+                "prompts",
+                name,
+                supported=supported,
+                detail=detail,
+                probe=probe,
+                evidence={"prompt_identifier": prompt_identifier},
+            )
+
+        try:
+            self.dest_ls_client.list_prompts(limit=1)
+            record("list_read", True, "ok", "sdk.list_prompts")
+        except Exception as e:
+            error_msg = str(e)
+            if "405" in error_msg or "Not Allowed" in error_msg:
+                record("list_read", False, "405_not_allowed", "sdk.list_prompts")
+            elif "404" in error_msg:
+                record("list_read", False, "404_not_found", "sdk.list_prompts")
+            else:
+                record("list_read", False, error_msg, "sdk.list_prompts")
+
+        repo_lookup_supported, repo_lookup_detail = self._probe_commit_endpoint(
+            prompt_identifier,
+            from_source=False,
+        )
+        record("repo_lookup", repo_lookup_supported, repo_lookup_detail, "GET /commits/.../latest")
+        record(
+            "latest_commit_lookup",
+            repo_lookup_supported,
+            repo_lookup_detail,
+            "GET /commits/.../latest",
+        )
+        record(
+            "repo_create",
+            None,
+            "deferred_until_first_write",
+            "POST create_prompt",
+        )
+        record(
+            "commit_write",
+            None,
+            "deferred_until_first_write",
+            "POST /commits/{owner}/{repo}",
+        )
+
+        return capabilities
+
     def check_prompts_api_available(self) -> tuple[bool, str]:
         """
         Check if the prompts API is available on the destination instance.
-        Tests both read (list) and write (push) operations.
+        Uses capability probes instead of relying only on list_prompts().
 
         Returns:
             Tuple of (is_available, error_message)
         """
-        self._sync_workspace_headers()
-        # Test 1: Check if we can list prompts (READ access)
-        try:
-            self.dest_ls_client.list_prompts(limit=1)
-        except Exception as e:
-            error_msg = str(e)
-            if "405" in error_msg or "Not Allowed" in error_msg:
-                return False, "Prompts API returned 405 Not Allowed - prompts may not be enabled on this instance"
-            elif "404" in error_msg:
-                return False, "Prompts API endpoints not found - this instance may not support prompts"
-            else:
-                return False, f"Prompts API read check failed: {error_msg}"
+        capabilities = self.probe_capabilities()
+        if capabilities["list_read"]["supported"] or capabilities["repo_lookup"]["supported"]:
+            return True, ""
 
-        # Note: We're NOT testing write access here because:
-        # 1. Testing with fake prompts may give false negatives
-        # 2. The SDK's push_prompt has an existence check that may fail even if push works
-        # 3. Better to attempt actual migration and provide good error messages if it fails
-        return True, ""
+        detail = capabilities["list_read"]["detail"]
+        if detail == "405_not_allowed":
+            return False, "Prompts API returned 405 Not Allowed - prompt listing is disabled on this instance"
+        if detail == "404_not_found":
+            return False, "Prompts API endpoints not found - this instance may not support prompts"
+        return False, f"Prompts API capability probe failed: {detail}"
 
     def _get_api_url(self, base_url: str) -> str:
         """
@@ -183,6 +306,114 @@ class PromptMigrator(BaseMigrator):
         except Exception as e:
             self.log(f"Could not get latest commit for {prompt_identifier}: {e}", "warning")
             return None
+
+    def _order_commits_for_replay(self, commits: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Replay commit history from oldest to newest."""
+        if not commits:
+            return []
+
+        commits_by_hash = {commit["commit_hash"]: commit for commit in commits}
+        children: Dict[Optional[str], List[Dict[str, Any]]] = {}
+        for commit in commits:
+            children.setdefault(commit.get("parent_commit_hash"), []).append(commit)
+
+        ordered: List[Dict[str, Any]] = []
+        roots = children.get(None, [])
+        if not roots:
+            roots = [commits[-1]]
+
+        stack = list(reversed(roots))
+        seen = set()
+        while stack:
+            commit = stack.pop()
+            commit_hash = commit["commit_hash"]
+            if commit_hash in seen:
+                continue
+            seen.add(commit_hash)
+            ordered.append(commit)
+            next_children = children.get(commit_hash, [])
+            for child in reversed(next_children):
+                stack.append(child)
+
+        for commit in commits:
+            if commit["commit_hash"] not in seen:
+                ordered.append(commit)
+        return ordered
+
+    def _verify_prompt_commit(
+        self,
+        prompt_identifier: str,
+        commit_hash: Optional[str] = None,
+    ) -> tuple[bool, Optional[str]]:
+        """Verify that a prompt commit can be fetched from destination."""
+        owner, repo, _ = self._parse_prompt_identifier(prompt_identifier)
+        owner_path = owner if owner else "-"
+        target_commit = commit_hash or "latest"
+        url = f"{self._get_api_url(self.config.destination.base_url)}/commits/{owner_path}/{repo}/{target_commit}"
+        headers = {"x-api-key": self.config.destination.api_key}
+
+        try:
+            response = self._dest_session.get(
+                url,
+                headers=headers,
+                params={"include_model": "true"},
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+            actual_commit_hash = data.get("commit_hash") or target_commit
+            return True, actual_commit_hash
+        except Exception as e:
+            self.log(f"Failed to verify prompt commit for {prompt_identifier}: {e}", "warning")
+            return False, None
+
+    def _export_prompt_manual_apply(
+        self,
+        prompt_identifier: str,
+        *,
+        include_all_commits: bool,
+        reason: str,
+        capabilities: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Export prompt data into the remediation bundle for manual apply."""
+        item_id = self._prompt_item_id(prompt_identifier)
+        commits = self.get_prompt_commits(prompt_identifier) if include_all_commits else []
+        commit_payload = []
+        if include_all_commits and commits:
+            for commit in self._order_commits_for_replay(commits):
+                manifest_data = self._pull_prompt_manifest(prompt_identifier, commit["commit_hash"])
+                if manifest_data and manifest_data.get("manifest"):
+                    commit_payload.append(
+                        {
+                            "source_commit_hash": commit["commit_hash"],
+                            "parent_commit_hash": commit.get("parent_commit_hash"),
+                            "manifest": manifest_data["manifest"],
+                        }
+                    )
+        else:
+            latest_manifest = self._pull_prompt_manifest(prompt_identifier, "latest")
+            if latest_manifest and latest_manifest.get("manifest"):
+                commit_payload.append(
+                    {
+                        "source_commit_hash": latest_manifest.get("commit_hash") or "latest",
+                        "parent_commit_hash": None,
+                        "manifest": latest_manifest["manifest"],
+                    }
+                )
+
+        export_payload = {
+            "prompt_identifier": prompt_identifier,
+            "include_all_commits": include_all_commits,
+            "reason": reason,
+            "capabilities": capabilities or {},
+            "commits": commit_payload,
+            "manual_steps": [
+                "Confirm prompt write support on the destination instance.",
+                "Apply the exported manifests in order using the destination prompt API.",
+                "Re-run `langsmith-migrator resume` after the prompt exists on destination.",
+            ],
+        }
+        return self.export_payload(item_id, "manual_apply", export_payload)
 
     def _push_prompt_manifest(
         self,
@@ -354,65 +585,41 @@ class PromptMigrator(BaseMigrator):
         self._sync_workspace_headers()
         prompts = []
         try:
-            offset = 0
-            limit = 100
-            max_iterations = 1000  # Safety limit to prevent infinite loops
-            iterations = 0
-
             self.log(f"Fetching prompts (archived={is_archived})...", "info")
+            seen_handles = set()
 
-            while iterations < max_iterations:
-                iterations += 1
-
-                self.log(f"Fetching prompts: offset={offset}, limit={limit}", "info")
-
+            for visibility in (False, True):
                 try:
-                    response = self.source_ls_client.list_prompts(
-                        limit=limit,
-                        offset=offset,
+                    for prompt in self._iter_prompt_repos(
+                        self.source_ls_client,
                         is_archived=is_archived,
-                        is_public=False  # Only fetch private prompts from this tenant
-                    )
+                        is_public=visibility,
+                    ):
+                        if prompt.repo_handle in seen_handles:
+                            continue
+                        seen_handles.add(prompt.repo_handle)
+                        prompts.append({
+                            'id': str(prompt.id),
+                            'repo_handle': prompt.repo_handle,
+                            'description': prompt.description,
+                            'readme': prompt.readme,
+                            'is_public': prompt.is_public,
+                            'is_archived': prompt.is_archived,
+                            'tags': prompt.tags or [],
+                            'num_likes': prompt.num_likes,
+                            'num_downloads': prompt.num_downloads,
+                            'num_commits': prompt.num_commits,
+                            'updated_at': str(prompt.updated_at) if prompt.updated_at else None,
+                        })
                 except Exception as api_error:
                     self.log(f"API error while listing prompts: {api_error}", "error")
-                    # If we got some prompts already, return them
                     if prompts:
-                        self.log(f"Returning {len(prompts)} prompts fetched before error", "warning")
+                        self.log(
+                            f"Returning {len(prompts)} prompts fetched before error",
+                            "warning",
+                        )
                         return prompts
                     raise
-
-                # Note: ListPromptsResponse has 'repos' attribute, not 'prompts'
-                if not response or not hasattr(response, 'repos') or not response.repos:
-                    self.log(f"No more prompts found at offset {offset}", "info")
-                    break
-
-                batch_size = len(response.repos)
-                self.log(f"Retrieved {batch_size} prompt(s) in this batch", "info")
-
-                for prompt in response.repos:
-                    prompts.append({
-                        'id': str(prompt.id),
-                        'repo_handle': prompt.repo_handle,
-                        'description': prompt.description,
-                        'readme': prompt.readme,
-                        'is_public': prompt.is_public,
-                        'is_archived': prompt.is_archived,
-                        'tags': prompt.tags or [],
-                        'num_likes': prompt.num_likes,
-                        'num_downloads': prompt.num_downloads,
-                        'num_commits': prompt.num_commits,
-                        'updated_at': str(prompt.updated_at) if prompt.updated_at else None,
-                    })
-
-                # If we got fewer results than the limit, we've reached the end
-                if batch_size < limit:
-                    self.log(f"Reached end of prompts (got {batch_size} < {limit})", "info")
-                    break
-
-                offset += batch_size
-
-            if iterations >= max_iterations:
-                self.log(f"Reached maximum iteration limit ({max_iterations}), stopping", "warning")
 
             self.log(f"Total prompts fetched: {len(prompts)}", "success")
             return prompts
@@ -448,17 +655,17 @@ class PromptMigrator(BaseMigrator):
         """
         self._sync_workspace_headers()
         try:
-            # Try to list prompts and find a match by repo_handle
-            response = self.dest_ls_client.list_prompts(limit=100)
-            if response and hasattr(response, 'repos'):
-                for prompt in response.repos:
+            for visibility in (False, True):
+                for prompt in self._iter_prompt_repos(
+                    self.dest_ls_client,
+                    is_public=visibility,
+                ):
                     if prompt.repo_handle == prompt_identifier:
                         return True
             return False
         except Exception as e:
-            # If we can't check, assume it doesn't exist and let push_prompt handle it
             self.log(f"Could not check if prompt exists: {e}", "warning")
-            return False
+            return self._get_latest_commit_hash(prompt_identifier) is not None
 
     def migrate_prompt(
         self,
@@ -476,6 +683,18 @@ class PromptMigrator(BaseMigrator):
             The prompt identifier in the destination instance, or None if failed
         """
         self._sync_workspace_headers()
+        item_id = self._prompt_item_id(prompt_identifier)
+        self.ensure_item(
+            item_id,
+            "prompt",
+            prompt_identifier,
+            prompt_identifier,
+            stage="planning",
+            strategy="full_history" if include_all_commits else "latest_only",
+            metadata={"include_all_commits": include_all_commits},
+        )
+        capabilities = self.probe_capabilities(prompt_identifier)
+
         if self.config.migration.dry_run:
             self.log(f"[DRY RUN] Would migrate prompt: {prompt_identifier}")
             return prompt_identifier
@@ -486,42 +705,97 @@ class PromptMigrator(BaseMigrator):
         if exists:
             if self.config.migration.skip_existing:
                 self.log(f"Prompt '{prompt_identifier}' already exists, skipping", "warning")
+                self.mark_migrated(
+                    item_id,
+                    outcome_code="prompt_already_exists",
+                    evidence={"prompt_identifier": prompt_identifier},
+                )
                 return prompt_identifier
             else:
                 self.log(f"Prompt '{prompt_identifier}' exists, updating with new commits...", "info")
 
         try:
             self.log(f"Migrating prompt: {prompt_identifier}", "info")
-
+            self.checkpoint_item(item_id, stage="migrating", destination_id=prompt_identifier)
             commits_migrated = 0
+            degraded_history = False
+            commit_map: Dict[str, str] = {}
 
             if include_all_commits:
-                commits = self.get_prompt_commits(prompt_identifier)
+                commits = self._order_commits_for_replay(
+                    self.get_prompt_commits(prompt_identifier)
+                )
                 self.log(f"Found {len(commits)} commits for {prompt_identifier}", "info")
+                existing_dest_parent = self._get_latest_commit_hash(prompt_identifier) if exists else None
 
                 for i, commit in enumerate(commits):
                     try:
-                        commit_hash = commit['commit_hash']
+                        commit_hash = commit["commit_hash"]
                         self.log(f"Pulling commit {commit_hash[:16]} manifest...", "info")
 
-                        # Use direct API to get raw manifest (includes model config without instantiating it)
                         manifest_data = self._pull_prompt_manifest(prompt_identifier, commit_hash)
 
-                        if not manifest_data or not manifest_data.get('manifest'):
+                        if not manifest_data or not manifest_data.get("manifest"):
                             self.log(f"Pull returned empty manifest for commit {commit_hash[:16]}", "warning")
                             continue
 
-                        parent_hash = commit['parent_commit_hash'] if i > 0 else None
+                        source_parent_hash = commit.get("parent_commit_hash")
+                        parent_hash = commit_map.get(source_parent_hash)
+                        if parent_hash is None and i == 0 and existing_dest_parent:
+                            parent_hash = existing_dest_parent
+                            degraded_history = True
 
-                        # Push manifest directly to destination
                         new_commit_hash = self._push_prompt_manifest(
                             prompt_identifier,
-                            manifest_data['manifest'],
-                            parent_commit=parent_hash
+                            manifest_data["manifest"],
+                            parent_commit=parent_hash,
+                            auto_parent=False,
                         )
 
                         if new_commit_hash:
-                            self.log(f"Migrated commit {commit_hash[:16]} -> {new_commit_hash[:16] if new_commit_hash != 'already_up_to_date' else 'already up to date'}", "success")
+                            if new_commit_hash == "already_up_to_date":
+                                verified, actual_commit_hash = self._verify_prompt_commit(
+                                    prompt_identifier,
+                                    None,
+                                )
+                                if not verified:
+                                    raise ValueError(
+                                        f"Post-write verification failed for commit {commit_hash[:16]}"
+                                    )
+                                mapped_commit_hash = actual_commit_hash or parent_hash or existing_dest_parent
+                            else:
+                                self.record_capability(
+                                    "prompts",
+                                    "commit_write",
+                                    supported=True,
+                                    detail="write_succeeded",
+                                    probe="POST /commits/{owner}/{repo}",
+                                )
+                                verified, actual_commit_hash = self._verify_prompt_commit(
+                                    prompt_identifier,
+                                    new_commit_hash,
+                                )
+                                if not verified:
+                                    raise ValueError(
+                                        f"Post-write verification failed for commit {commit_hash[:16]}"
+                                    )
+                                mapped_commit_hash = actual_commit_hash or new_commit_hash
+
+                            if mapped_commit_hash:
+                                commit_map[commit_hash] = mapped_commit_hash
+                                if self.state:
+                                    self.state.set_mapped_id(
+                                        "prompt_commit",
+                                        f"{prompt_identifier}:{commit_hash}",
+                                        mapped_commit_hash,
+                                    )
+                                    self.persist_state()
+
+                            self.log(
+                                f"Migrated commit {commit_hash[:16]} -> "
+                                f"{mapped_commit_hash[:16] if mapped_commit_hash else 'verified latest'}",
+                                "success",
+                            )
                             commits_migrated += 1
                         else:
                             self.log(f"Failed to push commit {commit_hash[:16]}", "warning")
@@ -533,42 +807,72 @@ class PromptMigrator(BaseMigrator):
                             self.log(f"Traceback: {traceback.format_exc()}", "error")
                         continue
 
-                # Fallback: if no commits were successfully migrated, try latest version
                 if commits_migrated == 0:
                     self.log("No commits migrated, falling back to latest version", "warning")
                     manifest_data = self._pull_prompt_manifest(prompt_identifier, "latest")
 
-                    if not manifest_data or not manifest_data.get('manifest'):
+                    if not manifest_data or not manifest_data.get("manifest"):
                         raise ValueError("Failed to pull prompt manifest")
 
                     new_commit_hash = self._push_prompt_manifest(
                         prompt_identifier,
-                        manifest_data['manifest']
+                        manifest_data["manifest"],
                     )
 
                     if new_commit_hash:
+                        verified, actual_commit_hash = self._verify_prompt_commit(
+                            prompt_identifier,
+                            None if new_commit_hash == "already_up_to_date" else new_commit_hash,
+                        )
+                        if not verified:
+                            raise ValueError("Failed to verify latest prompt commit")
+                        if self.state and manifest_data.get("commit_hash") and actual_commit_hash:
+                            self.state.set_mapped_id(
+                                "prompt_commit",
+                                f"{prompt_identifier}:{manifest_data['commit_hash']}",
+                                actual_commit_hash,
+                            )
+                            self.persist_state()
                         self.log(f"Migrated prompt (latest only): {prompt_identifier}", "success")
-                        return prompt_identifier
                     else:
                         raise ValueError("Failed to push prompt manifest")
                 else:
                     self.log(f"Successfully migrated {commits_migrated}/{len(commits)} commits", "success")
             else:
-                # Migrate only latest version using direct API (doesn't instantiate models)
                 self.log(f"Pulling latest version of {prompt_identifier} (manifest)...", "info")
 
                 manifest_data = self._pull_prompt_manifest(prompt_identifier, "latest")
 
-                if not manifest_data or not manifest_data.get('manifest'):
+                if not manifest_data or not manifest_data.get("manifest"):
                     raise ValueError("Failed to pull prompt manifest - prompt may not exist or be inaccessible")
 
                 self.log("Pushing manifest to destination...", "info")
                 new_commit_hash = self._push_prompt_manifest(
                     prompt_identifier,
-                    manifest_data['manifest']
+                    manifest_data["manifest"],
                 )
 
                 if new_commit_hash:
+                    self.record_capability(
+                        "prompts",
+                        "commit_write",
+                        supported=True,
+                        detail="write_succeeded" if new_commit_hash != "already_up_to_date" else "already_up_to_date",
+                        probe="POST /commits/{owner}/{repo}",
+                    )
+                    verified, actual_commit_hash = self._verify_prompt_commit(
+                        prompt_identifier,
+                        None if new_commit_hash == "already_up_to_date" else new_commit_hash,
+                    )
+                    if not verified:
+                        raise ValueError("Failed post-write verification for prompt commit")
+                    if self.state and manifest_data.get("commit_hash") and actual_commit_hash:
+                        self.state.set_mapped_id(
+                            "prompt_commit",
+                            f"{prompt_identifier}:{manifest_data['commit_hash']}",
+                            actual_commit_hash,
+                        )
+                        self.persist_state()
                     if new_commit_hash == "already_up_to_date":
                         self.log(f"Prompt already up to date: {prompt_identifier}", "success")
                     else:
@@ -576,20 +880,90 @@ class PromptMigrator(BaseMigrator):
                 else:
                     raise ValueError("Failed to push prompt manifest")
 
+            self.checkpoint_item(item_id, stage="completed")
+            if degraded_history:
+                self.mark_degraded(
+                    item_id,
+                    "prompt_history_rebased_on_existing_destination_head",
+                    next_action="Review the prompt commit history if exact ancestry must be preserved.",
+                    evidence={"prompt_identifier": prompt_identifier},
+                )
+            else:
+                self.mark_migrated(
+                    item_id,
+                    outcome_code="prompt_migrated",
+                    evidence={
+                        "prompt_identifier": prompt_identifier,
+                        "include_all_commits": include_all_commits,
+                    },
+                )
             return prompt_identifier
 
         except Exception as e:
             error_msg = str(e)
 
-            # Provide specific guidance for 405 errors
             if "405" in error_msg or "Not Allowed" in error_msg:
                 self.log(f"Failed to migrate prompt {prompt_identifier}: {e}", "error")
-                self.log("", "error")
-                self.log("The destination instance does not support prompt write operations.", "error")
-                self.log("This feature may not be enabled or available on your LangSmith instance.", "error")
-                self.log("Please contact your LangSmith administrator for assistance.", "error")
+                self.record_capability(
+                    "prompts",
+                    "commit_write",
+                    supported=False,
+                    detail="405_not_allowed",
+                    probe="POST /commits/{owner}/{repo}",
+                )
+                export_path = self._export_prompt_manual_apply(
+                    prompt_identifier,
+                    include_all_commits=include_all_commits,
+                    reason="destination_prompt_write_not_supported",
+                    capabilities=capabilities,
+                )
+                issue = self.record_issue(
+                    "capability",
+                    "prompt_write_unsupported",
+                    f"Destination prompt write API is not available for {prompt_identifier}",
+                    item_id=item_id,
+                    next_action="Enable prompt write support or apply the exported payload manually, then run `langsmith-migrator resume`.",
+                    evidence={"error": error_msg, "capabilities": capabilities},
+                    export_path=export_path,
+                )
+                if issue:
+                    self.queue_remediation(
+                        issue_id=issue.id,
+                        item_id=item_id,
+                        export_path=export_path,
+                        next_action=issue.next_action or "Apply exported prompt payload manually.",
+                        command="langsmith-migrator resume",
+                    )
+                self.mark_exported(
+                    item_id,
+                    "prompt_write_unsupported",
+                    next_action="Apply the exported prompt payload manually, then run `langsmith-migrator resume`.",
+                    export_path=export_path,
+                    evidence={"error": error_msg},
+                )
             else:
                 self.log(f"Failed to migrate prompt {prompt_identifier}: {e}", "error")
+                issue = self.record_issue(
+                    "post_write_verification" if "verification" in error_msg.lower() else "transient",
+                    "prompt_migration_failed",
+                    f"Prompt migration failed for {prompt_identifier}",
+                    item_id=item_id,
+                    next_action="Re-run `langsmith-migrator resume` after reviewing the error.",
+                    evidence={"error": error_msg},
+                )
+                if issue:
+                    self.queue_remediation(
+                        issue_id=issue.id,
+                        item_id=item_id,
+                        next_action=issue.next_action or "Retry prompt migration.",
+                        command="langsmith-migrator resume",
+                    )
+                self.mark_blocked(
+                    item_id,
+                    "prompt_migration_failed",
+                    next_action="Re-run `langsmith-migrator resume` after reviewing the error.",
+                    evidence={"error": error_msg},
+                )
 
             if self.config.migration.verbose:
                 import traceback

--- a/langsmith_migrator/core/migrators/rules.py
+++ b/langsmith_migrator/core/migrators/rules.py
@@ -6,6 +6,7 @@ from langsmith import Client
 
 from .base import BaseMigrator
 from ..api_client import NotFoundError
+from ...utils.matching import unique_name_map
 
 
 class RulesMigrator(BaseMigrator):
@@ -22,6 +23,7 @@ class RulesMigrator(BaseMigrator):
 
         # Initialize LangSmith client for checking prompts
         self.dest_ls_client = None
+        self._dest_session = requests.Session()
         try:
             self._init_ls_client()
         except Exception as e:
@@ -53,17 +55,49 @@ class RulesMigrator(BaseMigrator):
         dest_kwargs = {
             "api_key": self.config.destination.api_key,
             "api_url": self._get_api_url(self.config.destination.base_url),
-            "info": {}
+            "info": {},
+            "session": self._dest_session,
         }
 
         if not self.config.destination.verify_ssl:
             import urllib3
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-            session = requests.Session()
-            session.verify = False
-            dest_kwargs["session"] = session
+            self._dest_session.verify = False
 
         self.dest_ls_client = Client(**dest_kwargs)
+
+    def _sync_workspace_headers(self) -> None:
+        """Sync X-Tenant-Id from the destination API client to the SDK session."""
+        ws_id = self.dest.session.headers.get("X-Tenant-Id")
+        if ws_id:
+            self._dest_session.headers["X-Tenant-Id"] = ws_id
+        else:
+            self._dest_session.headers.pop("X-Tenant-Id", None)
+
+    def _iter_dest_prompt_repos(self, *, limit: int = 100):
+        """Yield destination prompt repos with pagination support."""
+        if not self.dest_ls_client:
+            return
+
+        self._sync_workspace_headers()
+        for visibility in (False, True):
+            offset = 0
+            while True:
+                response = self.dest_ls_client.list_prompts(
+                    limit=limit,
+                    offset=offset,
+                    is_public=visibility,
+                )
+                repos = list(getattr(response, "repos", []) or [])
+                if not repos:
+                    break
+
+                for prompt in repos:
+                    yield prompt
+
+                if len(repos) < limit:
+                    break
+                offset += len(repos)
 
     def _find_existing_prompt(self, prompt_handle: str) -> bool:
         """Check if a prompt exists in destination."""
@@ -71,17 +105,91 @@ class RulesMigrator(BaseMigrator):
             return False
 
         try:
-            # Try to list prompts and find a match by repo_handle
-            # We iterate because accessing directly might fail or require different permissions
-            response = self.dest_ls_client.list_prompts(limit=100)
-            if response and hasattr(response, 'repos'):
-                for prompt in response.repos:
-                    if prompt.repo_handle == prompt_handle:
-                        return True
+            for prompt in self._iter_dest_prompt_repos():
+                if prompt.repo_handle == prompt_handle:
+                    return True
             return False
         except Exception as e:
             self.log(f"Failed to check prompt existence for {prompt_handle}: {e}", "warning")
             return False
+
+    def _rule_item_id(self, rule: Dict[str, Any]) -> str:
+        return f"rule_{rule.get('id', rule.get('display_name', 'unnamed'))}"
+
+    def probe_capabilities(self) -> Dict[str, Dict[str, Any]]:
+        """Probe rules-related capabilities without mutating destination state."""
+        capabilities: Dict[str, Dict[str, Any]] = {}
+
+        def record(name: str, supported: Optional[bool], detail: str) -> None:
+            capabilities[name] = {"supported": supported, "detail": detail}
+            self.record_capability(
+                "rules",
+                name,
+                supported=supported,
+                detail=detail,
+                probe="/runs/rules",
+            )
+
+        try:
+            iterator = iter(self.dest.get_paginated(self._get_rules_endpoint(), params={"limit": 1}))
+            next(iterator, None)
+            record("rules_read", True, "ok")
+        except Exception as e:
+            record("rules_read", False, str(e))
+
+        record("rules_write", None, "deferred_until_first_write")
+        return capabilities
+
+    def _normalize_rule_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize a rule payload for verification."""
+        normalized = {}
+        for key, value in payload.items():
+            if key in {"evaluators", "code_evaluators"} and isinstance(value, list):
+                normalized[key] = self._clean_none_values(value)
+            elif value is not None:
+                normalized[key] = value
+        return normalized
+
+    def _verify_rule(self, rule_id: str, payload: Dict[str, Any]) -> tuple[bool, Dict[str, Any]]:
+        """Verify created or updated rule fields by refetching the resource."""
+        try:
+            actual = self.dest.get(f"{self._get_rules_endpoint()}/{rule_id}")
+        except Exception as e:
+            return False, {"error": str(e)}
+
+        mismatches = {}
+        for key, expected in self._normalize_rule_payload(payload).items():
+            actual_value = actual.get(key)
+            if actual_value != expected:
+                mismatches[key] = {"expected": expected, "actual": actual_value}
+        return not mismatches, mismatches
+
+    def _export_rule_manual_apply(
+        self,
+        rule: Dict[str, Any],
+        payload: Dict[str, Any],
+        *,
+        reason: str,
+        unmet_dependencies: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Export a normalized rule payload for manual apply."""
+        item_id = self._rule_item_id(rule)
+        return self.export_payload(
+            item_id,
+            "manual_apply",
+            {
+                "rule_id": rule.get("id"),
+                "display_name": rule.get("display_name") or rule.get("name"),
+                "reason": reason,
+                "unmet_dependencies": unmet_dependencies or {},
+                "payload": self._normalize_rule_payload(payload),
+                "manual_steps": [
+                    "Resolve the unmet dependencies listed in this artifact.",
+                    "Create or update the rule with the exported payload.",
+                    "Re-run `langsmith-migrator resume` after the rule exists on destination.",
+                ],
+            },
+        )
 
     def _fetch_prompt_manifest(self, prompt_handle: str, commit: str = "latest", from_source: bool = True) -> Optional[Dict[str, Any]]:
         """
@@ -286,46 +394,72 @@ class RulesMigrator(BaseMigrator):
         self._project_id_map = {}
 
         try:
-            # Get all projects from source (store full objects for potential creation)
-            source_projects = {}  # name -> full project dict
-            source_projects_by_id = {}  # id -> full project dict
+            source_records: List[Dict[str, Any]] = []
             for project in self.source.get_paginated("/sessions", page_size=100):
                 if isinstance(project, dict):
-                    source_projects[project['name']] = project
-                    source_projects_by_id[project['id']] = project
+                    source_records.append(project)
 
-            # Get all projects from destination
-            dest_projects = {}  # name -> project id
+            dest_records: List[Dict[str, Any]] = []
             for project in self.dest.get_paginated("/sessions", page_size=100):
                 if isinstance(project, dict):
-                    dest_projects[project['name']] = project['id']
+                    dest_records.append(project)
 
-            # Build mapping by matching names
+            _, source_duplicates = unique_name_map(source_records)
+            dest_unique, dest_duplicates = unique_name_map(dest_records)
             existing_count = 0
             created_count = 0
 
-            for name, source_project in source_projects.items():
-                source_id = source_project['id']
+            for source_project in source_records:
+                source_id = source_project["id"]
+                source_name = source_project["name"]
 
-                if name in dest_projects:
-                    # Project exists in both - create mapping
-                    self._project_id_map[source_id] = dest_projects[name]
-                    self.log(f"Mapped project '{name}': {source_id} -> {dest_projects[name]}", "info")
+                if self.state and self.state.get_mapped_id("project", source_id):
+                    mapped_id = self.state.get_mapped_id("project", source_id)
+                    self._project_id_map[source_id] = mapped_id
+                    self.record_provenance(f"project:{source_id}", "state_mapping")
+                    continue
+
+                if source_name in source_duplicates:
+                    self.log(
+                        f"Project '{source_name}' is duplicated on source; skipping automatic mapping",
+                        "warning",
+                    )
+                    continue
+                if source_name in dest_duplicates:
+                    self.log(
+                        f"Project '{source_name}' is duplicated on destination; skipping automatic mapping",
+                        "warning",
+                    )
+                    continue
+
+                if source_name in dest_unique:
+                    self._project_id_map[source_id] = dest_unique[source_name]
+                    self.record_provenance(f"project:{source_id}", "exact_name_match")
+                    self.log(
+                        f"Mapped project '{source_name}': {source_id} -> {dest_unique[source_name]}",
+                        "info",
+                    )
                     existing_count += 1
                 elif create_missing:
-                    # Project missing in destination - create it
-                    self.log(f"Project '{name}' not found in destination, creating...", "info")
+                    self.log(f"Project '{source_name}' not found in destination, creating...", "info")
                     new_project = self._create_project(source_project)
                     if new_project:
-                        self._project_id_map[source_id] = new_project['id']
-                        self.log(f"Mapped project '{name}': {source_id} -> {new_project['id']}", "info")
+                        self._project_id_map[source_id] = new_project["id"]
+                        self.record_provenance(f"project:{source_id}", "created_on_destination")
+                        self.log(
+                            f"Mapped project '{source_name}': {source_id} -> {new_project['id']}",
+                            "info",
+                        )
                         created_count += 1
                     else:
-                        self.log(f"Failed to create project '{name}' in destination", "error")
+                        self.log(f"Failed to create project '{source_name}' in destination", "error")
 
             total_mapped = len(self._project_id_map)
             if created_count > 0:
-                self.log(f"Built project mapping: {existing_count} existing, {created_count} created, {total_mapped} total", "success")
+                self.log(
+                    f"Built project mapping: {existing_count} existing, {created_count} created, {total_mapped} total",
+                    "success",
+                )
             else:
                 self.log(f"Built project mapping: {total_mapped} projects mapped", "success")
 
@@ -349,23 +483,43 @@ class RulesMigrator(BaseMigrator):
         self._dataset_id_map = {}
 
         try:
-            # Get all datasets from source
-            source_datasets = {}
+            source_records: List[Dict[str, Any]] = []
             for dataset in self.source.get_paginated("/datasets", page_size=100):
                 if isinstance(dataset, dict):
-                    source_datasets[dataset['name']] = dataset['id']
+                    source_records.append(dataset)
 
-            # Get all datasets from destination
-            dest_datasets = {}
+            dest_records: List[Dict[str, Any]] = []
             for dataset in self.dest.get_paginated("/datasets", page_size=100):
                 if isinstance(dataset, dict):
-                    dest_datasets[dataset['name']] = dataset['id']
+                    dest_records.append(dataset)
 
-            # Build mapping by matching names
-            for name, source_id in source_datasets.items():
-                if name in dest_datasets:
-                    self._dataset_id_map[source_id] = dest_datasets[name]
-                    self.log(f"Mapped dataset '{name}': {source_id} -> {dest_datasets[name]}", "info")
+            _, source_duplicates = unique_name_map(source_records)
+            dest_unique, dest_duplicates = unique_name_map(dest_records)
+
+            for dataset in source_records:
+                source_id = dataset["id"]
+                dataset_name = dataset["name"]
+
+                if self.state and self.state.get_mapped_id("dataset", source_id):
+                    mapped_id = self.state.get_mapped_id("dataset", source_id)
+                    self._dataset_id_map[source_id] = mapped_id
+                    self.record_provenance(f"dataset:{source_id}", "state_mapping")
+                    continue
+
+                if dataset_name in source_duplicates or dataset_name in dest_duplicates:
+                    self.log(
+                        f"Dataset '{dataset_name}' is duplicated; skipping automatic exact-name mapping",
+                        "warning",
+                    )
+                    continue
+
+                if dataset_name in dest_unique:
+                    self._dataset_id_map[source_id] = dest_unique[dataset_name]
+                    self.record_provenance(f"dataset:{source_id}", "exact_name_match")
+                    self.log(
+                        f"Mapped dataset '{dataset_name}': {source_id} -> {dest_unique[dataset_name]}",
+                        "info",
+                    )
 
             self.log(f"Built dataset mapping: {len(self._dataset_id_map)} datasets matched", "success")
 
@@ -597,6 +751,16 @@ class RulesMigrator(BaseMigrator):
                 self.log(f"Warning: Rule {rule_id} missing display_name/name, using: {display_name}", "warning")
                 self.log(f"Available fields in rule: {list(rule.keys())}", "info")
 
+            item_id = self._rule_item_id(rule)
+            self.ensure_item(
+                item_id,
+                "rule",
+                display_name,
+                rule.get("id", display_name),
+                stage="planning",
+                metadata={"display_name": display_name},
+            )
+
             # Build dataset mapping to map add_to_dataset_id
             dataset_map = self.build_dataset_mapping()
             source_add_to_dataset_id = rule.get('add_to_dataset_id')
@@ -716,6 +880,36 @@ class RulesMigrator(BaseMigrator):
                     self.log("    1. The prompt on source doesn't have a model (simple prompt, not RunnableSequence)", "error")
                     self.log("    2. Or the prompt migration didn't include the model", "error")
                     self.log("  Skipping this rule - it will fail validation without a model", "error")
+                    export_path = self._export_rule_manual_apply(
+                        rule,
+                        payload,
+                        reason="missing_evaluator_model",
+                        unmet_dependencies={"prompt_handle": prompt_handle},
+                    )
+                    issue = self.record_issue(
+                        "dependency",
+                        "missing_evaluator_model",
+                        f"Rule '{display_name}' is missing evaluator model configuration",
+                        item_id=item_id,
+                        next_action="Migrate the evaluator prompt with model config, then run `langsmith-migrator resume`.",
+                        evidence={"prompt_handle": prompt_handle},
+                        export_path=export_path,
+                    )
+                    if issue:
+                        self.queue_remediation(
+                            issue_id=issue.id,
+                            item_id=item_id,
+                            next_action=issue.next_action or "Resolve evaluator prompt dependency.",
+                            export_path=export_path,
+                            command="langsmith-migrator resume",
+                        )
+                    self.mark_exported(
+                        item_id,
+                        "missing_evaluator_model",
+                        next_action="Resolve the evaluator prompt model config, then run `langsmith-migrator resume`.",
+                        export_path=export_path,
+                        evidence={"prompt_handle": prompt_handle},
+                    )
                     return None
 
                 # Check if prompt exists on destination (for informational purposes)
@@ -764,6 +958,37 @@ class RulesMigrator(BaseMigrator):
                     for prompt in actually_missing:
                         self.log(f"  - {prompt}", "warning")
                     self.log("Run 'langsmith-migrator prompts' first to migrate prompts", "warning")
+                    export_path = self._export_rule_manual_apply(
+                        rule,
+                        payload,
+                        reason="missing_prompt_dependencies",
+                        unmet_dependencies={"prompts": actually_missing},
+                    )
+                    issue = self.record_issue(
+                        "dependency",
+                        "missing_prompt_dependencies",
+                        f"Rule '{display_name}' references prompts that do not exist on destination",
+                        item_id=item_id,
+                        next_action="Migrate the missing prompts, then run `langsmith-migrator resume`.",
+                        evidence={"prompts": actually_missing},
+                        export_path=export_path,
+                    )
+                    if issue:
+                        self.queue_remediation(
+                            issue_id=issue.id,
+                            item_id=item_id,
+                            next_action=issue.next_action or "Migrate prompt dependencies.",
+                            export_path=export_path,
+                            command="langsmith-migrator resume",
+                        )
+                    self.mark_exported(
+                        item_id,
+                        "missing_prompt_dependencies",
+                        next_action="Migrate the missing prompts, then run `langsmith-migrator resume`.",
+                        export_path=export_path,
+                        evidence={"prompts": actually_missing},
+                    )
+                    return None
 
             # Copy code_evaluators array directly (contains code evaluator configs)
             # Each code evaluator has: { code: str, language?: 'python' | 'javascript' }
@@ -819,9 +1044,51 @@ class RulesMigrator(BaseMigrator):
                 elif source_dataset_id:
                     self.log(f"Warning: Dataset {source_dataset_id} not found in destination", "warning")
                     self.log("Cannot migrate rule without valid dataset or project", "warning")
+                    export_path = self._export_rule_manual_apply(
+                        rule,
+                        payload,
+                        reason="missing_dataset_dependency",
+                        unmet_dependencies={"dataset_id": source_dataset_id},
+                    )
+                    issue = self.record_issue(
+                        "dependency",
+                        "missing_dataset_dependency",
+                        f"Rule '{display_name}' could not resolve dataset {source_dataset_id}",
+                        item_id=item_id,
+                        next_action="Migrate or map the missing dataset, then run `langsmith-migrator resume`.",
+                        evidence={"dataset_id": source_dataset_id},
+                        export_path=export_path,
+                    )
+                    if issue:
+                        self.queue_remediation(
+                            issue_id=issue.id,
+                            item_id=item_id,
+                            next_action=issue.next_action or "Resolve dataset dependency.",
+                            export_path=export_path,
+                            command="langsmith-migrator resume",
+                        )
+                    self.mark_exported(
+                        item_id,
+                        "missing_dataset_dependency",
+                        next_action="Resolve the dataset dependency, then run `langsmith-migrator resume`.",
+                        export_path=export_path,
+                        evidence={"dataset_id": source_dataset_id},
+                    )
                     return None
                 else:
                     self.log(f"Warning: Cannot strip project from rule '{display_name}' - no dataset_id to use instead", "warning")
+                    export_path = self._export_rule_manual_apply(
+                        rule,
+                        payload,
+                        reason="strip_projects_requires_dataset",
+                    )
+                    self.mark_exported(
+                        item_id,
+                        "strip_projects_requires_dataset",
+                        next_action="Provide a dataset mapping or keep the project association, then run `langsmith-migrator resume`.",
+                        export_path=export_path,
+                        evidence={"display_name": display_name},
+                    )
                     return None
                 endpoint = base_endpoint
             elif target_project_id:
@@ -850,6 +1117,41 @@ class RulesMigrator(BaseMigrator):
                         self.log(f"  Dataset {source_dataset_id} not found in destination", "error")
                     if not source_session_id and not source_dataset_id:
                         self.log("  Rule has neither session_id nor dataset_id in source", "error")
+                    unmet_dependencies = {}
+                    if source_session_id and not dest_session_id:
+                        unmet_dependencies["project_id"] = source_session_id
+                    if source_dataset_id and not dest_dataset_id:
+                        unmet_dependencies["dataset_id"] = source_dataset_id
+                    export_path = self._export_rule_manual_apply(
+                        rule,
+                        payload,
+                        reason="unresolved_rule_dependencies",
+                        unmet_dependencies=unmet_dependencies,
+                    )
+                    issue = self.record_issue(
+                        "dependency",
+                        "unresolved_rule_dependencies",
+                        f"Rule '{display_name}' could not resolve its project/dataset dependencies",
+                        item_id=item_id,
+                        next_action="Provide explicit mappings or migrate the missing dependencies, then run `langsmith-migrator resume`.",
+                        evidence=unmet_dependencies,
+                        export_path=export_path,
+                    )
+                    if issue:
+                        self.queue_remediation(
+                            issue_id=issue.id,
+                            item_id=item_id,
+                            next_action=issue.next_action or "Resolve rule dependencies.",
+                            export_path=export_path,
+                            command="langsmith-migrator resume",
+                        )
+                    self.mark_exported(
+                        item_id,
+                        "unresolved_rule_dependencies",
+                        next_action="Resolve the exported dependency issues, then run `langsmith-migrator resume`.",
+                        export_path=export_path,
+                        evidence=unmet_dependencies,
+                    )
                     return None
 
                 endpoint = base_endpoint
@@ -862,10 +1164,46 @@ class RulesMigrator(BaseMigrator):
             if existing_id:
                 if self.config.migration.skip_existing:
                     self.log(f"Rule '{display_name}' already exists, skipping", "warning")
+                    self.mark_migrated(
+                        item_id,
+                        outcome_code="rule_already_exists",
+                        evidence={"rule_id": existing_id},
+                    )
                     return existing_id
                 else:
                     self.log(f"Rule '{display_name}' exists, updating...", "info")
                     result = self.update_rule(existing_id, payload)
+                    if result:
+                        verified, mismatches = self._verify_rule(existing_id, payload)
+                        if verified:
+                            self.checkpoint_item(item_id, stage="completed", destination_id=existing_id)
+                            self.mark_migrated(
+                                item_id,
+                                outcome_code="rule_updated",
+                                evidence={"rule_id": existing_id},
+                            )
+                        else:
+                            issue = self.record_issue(
+                                "post_write_verification",
+                                "rule_update_verification_failed",
+                                f"Rule '{display_name}' did not match the requested payload after update",
+                                item_id=item_id,
+                                next_action="Review the verification mismatches in the remediation bundle, then re-run resume.",
+                                evidence=mismatches,
+                            )
+                            if issue:
+                                self.queue_remediation(
+                                    issue_id=issue.id,
+                                    item_id=item_id,
+                                    next_action=issue.next_action or "Review rule update mismatches.",
+                                    command="langsmith-migrator resume",
+                                )
+                            self.mark_degraded(
+                                item_id,
+                                "rule_update_verification_mismatch",
+                                next_action="Review rule field mismatches in the remediation bundle.",
+                                evidence=mismatches,
+                            )
                     return result  # Will be existing_id on success, None on failure
 
             # Filter payload to only include valid CREATE fields per API spec
@@ -905,12 +1243,49 @@ class RulesMigrator(BaseMigrator):
                 raise APIError(f"Invalid response creating rule: missing 'id' field. Response: {response}")
 
             self.log(f"Created rule: {display_name} -> {rule_id}", "success")
+            self.record_capability(
+                "rules",
+                "rules_write",
+                supported=True,
+                detail="write_succeeded",
+            )
+            verified, mismatches = self._verify_rule(rule_id, create_payload)
+            self.checkpoint_item(item_id, destination_id=rule_id, stage="completed")
+            if verified:
+                self.mark_migrated(
+                    item_id,
+                    outcome_code="rule_migrated",
+                    evidence={"rule_id": rule_id},
+                )
+            else:
+                issue = self.record_issue(
+                    "post_write_verification",
+                    "rule_create_verification_failed",
+                    f"Rule '{display_name}' did not match the requested payload after creation",
+                    item_id=item_id,
+                    next_action="Review the verification mismatches in the remediation bundle, then re-run resume.",
+                    evidence=mismatches,
+                )
+                if issue:
+                    self.queue_remediation(
+                        issue_id=issue.id,
+                        item_id=item_id,
+                        next_action=issue.next_action or "Review rule verification mismatches.",
+                        command="langsmith-migrator resume",
+                    )
+                self.mark_degraded(
+                    item_id,
+                    "rule_create_verification_mismatch",
+                    next_action="Review rule field mismatches in the remediation bundle.",
+                    evidence=mismatches,
+                )
             return rule_id
 
         except Exception as e:
             rule_name = rule.get('display_name') or rule.get('name', 'unnamed')
             error_str = str(e)
             self.log(f"Failed to create rule {rule_name}: {e}", "error")
+            current_payload = locals().get("payload", {})
 
             # Provide specific guidance for common errors
             if "RunnableSequence must have at least 2 steps" in error_str:
@@ -940,10 +1315,42 @@ class RulesMigrator(BaseMigrator):
                 self.log("", "error")
                 self.log("Run 'langsmith-migrator prompts' first to ensure prompts are migrated", "error")
 
+            export_path = self._export_rule_manual_apply(
+                rule,
+                current_payload or {"display_name": rule_name},
+                reason="rule_migration_failed",
+                unmet_dependencies={"error": error_str},
+            )
+            issue = self.record_issue(
+                "transient",
+                "rule_migration_failed",
+                f"Rule migration failed for '{rule_name}'",
+                item_id=locals().get("item_id"),
+                next_action="Review the exported rule payload, then run `langsmith-migrator resume`.",
+                evidence={"error": error_str},
+                export_path=export_path,
+            )
+            if issue:
+                self.queue_remediation(
+                    issue_id=issue.id,
+                    item_id=locals().get("item_id"),
+                    next_action=issue.next_action or "Review exported rule payload.",
+                    export_path=export_path,
+                    command="langsmith-migrator resume",
+                )
+            if locals().get("item_id"):
+                self.mark_exported(
+                    locals()["item_id"],
+                    "rule_migration_failed",
+                    next_action="Review the exported rule payload, then run `langsmith-migrator resume`.",
+                    export_path=export_path,
+                    evidence={"error": error_str},
+                )
+
             if self.config.migration.verbose:
-                self.log(f"Payload that failed: {list(payload.keys())}", "info")
-                if payload.get('evaluators'):
-                    self.log(f"Evaluators in payload: {payload['evaluators']}", "info")
+                self.log(f"Payload that failed: {list(current_payload.keys())}", "info")
+                if current_payload.get('evaluators'):
+                    self.log(f"Evaluators in payload: {current_payload['evaluators']}", "info")
             return None
 
     def migrate_rule(

--- a/langsmith_migrator/utils/config.py
+++ b/langsmith_migrator/utils/config.py
@@ -29,6 +29,8 @@ class MigrationConfig:
     skip_existing: bool = False
     resume_on_error: bool = True
     verbose: bool = False
+    interactive: bool = True
+    non_interactive: bool = False
 
     # Performance settings
     stream_examples: bool = True  # Stream instead of loading all into memory
@@ -49,7 +51,8 @@ class Config:
                  concurrent_workers: Optional[int] = None,
                  dry_run: bool = False,
                  skip_existing: Optional[bool] = None,
-                 verbose: bool = False):
+                 verbose: bool = False,
+                 non_interactive: bool = False):
         """
         Initialize configuration from CLI args, falling back to environment variables.
 
@@ -64,6 +67,7 @@ class Config:
             dry_run: Whether to run in dry-run mode
             skip_existing: If True, skip existing resources; if False, update them (overrides env)
             verbose: Whether to enable verbose logging
+            non_interactive: Disable guided remediation prompts
         """
         # Determine SSL verification setting
         # Priority: CLI arg > env var > default (True)
@@ -114,10 +118,13 @@ class Config:
             dry_run=dry_run or os.getenv('MIGRATION_DRY_RUN', 'false').lower() == 'true',
             verbose=verbose or os.getenv('MIGRATION_VERBOSE', 'false').lower() == 'true',
             skip_existing=should_skip,
+            interactive=not non_interactive,
+            non_interactive=non_interactive,
             stream_examples=os.getenv('MIGRATION_STREAM_EXAMPLES', 'true').lower() != 'false',
             chunk_size=parsed_chunk_size,
             rate_limit_delay=parsed_rate_limit
         )
+        self.state_manager = None
 
         # Disable SSL warnings if needed
         if not self.source.verify_ssl or not self.destination.verify_ssl:

--- a/langsmith_migrator/utils/matching.py
+++ b/langsmith_migrator/utils/matching.py
@@ -1,0 +1,35 @@
+"""Helpers for duplicate-aware exact-name matching."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, Iterable, List, Tuple
+
+
+def build_name_buckets(
+    records: Iterable[dict],
+    *,
+    name_key: str = "name",
+    id_key: str = "id",
+) -> Dict[str, List[str]]:
+    """Index records by exact name, preserving duplicates."""
+    buckets: Dict[str, List[str]] = defaultdict(list)
+    for record in records:
+        name = record.get(name_key)
+        record_id = record.get(id_key)
+        if name and record_id:
+            buckets[name].append(record_id)
+    return dict(buckets)
+
+
+def unique_name_map(
+    records: Iterable[dict],
+    *,
+    name_key: str = "name",
+    id_key: str = "id",
+) -> Tuple[Dict[str, str], Dict[str, List[str]]]:
+    """Return unique exact-name matches and a duplicate index."""
+    buckets = build_name_buckets(records, name_key=name_key, id_key=id_key)
+    unique = {name: ids[0] for name, ids in buckets.items() if len(ids) == 1}
+    duplicates = {name: ids for name, ids in buckets.items() if len(ids) > 1}
+    return unique, duplicates

--- a/langsmith_migrator/utils/state.py
+++ b/langsmith_migrator/utils/state.py
@@ -1,15 +1,21 @@
-"""Migration state management for resume capability."""
+"""Migration state management for resume capability and remediation workflows."""
+
+from __future__ import annotations
 
 import json
+import shutil
+import re
 import time
-from pathlib import Path
-from typing import Dict, List, Any, Optional
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
 
 
 class MigrationStatus(Enum):
     """Status of a migration item."""
+
     PENDING = "pending"
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
@@ -17,9 +23,155 @@ class MigrationStatus(Enum):
     SKIPPED = "skipped"
 
 
+class ResolutionOutcome(Enum):
+    """Terminal resolution state for a migration item."""
+
+    MIGRATED = "migrated"
+    MIGRATED_WITH_VERIFIED_DOWNGRADE = "migrated_with_verified_downgrade"
+    BLOCKED_WITH_CHECKPOINT = "blocked_with_checkpoint"
+    EXPORTED_WITH_MANUAL_APPLY = "exported_with_manual_apply"
+
+
+class VerificationState(Enum):
+    """Verification status for a migration item."""
+
+    PENDING = "pending"
+    VERIFIED = "verified"
+    DEGRADED = "degraded"
+    BLOCKED = "blocked"
+    EXPORTED = "exported"
+
+
+class IssueClass(Enum):
+    """Typed incident classes for resolver workflows."""
+
+    TRANSIENT = "transient"
+    CAPABILITY = "capability"
+    DEPENDENCY = "dependency"
+    AMBIGUITY = "ambiguity"
+    SOURCE_DATA_GAP = "source_data_gap"
+    POST_WRITE_VERIFICATION = "post_write_verification"
+
+
+REPAIR_POLICIES = {
+    IssueClass.TRANSIENT.value: "auto_retry_with_backoff",
+    IssueClass.CAPABILITY.value: "switch_strategy_or_export_manual_apply",
+    IssueClass.DEPENDENCY.value: "auto_repair_if_deterministic_otherwise_guided_remediation",
+    IssueClass.AMBIGUITY.value: "require_explicit_operator_choice",
+    IssueClass.SOURCE_DATA_GAP.value: "attempt_enrichment_once_then_export_missing_fields",
+    IssueClass.POST_WRITE_VERIFICATION.value: "retry_verification_once_then_mark_degraded_or_blocked",
+}
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _safe_name(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("._")
+    return cleaned or "artifact"
+
+
+@dataclass
+class MigrationIssue:
+    """A typed issue captured during migration resolution."""
+
+    id: str
+    issue_class: str
+    code: str
+    summary: str
+    repair_policy: str
+    created_at: float
+    item_id: Optional[str] = None
+    next_action: Optional[str] = None
+    evidence: Dict[str, Any] = field(default_factory=dict)
+    workspace_pair: Dict[str, Optional[str]] = field(default_factory=dict)
+    export_path: Optional[str] = None
+    resolved: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "issue_class": self.issue_class,
+            "code": self.code,
+            "summary": self.summary,
+            "repair_policy": self.repair_policy,
+            "created_at": self.created_at,
+            "item_id": self.item_id,
+            "next_action": self.next_action,
+            "evidence": self.evidence,
+            "workspace_pair": self.workspace_pair,
+            "export_path": self.export_path,
+            "resolved": self.resolved,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "MigrationIssue":
+        return cls(
+            id=data["id"],
+            issue_class=data["issue_class"],
+            code=data["code"],
+            summary=data["summary"],
+            repair_policy=data.get(
+                "repair_policy",
+                REPAIR_POLICIES.get(data.get("issue_class", ""), "manual_review"),
+            ),
+            created_at=data.get("created_at", _now()),
+            item_id=data.get("item_id"),
+            next_action=data.get("next_action"),
+            evidence=data.get("evidence", {}),
+            workspace_pair=data.get("workspace_pair", {}),
+            export_path=data.get("export_path"),
+            resolved=data.get("resolved", False),
+        )
+
+
+@dataclass
+class RemediationTask:
+    """A resumable remediation task derived from a migration issue."""
+
+    id: str
+    item_id: Optional[str]
+    issue_id: str
+    next_action: str
+    created_at: float
+    status: str = "pending"
+    export_path: Optional[str] = None
+    command: Optional[str] = None
+    requires_interaction: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "item_id": self.item_id,
+            "issue_id": self.issue_id,
+            "next_action": self.next_action,
+            "created_at": self.created_at,
+            "status": self.status,
+            "export_path": self.export_path,
+            "command": self.command,
+            "requires_interaction": self.requires_interaction,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RemediationTask":
+        return cls(
+            id=data["id"],
+            item_id=data.get("item_id"),
+            issue_id=data["issue_id"],
+            next_action=data["next_action"],
+            created_at=data.get("created_at", _now()),
+            status=data.get("status", "pending"),
+            export_path=data.get("export_path"),
+            command=data.get("command"),
+            requires_interaction=data.get("requires_interaction", False),
+        )
+
+
 @dataclass
 class MigrationItem:
     """Represents an item being migrated."""
+
     id: str
     type: str  # dataset, experiment, queue, prompt, etc.
     name: str
@@ -30,6 +182,21 @@ class MigrationItem:
     attempts: int = 0
     last_attempt: Optional[float] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
+    resource_type: Optional[str] = None
+    stage: str = "pending"
+    workspace_pair: Dict[str, Optional[str]] = field(default_factory=dict)
+    dependencies: List[str] = field(default_factory=list)
+    strategy: Optional[str] = None
+    outcome_code: Optional[str] = None
+    terminal_state: Optional[str] = None
+    next_action: Optional[str] = None
+    evidence: Dict[str, Any] = field(default_factory=dict)
+    export_path: Optional[str] = None
+    verification_state: str = VerificationState.PENDING.value
+
+    def __post_init__(self) -> None:
+        if self.resource_type is None:
+            self.resource_type = self.type
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""
@@ -43,11 +210,22 @@ class MigrationItem:
             "error": self.error,
             "attempts": self.attempts,
             "last_attempt": self.last_attempt,
-            "metadata": self.metadata
+            "metadata": self.metadata,
+            "resource_type": self.resource_type,
+            "stage": self.stage,
+            "workspace_pair": self.workspace_pair,
+            "dependencies": self.dependencies,
+            "strategy": self.strategy,
+            "outcome_code": self.outcome_code,
+            "terminal_state": self.terminal_state,
+            "next_action": self.next_action,
+            "evidence": self.evidence,
+            "export_path": self.export_path,
+            "verification_state": self.verification_state,
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'MigrationItem':
+    def from_dict(cls, data: Dict[str, Any]) -> "MigrationItem":
         """Create from dictionary."""
         return cls(
             id=data["id"],
@@ -59,29 +237,99 @@ class MigrationItem:
             error=data.get("error"),
             attempts=data.get("attempts", 0),
             last_attempt=data.get("last_attempt"),
-            metadata=data.get("metadata", {})
+            metadata=data.get("metadata", {}),
+            resource_type=data.get("resource_type"),
+            stage=data.get("stage", "pending"),
+            workspace_pair=data.get("workspace_pair", {}),
+            dependencies=data.get("dependencies", []),
+            strategy=data.get("strategy"),
+            outcome_code=data.get("outcome_code"),
+            terminal_state=data.get("terminal_state"),
+            next_action=data.get("next_action"),
+            evidence=data.get("evidence", {}),
+            export_path=data.get("export_path"),
+            verification_state=data.get(
+                "verification_state",
+                VerificationState.PENDING.value,
+            ),
         )
 
 
 @dataclass
 class MigrationState:
     """Tracks the state of an entire migration session."""
+
     session_id: str
     started_at: float
     updated_at: float
     source_url: str
     destination_url: str
     items: Dict[str, MigrationItem] = field(default_factory=dict)
-    id_mappings: Dict[str, Dict[str, str]] = field(default_factory=dict)  # type -> {source_id: dest_id}
+    id_mappings: Dict[str, Dict[str, str]] = field(default_factory=dict)
     statistics: Dict[str, int] = field(default_factory=dict)
     source_workspace_id: Optional[str] = None
     dest_workspace_id: Optional[str] = None
-    workspace_mapping: Dict[str, str] = field(default_factory=dict)  # source_ws_id -> dest_ws_id
+    workspace_mapping: Dict[str, str] = field(default_factory=dict)
+    schema_version: int = 2
+    capability_matrix: Dict[str, Any] = field(default_factory=dict)
+    inventory_snapshot: Dict[str, Any] = field(default_factory=dict)
+    dependency_graph: Dict[str, List[str]] = field(default_factory=dict)
+    issue_log: List[MigrationIssue] = field(default_factory=list)
+    remediation_queue: List[RemediationTask] = field(default_factory=list)
+    verification_summary: Dict[str, Any] = field(default_factory=dict)
+    remediation_bundle_path: Optional[str] = None
+    resolution_decisions: Dict[str, Any] = field(default_factory=dict)
+    resolution_provenance: Dict[str, Any] = field(default_factory=dict)
 
-    def add_item(self, item: MigrationItem):
-        """Add an item to track."""
+    def touch(self) -> None:
+        self.updated_at = _now()
+
+    def add_item(self, item: MigrationItem) -> MigrationItem:
+        """Add or replace an item to track."""
         self.items[item.id] = item
-        self.updated_at = time.time()
+        self.touch()
+        return item
+
+    def ensure_item(
+        self,
+        item_id: str,
+        item_type: str,
+        name: str,
+        source_id: str,
+        **kwargs: Any,
+    ) -> MigrationItem:
+        """Get or create a tracked item."""
+        if item_id in self.items:
+            item = self.items[item_id]
+            if kwargs.get("stage"):
+                item.stage = kwargs["stage"]
+            if kwargs.get("workspace_pair"):
+                item.workspace_pair = kwargs["workspace_pair"]
+            if kwargs.get("strategy"):
+                item.strategy = kwargs["strategy"]
+            if kwargs.get("dependencies"):
+                item.dependencies = kwargs["dependencies"]
+            if kwargs.get("metadata"):
+                item.metadata.update(kwargs["metadata"])
+            self.touch()
+            return item
+
+        item = MigrationItem(
+            id=item_id,
+            type=item_type,
+            name=name,
+            source_id=source_id,
+            resource_type=kwargs.get("resource_type", item_type),
+            stage=kwargs.get("stage", "pending"),
+            workspace_pair=kwargs.get("workspace_pair", {}),
+            dependencies=kwargs.get("dependencies", []),
+            strategy=kwargs.get("strategy"),
+            metadata=kwargs.get("metadata", {}),
+        )
+        return self.add_item(item)
+
+    def get_item(self, item_id: str) -> Optional[MigrationItem]:
+        return self.items.get(item_id)
 
     def get_mapped_id(self, item_type: str, source_id: str) -> Optional[str]:
         """Return the destination ID for a previously migrated item."""
@@ -92,31 +340,122 @@ class MigrationState:
         if item_type not in self.id_mappings:
             self.id_mappings[item_type] = {}
         self.id_mappings[item_type][source_id] = destination_id
-        self.updated_at = time.time()
+        self.touch()
 
-    def update_item_status(self, item_id: str, status: MigrationStatus,
-                          destination_id: Optional[str] = None, error: Optional[str] = None):
+    def update_item_status(
+        self,
+        item_id: str,
+        status: MigrationStatus,
+        destination_id: Optional[str] = None,
+        error: Optional[str] = None,
+        stage: Optional[str] = None,
+    ) -> None:
         """Update the status of an item."""
-        if item_id in self.items:
-            item = self.items[item_id]
-            item.status = status
-            item.last_attempt = time.time()
-            item.attempts += 1
+        if item_id not in self.items:
+            return
 
-            if destination_id:
-                item.destination_id = destination_id
-                self.set_mapped_id(item.type, item.source_id, destination_id)
+        item = self.items[item_id]
+        item.status = status
+        item.last_attempt = _now()
+        item.attempts += 1
 
-            if error:
-                item.error = error
+        if destination_id:
+            item.destination_id = destination_id
+            self.set_mapped_id(item.type, item.source_id, destination_id)
 
-            self.updated_at = time.time()
+        if error is not None:
+            item.error = error
 
-    def get_pending_items(self, item_type: Optional[str] = None) -> List[MigrationItem]:
+        if stage is not None:
+            item.stage = stage
+
+        self.touch()
+
+    def update_item_checkpoint(self, item_id: str, **kwargs: Any) -> None:
+        """Persist non-status checkpoint details for an item."""
+        item = self.items.get(item_id)
+        if not item:
+            return
+
+        for field_name in (
+            "destination_id",
+            "stage",
+            "strategy",
+            "next_action",
+            "outcome_code",
+            "terminal_state",
+            "export_path",
+            "verification_state",
+            "error",
+        ):
+            if field_name in kwargs and kwargs[field_name] is not None:
+                setattr(item, field_name, kwargs[field_name])
+
+        if "workspace_pair" in kwargs and kwargs["workspace_pair"] is not None:
+            item.workspace_pair = kwargs["workspace_pair"]
+        if "dependencies" in kwargs and kwargs["dependencies"] is not None:
+            item.dependencies = list(kwargs["dependencies"])
+        if "metadata" in kwargs and kwargs["metadata"] is not None:
+            item.metadata.update(kwargs["metadata"])
+        if "evidence" in kwargs and kwargs["evidence"] is not None:
+            item.evidence.update(kwargs["evidence"])
+
+        if item.destination_id:
+            self.set_mapped_id(item.type, item.source_id, item.destination_id)
+        self.touch()
+
+    def mark_terminal(
+        self,
+        item_id: str,
+        terminal_state: ResolutionOutcome,
+        outcome_code: str,
+        *,
+        verification_state: VerificationState,
+        next_action: Optional[str] = None,
+        evidence: Optional[Dict[str, Any]] = None,
+        export_path: Optional[str] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        """Mark an item with a terminal resolution state."""
+        item = self.items.get(item_id)
+        if not item:
+            return
+
+        item.terminal_state = terminal_state.value
+        item.outcome_code = outcome_code
+        item.verification_state = verification_state.value
+        item.next_action = next_action
+        item.export_path = export_path
+        if evidence:
+            item.evidence.update(evidence)
+        if error is not None:
+            item.error = error
+
+        if terminal_state in (
+            ResolutionOutcome.MIGRATED,
+            ResolutionOutcome.MIGRATED_WITH_VERIFIED_DOWNGRADE,
+        ):
+            item.status = MigrationStatus.COMPLETED
+        else:
+            item.status = MigrationStatus.SKIPPED
+
+        item.last_attempt = _now()
+        self.refresh_verification_summary()
+        self.touch()
+
+    def get_pending_items(
+        self,
+        item_type: Optional[str] = None,
+        include_in_progress: bool = False,
+    ) -> List[MigrationItem]:
         """Get all pending items, optionally filtered by type."""
+        statuses = {MigrationStatus.PENDING}
+        if include_in_progress:
+            statuses.add(MigrationStatus.IN_PROGRESS)
+
         items = []
         for item in self.items.values():
-            if item.status == MigrationStatus.PENDING:
+            if item.status in statuses:
                 if item_type is None or item.type == item_type:
                     items.append(item)
         return items
@@ -129,6 +468,141 @@ class MigrationState:
                 items.append(item)
         return items
 
+    def get_resume_items(self, max_attempts: int = 3) -> List[MigrationItem]:
+        """Return items that should be reconsidered by resume."""
+        items = self.get_pending_items(include_in_progress=True)
+        items.extend(self.get_failed_items(max_attempts=max_attempts))
+        return items
+
+    def get_checkpoint_items(self) -> List[MigrationItem]:
+        """Return items that landed in a checkpoint/export terminal state."""
+        items = []
+        for item in self.items.values():
+            if item.terminal_state in (
+                ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value,
+                ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY.value,
+            ):
+                items.append(item)
+        return items
+
+    def record_capability(
+        self,
+        scope: str,
+        capability: str,
+        *,
+        supported: Optional[bool],
+        detail: Optional[str] = None,
+        evidence: Optional[Dict[str, Any]] = None,
+        probe: Optional[str] = None,
+    ) -> None:
+        """Record the result of a capability probe."""
+        scope_entry = self.capability_matrix.setdefault(scope, {})
+        scope_entry[capability] = {
+            "supported": supported,
+            "detail": detail,
+            "evidence": evidence or {},
+            "probe": probe,
+            "recorded_at": _now(),
+        }
+        self.touch()
+
+    def record_inventory(self, key: str, value: Any) -> None:
+        """Store an inventory snapshot entry."""
+        self.inventory_snapshot[key] = value
+        self.touch()
+
+    def add_dependency(self, node: str, depends_on: str) -> None:
+        """Add a directed dependency edge."""
+        deps = self.dependency_graph.setdefault(node, [])
+        if depends_on not in deps:
+            deps.append(depends_on)
+            self.touch()
+
+    def set_dependency_graph(self, graph: Dict[str, List[str]]) -> None:
+        self.dependency_graph = graph
+        self.touch()
+
+    def record_resolution_decision(self, key: str, value: Any) -> None:
+        self.resolution_decisions[key] = value
+        self.touch()
+
+    def record_resolution_provenance(self, key: str, value: Any) -> None:
+        self.resolution_provenance[key] = value
+        self.touch()
+
+    def add_issue(
+        self,
+        issue_class: str,
+        code: str,
+        summary: str,
+        *,
+        item_id: Optional[str] = None,
+        next_action: Optional[str] = None,
+        evidence: Optional[Dict[str, Any]] = None,
+        workspace_pair: Optional[Dict[str, Optional[str]]] = None,
+        export_path: Optional[str] = None,
+        repair_policy: Optional[str] = None,
+    ) -> MigrationIssue:
+        """Record a typed issue."""
+        issue = MigrationIssue(
+            id=f"issue_{uuid4().hex}",
+            issue_class=issue_class,
+            code=code,
+            summary=summary,
+            repair_policy=repair_policy
+            or REPAIR_POLICIES.get(issue_class, "manual_review"),
+            created_at=_now(),
+            item_id=item_id,
+            next_action=next_action,
+            evidence=evidence or {},
+            workspace_pair=workspace_pair or {},
+            export_path=export_path,
+        )
+        self.issue_log.append(issue)
+        self.touch()
+        return issue
+
+    def queue_remediation(
+        self,
+        *,
+        issue_id: str,
+        next_action: str,
+        item_id: Optional[str] = None,
+        export_path: Optional[str] = None,
+        command: Optional[str] = None,
+        requires_interaction: bool = False,
+    ) -> RemediationTask:
+        """Queue a resumable remediation task."""
+        task = RemediationTask(
+            id=f"remediation_{uuid4().hex}",
+            item_id=item_id,
+            issue_id=issue_id,
+            next_action=next_action,
+            created_at=_now(),
+            export_path=export_path,
+            command=command,
+            requires_interaction=requires_interaction,
+        )
+        self.remediation_queue.append(task)
+        self.touch()
+        return task
+
+    def get_terminal_counts(self) -> Dict[str, int]:
+        counts = {outcome.value: 0 for outcome in ResolutionOutcome}
+        for item in self.items.values():
+            if item.terminal_state in counts:
+                counts[item.terminal_state] += 1
+        return counts
+
+    def refresh_verification_summary(self) -> None:
+        """Recompute verification counts."""
+        summary = {state.value: 0 for state in VerificationState}
+        for item in self.items.values():
+            if item.verification_state in summary:
+                summary[item.verification_state] += 1
+        summary["total"] = len(self.items)
+        self.verification_summary = summary
+
     def get_statistics(self) -> Dict[str, Any]:
         """Get migration statistics."""
         stats = {
@@ -138,7 +612,10 @@ class MigrationState:
             "pending": 0,
             "in_progress": 0,
             "skipped": 0,
-            "by_type": {}
+            "by_type": {},
+            "terminal": self.get_terminal_counts(),
+            "issues": len(self.issue_log),
+            "remediation_tasks": len(self.remediation_queue),
         }
 
         for item in self.items.values():
@@ -149,26 +626,127 @@ class MigrationState:
                     "total": 0,
                     "completed": 0,
                     "failed": 0,
-                    "pending": 0
+                    "pending": 0,
+                    "in_progress": 0,
+                    "skipped": 0,
                 }
 
             stats["by_type"][item.type]["total"] += 1
             stats["by_type"][item.type][item.status.value.lower()] += 1
 
-        # Calculate completion percentage
         if stats["total"] > 0:
             stats["completion_percentage"] = (stats["completed"] / stats["total"]) * 100
         else:
             stats["completion_percentage"] = 0
 
-        # Calculate elapsed time
         stats["elapsed_time"] = self.updated_at - self.started_at
-
+        self.refresh_verification_summary()
+        stats["verification"] = self.verification_summary
         return stats
+
+    def _bundle_dir(self) -> Optional[Path]:
+        if not self.remediation_bundle_path:
+            return None
+        return Path(self.remediation_bundle_path)
+
+    def ensure_bundle_dir(self) -> Optional[Path]:
+        """Ensure the remediation bundle directory exists."""
+        bundle_dir = self._bundle_dir()
+        if bundle_dir is None:
+            return None
+        bundle_dir.mkdir(parents=True, exist_ok=True)
+        (bundle_dir / "artifacts").mkdir(parents=True, exist_ok=True)
+        return bundle_dir
+
+    def export_artifact(
+        self,
+        item_id: str,
+        name: str,
+        payload: Any,
+        *,
+        extension: Optional[str] = None,
+    ) -> Optional[str]:
+        """Write a remediation artifact and return its absolute path."""
+        bundle_dir = self.ensure_bundle_dir()
+        if bundle_dir is None:
+            return None
+
+        item_safe = _safe_name(item_id)
+        name_safe = _safe_name(name)
+        if extension is None:
+            extension = "md" if isinstance(payload, str) else "json"
+
+        path = bundle_dir / "artifacts" / f"{item_safe}_{name_safe}.{extension}"
+        if isinstance(payload, str):
+            path.write_text(payload, encoding="utf-8")
+        else:
+            path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        return str(path.resolve())
+
+    def write_remediation_bundle(self) -> Optional[Path]:
+        """Refresh the remediation bundle files on disk."""
+        bundle_dir = self.ensure_bundle_dir()
+        if bundle_dir is None:
+            return None
+
+        issues_path = bundle_dir / "issues.json"
+        issues_path.write_text(
+            json.dumps([issue.to_dict() for issue in self.issue_log], indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+        state_items_path = bundle_dir / "items.json"
+        state_items_path.write_text(
+            json.dumps({key: item.to_dict() for key, item in self.items.items()}, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+        stats = self.get_statistics()
+        checkpoint_items = self.get_checkpoint_items()
+        resume_command = "langsmith-migrator resume"
+        lines = [
+            f"# Remediation Summary: {self.session_id}",
+            "",
+            f"- Session ID: `{self.session_id}`",
+            f"- Source: `{self.source_url}`",
+            f"- Destination: `{self.destination_url}`",
+            f"- Migrated: {stats['terminal'][ResolutionOutcome.MIGRATED.value]}",
+            f"- Verified downgrade: {stats['terminal'][ResolutionOutcome.MIGRATED_WITH_VERIFIED_DOWNGRADE.value]}",
+            f"- Blocked: {stats['terminal'][ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value]}",
+            f"- Exported/manual apply: {stats['terminal'][ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY.value]}",
+            f"- Issues: {len(self.issue_log)}",
+            f"- Remediation tasks: {len(self.remediation_queue)}",
+            f"- Resume command: `{resume_command}`",
+            "",
+        ]
+
+        if checkpoint_items:
+            lines.append("## Actionable Items")
+            lines.append("")
+            for item in checkpoint_items:
+                lines.append(f"- `{item.id}` ({item.type}): {item.outcome_code or 'needs_attention'}")
+                if item.next_action:
+                    lines.append(f"  Next: {item.next_action}")
+                if item.export_path:
+                    lines.append(f"  Artifact: `{item.export_path}`")
+            lines.append("")
+
+        if self.remediation_queue:
+            lines.append("## Remediation Queue")
+            lines.append("")
+            for task in self.remediation_queue:
+                lines.append(f"- `{task.id}`: {task.next_action}")
+                if task.command:
+                    lines.append(f"  Command: `{task.command}`")
+            lines.append("")
+
+        (bundle_dir / "summary.md").write_text("\n".join(lines), encoding="utf-8")
+        return bundle_dir
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""
         d = {
+            "schema_version": self.schema_version,
             "session_id": self.session_id,
             "started_at": self.started_at,
             "updated_at": self.updated_at,
@@ -177,6 +755,14 @@ class MigrationState:
             "items": {k: v.to_dict() for k, v in self.items.items()},
             "id_mappings": self.id_mappings,
             "statistics": self.get_statistics(),
+            "capability_matrix": self.capability_matrix,
+            "inventory_snapshot": self.inventory_snapshot,
+            "dependency_graph": self.dependency_graph,
+            "issue_log": [issue.to_dict() for issue in self.issue_log],
+            "remediation_queue": [task.to_dict() for task in self.remediation_queue],
+            "verification_summary": self.verification_summary,
+            "resolution_decisions": self.resolution_decisions,
+            "resolution_provenance": self.resolution_provenance,
         }
         if self.source_workspace_id:
             d["source_workspace_id"] = self.source_workspace_id
@@ -184,10 +770,12 @@ class MigrationState:
             d["dest_workspace_id"] = self.dest_workspace_id
         if self.workspace_mapping:
             d["workspace_mapping"] = self.workspace_mapping
+        if self.remediation_bundle_path:
+            d["remediation_bundle_path"] = self.remediation_bundle_path
         return d
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'MigrationState':
+    def from_dict(cls, data: Dict[str, Any]) -> "MigrationState":
         """Create from dictionary."""
         state = cls(
             session_id=data["session_id"],
@@ -199,11 +787,28 @@ class MigrationState:
             source_workspace_id=data.get("source_workspace_id"),
             dest_workspace_id=data.get("dest_workspace_id"),
             workspace_mapping=data.get("workspace_mapping", {}),
+            schema_version=max(data.get("schema_version", 1), 2),
+            capability_matrix=data.get("capability_matrix", {}),
+            inventory_snapshot=data.get("inventory_snapshot", {}),
+            dependency_graph=data.get("dependency_graph", {}),
+            verification_summary=data.get("verification_summary", {}),
+            remediation_bundle_path=data.get("remediation_bundle_path"),
+            resolution_decisions=data.get("resolution_decisions", {}),
+            resolution_provenance=data.get("resolution_provenance", {}),
         )
 
-        # Reconstruct items
         for item_id, item_data in data.get("items", {}).items():
             state.items[item_id] = MigrationItem.from_dict(item_data)
+
+        state.issue_log = [
+            MigrationIssue.from_dict(issue) for issue in data.get("issue_log", [])
+        ]
+        state.remediation_queue = [
+            RemediationTask.from_dict(task)
+            for task in data.get("remediation_queue", [])
+        ]
+        if not state.verification_summary:
+            state.refresh_verification_summary()
 
         return state
 
@@ -211,27 +816,43 @@ class MigrationState:
 class StateManager:
     """Manages migration state persistence."""
 
-    def __init__(self, state_dir: Optional[Path] = None):
+    def __init__(
+        self,
+        state_dir: Optional[Path] = None,
+        remediation_dir: Optional[Path] = None,
+    ):
         """
         Initialize state manager.
 
         Args:
-            state_dir: Directory for state files (default: ~/.langsmith-migrator/state)
+            state_dir: Directory for state files
+            remediation_dir: Directory for remediation bundles
         """
         self.state_dir = state_dir or Path.home() / ".langsmith-migrator" / "state"
         self.state_dir.mkdir(parents=True, exist_ok=True)
+        if remediation_dir is not None:
+            self.remediation_dir = remediation_dir
+        elif state_dir is not None:
+            self.remediation_dir = self.state_dir.parent / "remediation"
+        else:
+            self.remediation_dir = Path.cwd() / ".langsmith-migrator" / "remediation"
+        self.remediation_dir.mkdir(parents=True, exist_ok=True)
         self.current_state: Optional[MigrationState] = None
         self.state_file: Optional[Path] = None
 
+    def _default_bundle_path(self, session_id: str) -> Path:
+        return self.remediation_dir / session_id
+
     def create_session(self, source_url: str, destination_url: str) -> MigrationState:
         """Create a new migration session."""
-        session_id = f"migration_{int(time.time())}"
+        session_id = f"migration_{int(_now())}"
         self.current_state = MigrationState(
             session_id=session_id,
-            started_at=time.time(),
-            updated_at=time.time(),
+            started_at=_now(),
+            updated_at=_now(),
             source_url=source_url,
-            destination_url=destination_url
+            destination_url=destination_url,
+            remediation_bundle_path=str(self._default_bundle_path(session_id).resolve()),
         )
 
         self.state_file = self.state_dir / f"{session_id}.json"
@@ -246,10 +867,14 @@ class StateManager:
         if not state_file.exists():
             return None
 
-        with open(state_file, 'r') as f:
+        with open(state_file, "r", encoding="utf-8") as f:
             data = json.load(f)
 
         self.current_state = MigrationState.from_dict(data)
+        if not self.current_state.remediation_bundle_path:
+            self.current_state.remediation_bundle_path = str(
+                self._default_bundle_path(session_id).resolve()
+            )
         self.state_file = state_file
 
         return self.current_state
@@ -260,54 +885,79 @@ class StateManager:
 
         for state_file in self.state_dir.glob("migration_*.json"):
             try:
-                with open(state_file, 'r') as f:
+                with open(state_file, "r", encoding="utf-8") as f:
                     data = json.load(f)
 
-                sessions.append({
-                    "session_id": data["session_id"],
-                    "started_at": data["started_at"],
-                    "updated_at": data["updated_at"],
-                    "source_url": data["source_url"],
-                    "destination_url": data["destination_url"],
-                    "statistics": data.get("statistics", {})
-                })
+                stats = data.get("statistics", {})
+                sessions.append(
+                    {
+                        "session_id": data["session_id"],
+                        "started_at": data["started_at"],
+                        "updated_at": data["updated_at"],
+                        "source_url": data["source_url"],
+                        "destination_url": data["destination_url"],
+                        "statistics": stats,
+                        "schema_version": data.get("schema_version", 1),
+                        "remediation_bundle_path": data.get("remediation_bundle_path"),
+                    }
+                )
             except Exception:
                 continue
 
-        # Sort by updated_at descending
         sessions.sort(key=lambda x: x["updated_at"], reverse=True)
-
         return sessions
 
-    def save(self):
+    def save(self) -> None:
         """Save current state to disk."""
         if not self.current_state or not self.state_file:
             return
 
-        with open(self.state_file, 'w') as f:
+        self.current_state.touch()
+        with open(self.state_file, "w", encoding="utf-8") as f:
             json.dump(self.current_state.to_dict(), f, indent=2)
+
+        self.current_state.write_remediation_bundle()
 
     def delete_session(self, session_id: str) -> bool:
         """Delete a migration session."""
         state_file = self.state_dir / f"{session_id}.json"
+        bundle_dir = self._default_bundle_path(session_id)
+        deleted = False
 
         if state_file.exists():
             state_file.unlink()
-            return True
+            deleted = True
 
-        return False
+        if bundle_dir.exists():
+            shutil.rmtree(bundle_dir, ignore_errors=True)
+            deleted = True
+
+        return deleted
 
     def get_resume_info(self, state: MigrationState) -> Dict[str, Any]:
         """Get information about what can be resumed."""
         stats = state.get_statistics()
-
+        blocked = stats["terminal"].get(
+            ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value, 0
+        )
+        exported = stats["terminal"].get(
+            ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY.value, 0
+        )
         return {
             "session_id": state.session_id,
             "total_items": stats["total"],
             "completed": stats["completed"],
             "failed": stats["failed"],
             "pending": stats["pending"],
-            "can_resume": stats["pending"] > 0 or stats["failed"] > 0,
+            "blocked": blocked,
+            "exported": exported,
+            "can_resume": (
+                stats["pending"] > 0
+                or stats["failed"] > 0
+                or len(state.remediation_queue) > 0
+            ),
             "elapsed_time": stats["elapsed_time"],
-            "by_type": stats["by_type"]
+            "by_type": stats["by_type"],
+            "remediation_bundle_path": state.remediation_bundle_path,
+            "remediation_tasks": len(state.remediation_queue),
         }

--- a/langsmith_migrator/utils/state.py
+++ b/langsmith_migrator/utils/state.py
@@ -83,6 +83,17 @@ class MigrationState:
         self.items[item.id] = item
         self.updated_at = time.time()
 
+    def get_mapped_id(self, item_type: str, source_id: str) -> Optional[str]:
+        """Return the destination ID for a previously migrated item."""
+        return self.id_mappings.get(item_type, {}).get(source_id)
+
+    def set_mapped_id(self, item_type: str, source_id: str, destination_id: str) -> None:
+        """Store a source to destination ID mapping."""
+        if item_type not in self.id_mappings:
+            self.id_mappings[item_type] = {}
+        self.id_mappings[item_type][source_id] = destination_id
+        self.updated_at = time.time()
+
     def update_item_status(self, item_id: str, status: MigrationStatus,
                           destination_id: Optional[str] = None, error: Optional[str] = None):
         """Update the status of an item."""
@@ -94,10 +105,7 @@ class MigrationState:
 
             if destination_id:
                 item.destination_id = destination_id
-                # Update ID mappings
-                if item.type not in self.id_mappings:
-                    self.id_mappings[item.type] = {}
-                self.id_mappings[item.type][item.source_id] = destination_id
+                self.set_mapped_id(item.type, item.source_id, destination_id)
 
             if error:
                 item.error = error

--- a/langsmith_migrator/utils/workspace.py
+++ b/langsmith_migrator/utils/workspace.py
@@ -5,8 +5,8 @@ from typing import Dict, List, Optional
 from ..core.api_client import EnhancedAPIClient, NotFoundError
 
 
-def list_workspaces(client: EnhancedAPIClient) -> List[Dict]:
-    """Discover workspaces accessible to the current API key.
+def discover_workspaces(client: EnhancedAPIClient) -> Dict[str, object]:
+    """Discover workspaces and record endpoint-level probe outcomes.
 
     Tries multiple endpoints since the workspace API varies across LangSmith versions.
 
@@ -14,32 +14,46 @@ def list_workspaces(client: EnhancedAPIClient) -> List[Dict]:
         client: An EnhancedAPIClient instance.
 
     Returns:
-        List of workspace dicts with at least 'id' and 'display_name'/'name' keys.
-        Empty list if workspaces are not supported or none found.
+        Dict with ``workspaces`` and ``probes`` keys.
     """
     endpoints = ["/api/v1/workspaces", "/workspaces", "/orgs/current/workspaces"]
+    probes: List[Dict[str, object]] = []
 
     for endpoint in endpoints:
         try:
             response = client.get(endpoint)
             # Response may be a list directly or wrapped in a key
             if isinstance(response, list):
-                return response
+                probes.append({"endpoint": endpoint, "supported": True, "detail": "list"})
+                return {"workspaces": response, "probes": probes}
             if isinstance(response, dict):
                 # Common wrapper keys
                 for key in ("workspaces", "items", "results"):
                     if key in response and isinstance(response[key], list):
-                        return response[key]
+                        probes.append(
+                            {"endpoint": endpoint, "supported": True, "detail": f"wrapped:{key}"}
+                        )
+                        return {"workspaces": response[key], "probes": probes}
                 # Single workspace returned as dict
                 if "id" in response:
-                    return [response]
-            return []
-        except NotFoundError:
+                    probes.append({"endpoint": endpoint, "supported": True, "detail": "single"})
+                    return {"workspaces": [response], "probes": probes}
+            probes.append({"endpoint": endpoint, "supported": True, "detail": "empty"})
+            return {"workspaces": [], "probes": probes}
+        except NotFoundError as e:
+            probes.append({"endpoint": endpoint, "supported": False, "detail": str(e)})
             continue
-        except Exception:
+        except Exception as e:
+            probes.append({"endpoint": endpoint, "supported": False, "detail": str(e)})
             continue
 
-    return []
+    return {"workspaces": [], "probes": probes}
+
+
+def list_workspaces(client: EnhancedAPIClient) -> List[Dict]:
+    """Discover workspaces accessible to the current API key."""
+    result = discover_workspaces(client)
+    return list(result.get("workspaces", []))
 
 
 def create_workspace(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,4 +110,8 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "pytest>=9.0.1",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.0.0",
+    "httpx>=0.24.0",
+    "respx>=0.20.0",
 ]

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,332 @@
+"""Fixtures and fakes for CLI functional tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from click.testing import CliRunner
+
+from langsmith_migrator.cli import main as cli_main
+from langsmith_migrator.core import migrators as migrators_module
+from langsmith_migrator.utils.state import MigrationState, StateManager
+
+
+class FakeConsole:
+    """Small console shim for deterministic CLI tests."""
+
+    def __init__(self) -> None:
+        self.buffer = ""
+        self.inputs: list[str] = []
+
+    def print(self, *args: Any, end: str = "\n", **_: Any) -> None:
+        self.buffer += "".join(self._stringify(arg) for arg in args) + end
+
+    def input(self, prompt: str = "") -> str:
+        self.buffer += prompt
+        if not self.inputs:
+            raise AssertionError(f"No console input queued for prompt: {prompt!r}")
+        return self.inputs.pop(0)
+
+    def clear(self) -> None:
+        self.buffer = ""
+
+    @property
+    def text(self) -> str:
+        return self.buffer
+
+    @staticmethod
+    def _stringify(value: Any) -> str:
+        if value.__class__.__name__ == "Table":
+            title = getattr(value, "title", None)
+            return f"<Table title={title!r}>"
+        return str(value)
+
+
+class FakeProgress:
+    """Progress stub that behaves like rich.progress.Progress."""
+
+    def __init__(self, *_: Any, **__: Any) -> None:
+        self.tasks: dict[int, dict[str, Any]] = {}
+        self._next_task_id = 1
+
+    def __enter__(self) -> "FakeProgress":
+        return self
+
+    def __exit__(self, *_: Any) -> bool:
+        return False
+
+    def add_task(self, description: str, total: int) -> int:
+        task_id = self._next_task_id
+        self._next_task_id += 1
+        self.tasks[task_id] = {
+            "description": description,
+            "total": total,
+            "advanced": 0,
+        }
+        return task_id
+
+    def advance(self, task_id: int, advance: int = 1) -> None:
+        self.tasks[task_id]["advanced"] += advance
+
+
+class FakeClient:
+    """Client stub with enough surface for CLI tests."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.session = SimpleNamespace(headers={})
+        self.get_responses: dict[str, Any] = {}
+        self.paginated_results: list[dict[str, Any]] = []
+        self.get_calls: list[str] = []
+        self.get_paginated_calls: list[tuple[str, int]] = []
+        self.set_workspace_calls: list[str | None] = []
+        self.closed = False
+
+    def get(self, endpoint: str) -> Any:
+        self.get_calls.append(endpoint)
+        response = self.get_responses.get(endpoint, [])
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def get_paginated(self, endpoint: str, page_size: int = 100) -> list[dict[str, Any]]:
+        self.get_paginated_calls.append((endpoint, page_size))
+        return list(self.paginated_results)
+
+    def set_workspace(self, workspace_id: str | None) -> None:
+        self.set_workspace_calls.append(workspace_id)
+        if workspace_id is None:
+            self.session.headers.pop("X-Tenant-Id", None)
+        else:
+            self.session.headers["X-Tenant-Id"] = workspace_id
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def make_state(
+    *,
+    session_id: str = "session-1",
+    id_mappings: dict[str, dict[str, str]] | None = None,
+) -> MigrationState:
+    """Build a migration state for orchestrator fakes."""
+
+    return MigrationState(
+        session_id=session_id,
+        started_at=1.0,
+        updated_at=2.0,
+        source_url="https://source.example",
+        destination_url="https://dest.example",
+        id_mappings=id_mappings or {},
+    )
+
+
+@dataclass
+class FakeOrchestratorInstance:
+    """Concrete fake orchestrator captured for assertions."""
+
+    config: Any
+    state_manager: StateManager
+    source_client: FakeClient
+    dest_client: FakeClient
+    state: MigrationState | None
+    test_connections_value: bool
+    test_connections_detailed_value: tuple[bool, bool, str | None, str | None]
+    migrate_datasets_return: dict[str, str]
+    migrate_datasets_side_effect: Exception | None
+    migrate_dataset_calls: list[dict[str, Any]] = field(default_factory=list)
+    workspace_calls: list[tuple[str, str]] = field(default_factory=list)
+    clear_workspace_called: bool = False
+    cleanup_called: bool = False
+
+    def test_connections(self) -> bool:
+        return self.test_connections_value
+
+    def test_connections_detailed(self) -> tuple[bool, bool, str | None, str | None]:
+        return self.test_connections_detailed_value
+
+    def migrate_datasets_parallel(
+        self,
+        dataset_ids: list[str],
+        include_examples: bool = True,
+        include_experiments: bool = False,
+    ) -> dict[str, str]:
+        self.migrate_dataset_calls.append(
+            {
+                "dataset_ids": list(dataset_ids),
+                "include_examples": include_examples,
+                "include_experiments": include_experiments,
+            }
+        )
+        if self.migrate_datasets_side_effect is not None:
+            raise self.migrate_datasets_side_effect
+        return dict(self.migrate_datasets_return)
+
+    def set_workspace_context(self, source_ws_id: str, dest_ws_id: str) -> None:
+        self.workspace_calls.append((source_ws_id, dest_ws_id))
+        self.source_client.set_workspace(source_ws_id)
+        self.dest_client.set_workspace(dest_ws_id)
+
+    def clear_workspace_context(self) -> None:
+        self.clear_workspace_called = True
+        self.source_client.set_workspace(None)
+        self.dest_client.set_workspace(None)
+
+    def cleanup(self) -> None:
+        self.cleanup_called = True
+        self.source_client.close()
+        self.dest_client.close()
+
+
+class FakeOrchestratorFactory:
+    """Configurable orchestrator factory for CLI tests."""
+
+    def __init__(self) -> None:
+        self.instances: list[FakeOrchestratorInstance] = []
+        self.source_client = FakeClient("source")
+        self.dest_client = FakeClient("destination")
+        self.state: MigrationState | None = make_state()
+        self.test_connections_value = True
+        self.test_connections_detailed_value = (True, True, None, None)
+        self.migrate_datasets_return: dict[str, str] = {}
+        self.migrate_datasets_side_effect: Exception | None = None
+
+    def __call__(self, config: Any, state_manager: StateManager) -> FakeOrchestratorInstance:
+        instance = FakeOrchestratorInstance(
+            config=config,
+            state_manager=state_manager,
+            source_client=self.source_client,
+            dest_client=self.dest_client,
+            state=self.state,
+            test_connections_value=self.test_connections_value,
+            test_connections_detailed_value=self.test_connections_detailed_value,
+            migrate_datasets_return=self.migrate_datasets_return,
+            migrate_datasets_side_effect=self.migrate_datasets_side_effect,
+        )
+        self.instances.append(instance)
+        return instance
+
+
+@dataclass
+class CliControls:
+    """Interactive behavior controls for CLI tests."""
+
+    console: FakeConsole
+    confirm_answers: list[bool] = field(default_factory=list)
+    select_results: list[Any] = field(default_factory=list)
+    workspace_result: Any = None
+    project_mapping_result: Any = None
+
+    def confirm(self, prompt: str, default: bool = False, **_: Any) -> bool:
+        if self.confirm_answers:
+            return self.confirm_answers.pop(0)
+        return default
+
+    def select(self, items: list[dict[str, Any]], **_: Any) -> Any:
+        if self.select_results:
+            selection = self.select_results.pop(0)
+            if callable(selection):
+                return selection(items)
+            return selection
+        return items
+
+    def resolve_workspaces(self, *_: Any, **__: Any) -> Any:
+        return self.workspace_result
+
+    def build_project_mapping(self, *_: Any, **__: Any) -> Any:
+        return self.project_mapping_result
+
+
+@dataclass
+class MigratorRegistry:
+    """Injected migrator instances for CLI tests."""
+
+    dataset: Mock = field(default_factory=lambda: Mock(name="dataset_migrator"))
+    queue: Mock = field(default_factory=lambda: Mock(name="queue_migrator"))
+    prompt: Mock = field(default_factory=lambda: Mock(name="prompt_migrator"))
+    rules: Mock = field(default_factory=lambda: Mock(name="rules_migrator"))
+    chart: Mock = field(default_factory=lambda: Mock(name="chart_migrator"))
+
+    def __post_init__(self) -> None:
+        self.dataset.list_datasets.return_value = []
+        self.queue.list_queues.return_value = []
+        self.prompt.check_prompts_api_available.return_value = (True, None)
+        self.prompt.list_prompts.return_value = []
+        self.rules.list_rules.return_value = []
+        self.chart.list_sessions.return_value = []
+        self.chart.migrate_all_charts.return_value = {}
+        self.chart.migrate_session_charts.return_value = {}
+
+
+@dataclass
+class CliHarness:
+    """Convenience wrapper around the patched CLI."""
+
+    runner: CliRunner
+    console: FakeConsole
+    controls: CliControls
+    orchestrator_factory: FakeOrchestratorFactory
+    migrators: MigratorRegistry
+    state_manager: StateManager
+
+    base_args: tuple[str, ...] = (
+        "--source-key",
+        "src-key",
+        "--dest-key",
+        "dest-key",
+        "--source-url",
+        "https://source.example",
+        "--dest-url",
+        "https://dest.example",
+    )
+
+    def invoke(self, args: list[str], *, add_base_args: bool = True):
+        self.console.clear()
+        command = [*self.base_args, *args] if add_base_args else list(args)
+        return self.runner.invoke(cli_main.cli, command, catch_exceptions=False)
+
+
+@pytest.fixture
+def cli_harness(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliHarness:
+    """Patch the CLI module with deterministic fakes."""
+
+    console = FakeConsole()
+    controls = CliControls(console=console)
+    orchestrator_factory = FakeOrchestratorFactory()
+    migrators = MigratorRegistry()
+    state_manager = StateManager(tmp_path / "state")
+
+    monkeypatch.setattr(cli_main, "console", console)
+    monkeypatch.setattr(cli_main, "display_banner", lambda: None)
+    monkeypatch.setattr(cli_main, "Progress", FakeProgress)
+    monkeypatch.setattr(cli_main.Confirm, "ask", lambda *args, **kwargs: controls.confirm(*args, **kwargs))
+    monkeypatch.setattr(cli_main, "select_items", lambda *args, **kwargs: controls.select(*args, **kwargs))
+    monkeypatch.setattr(cli_main, "_resolve_workspaces", controls.resolve_workspaces)
+    monkeypatch.setattr(cli_main, "build_project_mapping_tui", controls.build_project_mapping)
+    monkeypatch.setattr(cli_main, "StateManager", lambda: state_manager)
+    monkeypatch.setattr(cli_main, "MigrationOrchestrator", orchestrator_factory)
+
+    def patch_migrator(name: str, instance: Mock) -> None:
+        factory = lambda *args, **kwargs: instance
+        monkeypatch.setattr(cli_main, name, factory)
+        monkeypatch.setattr(migrators_module, name, factory)
+
+    patch_migrator("DatasetMigrator", migrators.dataset)
+    patch_migrator("AnnotationQueueMigrator", migrators.queue)
+    patch_migrator("PromptMigrator", migrators.prompt)
+    patch_migrator("RulesMigrator", migrators.rules)
+    patch_migrator("ChartMigrator", migrators.chart)
+
+    return CliHarness(
+        runner=CliRunner(),
+        console=console,
+        controls=controls,
+        orchestrator_factory=orchestrator_factory,
+        migrators=migrators,
+        state_manager=state_manager,
+    )

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -139,6 +139,7 @@ class FakeOrchestratorInstance:
     test_connections_detailed_value: tuple[bool, bool, str | None, str | None]
     migrate_datasets_return: dict[str, str]
     migrate_datasets_side_effect: Exception | None
+    migrators: Any | None = None
     migrate_dataset_calls: list[dict[str, Any]] = field(default_factory=list)
     workspace_calls: list[tuple[str, str]] = field(default_factory=list)
     clear_workspace_called: bool = False
@@ -177,6 +178,44 @@ class FakeOrchestratorInstance:
         self.source_client.set_workspace(None)
         self.dest_client.set_workspace(None)
 
+    def resume_items(self, items_to_process: list[Any]) -> dict[str, list[str]]:
+        results = {"resumed": [], "blocked": []}
+        for item in items_to_process:
+            if item.type == "dataset":
+                self.migrate_datasets_parallel(
+                    [item.source_id],
+                    include_examples=True,
+                    include_experiments=False,
+                )
+                results["resumed"].append(f"dataset:{item.source_id}")
+            elif item.type == "prompt":
+                self.migrators.prompt.migrate_prompt(
+                    item.source_id,
+                    include_all_commits=item.metadata.get("include_all_commits", False),
+                )
+                results["resumed"].append(f"prompt:{item.source_id}")
+            elif item.type == "queue":
+                self.migrators.queue.create_queue(item.metadata.get("queue"))
+                results["resumed"].append(f"queue:{item.source_id}")
+            elif item.type == "rule":
+                self.migrators.rules._project_id_map = dict(item.metadata.get("project_id_map") or {})
+                self.migrators.rules.create_rule(
+                    item.metadata.get("rule"),
+                    strip_project_reference=item.metadata.get("strip_projects", False),
+                    ensure_project=item.metadata.get("ensure_project", False),
+                    create_disabled=item.metadata.get("create_disabled", False),
+                )
+                results["resumed"].append(f"rule:{item.source_id}")
+            elif item.type == "chart":
+                self.migrators.chart.migrate_chart(
+                    item.metadata.get("chart"),
+                    item.metadata.get("dest_session_id"),
+                )
+                results["resumed"].append(f"chart:{item.source_id}")
+            else:
+                results["blocked"].append(f"{item.type}:{item.source_id}")
+        return results
+
     def cleanup(self) -> None:
         self.cleanup_called = True
         self.source_client.close()
@@ -195,6 +234,7 @@ class FakeOrchestratorFactory:
         self.test_connections_detailed_value = (True, True, None, None)
         self.migrate_datasets_return: dict[str, str] = {}
         self.migrate_datasets_side_effect: Exception | None = None
+        self.migrators: Any | None = None
 
     def __call__(self, config: Any, state_manager: StateManager) -> FakeOrchestratorInstance:
         instance = FakeOrchestratorInstance(
@@ -207,6 +247,7 @@ class FakeOrchestratorFactory:
             test_connections_detailed_value=self.test_connections_detailed_value,
             migrate_datasets_return=self.migrate_datasets_return,
             migrate_datasets_side_effect=self.migrate_datasets_side_effect,
+            migrators=self.migrators,
         )
         self.instances.append(instance)
         return instance
@@ -256,8 +297,12 @@ class MigratorRegistry:
         self.dataset.list_datasets.return_value = []
         self.queue.list_queues.return_value = []
         self.prompt.check_prompts_api_available.return_value = (True, None)
+        self.prompt.probe_capabilities.return_value = {}
         self.prompt.list_prompts.return_value = []
+        self.rules.probe_capabilities.return_value = {}
         self.rules.list_rules.return_value = []
+        self.chart.probe_capabilities.return_value = {}
+        self.chart.list_charts.return_value = []
         self.chart.list_sessions.return_value = []
         self.chart.migrate_all_charts.return_value = {}
         self.chart.migrate_session_charts.return_value = {}
@@ -299,6 +344,7 @@ def cli_harness(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliHarness:
     controls = CliControls(console=console)
     orchestrator_factory = FakeOrchestratorFactory()
     migrators = MigratorRegistry()
+    orchestrator_factory.migrators = migrators
     state_manager = StateManager(tmp_path / "state")
 
     monkeypatch.setattr(cli_main, "console", console)

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -1,0 +1,525 @@
+"""Functional coverage for the Click CLI surface."""
+
+from __future__ import annotations
+
+import json
+
+from langsmith_migrator.cli import main as cli_main
+from langsmith_migrator.cli.tui_workspace_mapper import WorkspaceProjectResult
+from langsmith_migrator.utils.state import MigrationItem, MigrationState, MigrationStatus
+
+
+def build_state(
+    session_id: str,
+    *,
+    id_mappings: dict[str, dict[str, str]] | None = None,
+) -> MigrationState:
+    """Create a migration state for tests."""
+
+    return MigrationState(
+        session_id=session_id,
+        started_at=1.0,
+        updated_at=2.0,
+        source_url="https://source.example",
+        destination_url="https://dest.example",
+        id_mappings=id_mappings or {},
+    )
+
+
+def save_session(state_manager, state: MigrationState) -> None:
+    """Persist a migration state to the test state directory."""
+
+    state_path = state_manager.state_dir / f"{state.session_id}.json"
+    state_path.write_text(json.dumps(state.to_dict()), encoding="utf-8")
+
+
+def test_registered_command_names_match_public_cli_surface():
+    """Keep the Click command registry stable."""
+
+    assert sorted(cli_main.cli.commands) == [
+        "charts",
+        "clean",
+        "datasets",
+        "list-projects",
+        "list_workspaces",
+        "migrate-all",
+        "prompts",
+        "queues",
+        "resume",
+        "rules",
+        "test",
+    ]
+
+
+def test_name_mapping_to_id_mapping_ignores_unknown_project_names():
+    """Project mapping should only include names present on both sides."""
+
+    result = cli_main._name_mapping_to_id_mapping(
+        {"Source A": "Dest A", "Missing": "Dest B"},
+        source_projects=[
+            {"id": "src-a", "name": "Source A"},
+            {"id": "src-b", "name": "Source B"},
+        ],
+        dest_projects=[
+            {"id": "dst-a", "name": "Dest A"},
+            {"id": "dst-b", "name": "Dest B"},
+        ],
+    )
+
+    assert result == {"src-a": "dst-a"}
+
+
+def test_resolve_workspaces_with_explicit_pair_sets_context(monkeypatch):
+    """Providing both workspace IDs should skip discovery and scope the orchestrator."""
+
+    calls = []
+
+    class StubOrchestrator:
+        def set_workspace_context(self, source_ws_id, dest_ws_id):
+            calls.append((source_ws_id, dest_ws_id))
+
+    class SimpleConsole:
+        def __init__(self):
+            self.text = ""
+
+        def print(self, *args, end="\n", **kwargs):
+            self.text += "".join(str(arg) for arg in args) + end
+
+    monkeypatch.setattr(cli_main, "console", SimpleConsole())
+
+    result = cli_main._resolve_workspaces(
+        StubOrchestrator(),
+        source_workspace="src-ws",
+        dest_workspace="dst-ws",
+    )
+
+    assert calls == [("src-ws", "dst-ws")]
+    assert result.workspace_mapping == {"src-ws": "dst-ws"}
+
+
+def test_resolve_workspaces_requires_both_workspace_ids(monkeypatch):
+    """Partial workspace scoping should abort with the cancellation sentinel."""
+
+    class StubOrchestrator:
+        source_client = object()
+        dest_client = object()
+
+    class SimpleConsole:
+        def __init__(self):
+            self.text = ""
+
+        def print(self, *args, end="\n", **kwargs):
+            self.text += "".join(str(arg) for arg in args) + end
+
+    console = SimpleConsole()
+    monkeypatch.setattr(cli_main, "console", console)
+
+    result = cli_main._resolve_workspaces(StubOrchestrator(), source_workspace="src-ws")
+
+    assert result == cli_main._WS_CANCELLED
+    assert "must be provided together" in console.text
+
+
+def test_resolve_workspaces_returns_cancelled_when_forced_tui_is_cancelled(monkeypatch):
+    """A forced workspace TUI cancellation should map to the public cancelled sentinel."""
+
+    class StubOrchestrator:
+        source_client = object()
+        dest_client = object()
+
+    monkeypatch.setattr(cli_main, "resolve_workspace_context", lambda *args, **kwargs: None)
+
+    result = cli_main._resolve_workspaces(StubOrchestrator(), map_workspaces=True)
+
+    assert result == cli_main._WS_CANCELLED
+
+
+def test_test_command_uses_global_options_and_lists_workspaces(cli_harness):
+    """The smoke-test command should honor global config flags and verbose workspace listing."""
+
+    cli_harness.orchestrator_factory.source_client.get_responses["/api/v1/workspaces"] = [
+        {"id": "src-ws", "display_name": "Source Workspace", "tenant_handle": "source"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.get_responses["/api/v1/workspaces"] = [
+        {"id": "dst-ws", "display_name": "Destination Workspace", "tenant_handle": "dest"},
+    ]
+
+    result = cli_harness.invoke(
+        [
+            "--no-ssl",
+            "--batch-size",
+            "25",
+            "--workers",
+            "2",
+            "--dry-run",
+            "--skip-existing",
+            "-v",
+            "test",
+        ]
+    )
+
+    assert result.exit_code == 0
+    orchestrator = cli_harness.orchestrator_factory.instances[0]
+    assert orchestrator.config.source.verify_ssl is False
+    assert orchestrator.config.destination.verify_ssl is False
+    assert orchestrator.config.migration.batch_size == 25
+    assert orchestrator.config.migration.concurrent_workers == 2
+    assert orchestrator.config.migration.dry_run is True
+    assert orchestrator.config.migration.skip_existing is True
+    assert orchestrator.config.migration.verbose is True
+    assert "Source Workspaces" in cli_harness.console.text
+    assert "Destination Workspaces" in cli_harness.console.text
+
+
+def test_test_command_exits_nonzero_when_connections_fail(cli_harness):
+    """Connection smoke tests should surface failure via the command exit code."""
+
+    cli_harness.orchestrator_factory.test_connections_value = False
+
+    result = cli_harness.invoke(["test"])
+
+    assert result.exit_code == 1
+    assert "✗" in cli_harness.console.text
+
+
+def test_datasets_command_migrates_selected_datasets_with_workspace_scope(cli_harness):
+    """Dataset migration should pass selected IDs into the orchestrator and clean up workspace scope."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={},
+        workspaces_to_create=[],
+    )
+    cli_harness.migrators.dataset.list_datasets.return_value = [
+        {"id": "dataset-1", "name": "Dataset One", "description": "First"},
+        {"id": "dataset-2", "name": "Dataset Two", "description": "Second"},
+    ]
+    cli_harness.orchestrator_factory.migrate_datasets_return = {
+        "dataset-1": "dest-1",
+        "dataset-2": "dest-2",
+    }
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(["datasets", "--all", "--include-experiments"])
+
+    assert result.exit_code == 0
+    orchestrator = cli_harness.orchestrator_factory.instances[0]
+    assert orchestrator.workspace_calls == [("src-ws", "dst-ws")]
+    assert orchestrator.migrate_dataset_calls == [
+        {
+            "dataset_ids": ["dataset-1", "dataset-2"],
+            "include_examples": True,
+            "include_experiments": True,
+        }
+    ]
+    assert orchestrator.clear_workspace_called is True
+    assert "Migration completed" in cli_harness.console.text
+
+
+def test_prompts_command_surfaces_unavailable_prompts_api(cli_harness):
+    """Prompt migration should stop early when the destination API is unavailable."""
+
+    cli_harness.migrators.prompt.check_prompts_api_available.return_value = (False, "Feature disabled")
+
+    result = cli_harness.invoke(["prompts", "--all"])
+
+    assert result.exit_code == 0
+    cli_harness.migrators.prompt.list_prompts.assert_not_called()
+    assert "Feature disabled" in cli_harness.console.text
+
+
+def test_prompts_command_reports_405_failures_with_helpful_guidance(cli_harness):
+    """405 failures should be summarized with the dedicated troubleshooting message."""
+
+    cli_harness.migrators.prompt.list_prompts.return_value = [
+        {"repo_handle": "team/prompt-a"},
+        {"repo_handle": "team/prompt-b"},
+    ]
+    cli_harness.migrators.prompt.migrate_prompt.side_effect = [
+        True,
+        Exception("405 Not Allowed"),
+    ]
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(["prompts", "--all", "--include-all-commits"])
+
+    assert result.exit_code == 0
+    assert cli_harness.migrators.prompt.migrate_prompt.call_count == 2
+    cli_harness.migrators.prompt.migrate_prompt.assert_any_call(
+        "team/prompt-a",
+        include_all_commits=True,
+    )
+    cli_harness.migrators.prompt.migrate_prompt.assert_any_call(
+        "team/prompt-b",
+        include_all_commits=True,
+    )
+    assert "Prompts: 1 migrated, 1 failed" in cli_harness.console.text
+    assert "405 Not Allowed errors" in cli_harness.console.text
+
+
+def test_queues_command_migrates_selected_queues_and_reports_failures(cli_harness):
+    """Queue migration should continue through per-item failures and summarize the result."""
+
+    cli_harness.migrators.queue.list_queues.return_value = [
+        {"id": "queue-1", "name": "Queue One", "description": "First"},
+        {"id": "queue-2", "name": "Queue Two", "description": "Second"},
+    ]
+    cli_harness.migrators.queue.create_queue.side_effect = [
+        "new-queue-1",
+        Exception("queue create failed"),
+    ]
+
+    result = cli_harness.invoke(["queues"])
+
+    assert result.exit_code == 0
+    assert cli_harness.migrators.queue.create_queue.call_count == 2
+    assert "Queues: 1 migrated, 1 failed" in cli_harness.console.text
+
+
+def test_list_projects_requires_a_target_side(cli_harness):
+    """The list-projects helper should demand --source or --dest."""
+
+    result = cli_harness.invoke(["list-projects"], add_base_args=False)
+
+    assert result.exit_code == 0
+    assert "Specify --source or --dest" in cli_harness.console.text
+
+
+def test_list_projects_queries_each_requested_instance(cli_harness):
+    """Project listing should call the source and destination pagination endpoints."""
+
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {"id": "src-project", "name": "Source Project"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {"id": "dst-project", "name": "Destination Project"},
+    ]
+
+    result = cli_harness.invoke(["list-projects", "--source", "--dest"])
+
+    assert result.exit_code == 0
+    assert cli_harness.orchestrator_factory.source_client.get_paginated_calls == [
+        ("/sessions", 100)
+    ]
+    assert cli_harness.orchestrator_factory.dest_client.get_paginated_calls == [
+        ("/sessions", 100)
+    ]
+
+
+def test_list_workspaces_queries_each_requested_instance(cli_harness):
+    """Workspace listing should call the discovery endpoints for each requested side."""
+
+    cli_harness.orchestrator_factory.source_client.get_responses["/api/v1/workspaces"] = [
+        {"id": "src-ws", "display_name": "Source Workspace", "tenant_handle": "source"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.get_responses["/api/v1/workspaces"] = [
+        {"id": "dst-ws", "display_name": "Destination Workspace", "tenant_handle": "dest"},
+    ]
+
+    result = cli_harness.invoke(["list_workspaces", "--source", "--dest"])
+
+    assert result.exit_code == 0
+    assert cli_harness.orchestrator_factory.source_client.get_calls == ["/api/v1/workspaces"]
+    assert cli_harness.orchestrator_factory.dest_client.get_calls == ["/api/v1/workspaces"]
+    assert "Source Workspaces" in cli_harness.console.text
+    assert "Destination Workspaces" in cli_harness.console.text
+
+
+def test_rules_command_rejects_conflicting_project_mapping_modes(cli_harness):
+    """The rules CLI should guard against mutually exclusive mapping inputs."""
+
+    result = cli_harness.invoke(
+        ["rules", "--all", "--map-projects", "--project-mapping", '{"a": "b"}']
+    )
+
+    assert result.exit_code == 0
+    cli_harness.migrators.rules.list_rules.assert_not_called()
+    assert "mutually exclusive" in cli_harness.console.text
+
+
+def test_rules_command_uses_custom_project_mapping_and_create_enabled(cli_harness):
+    """Inline project mappings and create-enabled should flow into rule creation."""
+
+    cli_harness.migrators.rules.list_rules.return_value = [
+        {
+            "id": "rule-1",
+            "display_name": "Rule One",
+            "dataset_id": "dataset-1",
+        }
+    ]
+    cli_harness.migrators.rules.create_rule.return_value = "dest-rule-1"
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(
+        [
+            "rules",
+            "--all",
+            "--project-mapping",
+            '{"src-project": "dst-project"}',
+            "--create-enabled",
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert cli_harness.migrators.rules._project_id_map == {"src-project": "dst-project"}
+    cli_harness.migrators.rules.create_rule.assert_called_once_with(
+        cli_harness.migrators.rules.list_rules.return_value[0],
+        strip_project_reference=False,
+        create_disabled=False,
+    )
+    assert "Rules: 1 migrated, 0 skipped, 0 failed" in cli_harness.console.text
+
+
+def test_migrate_all_runs_every_step_and_applies_workspace_project_mappings(cli_harness):
+    """The all-in-one wizard should thread dataset and project mappings through later steps."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={"src-ws": {"Source Project": "Destination Project"}},
+        workspaces_to_create=[],
+    )
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {"id": "source-project-id", "name": "Source Project"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {"id": "dest-project-id", "name": "Destination Project"},
+    ]
+    cli_harness.migrators.dataset.list_datasets.return_value = [
+        {"id": "dataset-1", "name": "Dataset One"},
+    ]
+    cli_harness.migrators.prompt.list_prompts.return_value = [
+        {"repo_handle": "team/prompt-a"},
+    ]
+    cli_harness.migrators.queue.list_queues.return_value = [
+        {"id": "queue-1", "name": "Queue One"},
+    ]
+    cli_harness.migrators.rules.list_rules.return_value = [
+        {"id": "rule-1", "display_name": "Rule One", "dataset_id": "dataset-1"},
+    ]
+    cli_harness.orchestrator_factory.migrate_datasets_return = {"dataset-1": "dest-dataset-1"}
+    cli_harness.migrators.prompt.migrate_prompt.return_value = True
+    cli_harness.migrators.queue.create_queue.return_value = "dest-queue-1"
+    cli_harness.migrators.rules.create_rule.return_value = "dest-rule-1"
+    cli_harness.controls.confirm_answers = [True, True, True, True, True]
+
+    result = cli_harness.invoke(["migrate-all", "--include-all-commits"])
+
+    assert result.exit_code == 0
+    orchestrator = cli_harness.orchestrator_factory.instances[0]
+    assert orchestrator.workspace_calls == [("src-ws", "dst-ws")]
+    assert orchestrator.migrate_dataset_calls == [
+        {
+            "dataset_ids": ["dataset-1"],
+            "include_examples": True,
+            "include_experiments": True,
+        }
+    ]
+    assert cli_harness.migrators.rules._dataset_id_map == {"dataset-1": "dest-dataset-1"}
+    assert cli_harness.migrators.rules._project_id_map == {
+        "source-project-id": "dest-project-id"
+    }
+    assert cli_harness.migrators.prompt.migrate_prompt.call_count == 1
+    assert cli_harness.migrators.queue.create_queue.call_count == 1
+    assert cli_harness.migrators.rules.create_rule.call_count == 1
+    assert orchestrator.clear_workspace_called is True
+    assert "Migration wizard completed!" in cli_harness.console.text
+
+
+def test_charts_command_auto_detects_same_instance(cli_harness):
+    """Charts migration should flip into same-instance mode automatically when URLs and keys match."""
+
+    cli_harness.migrators.chart.migrate_all_charts.return_value = {
+        "session-1": {"chart-1": "dest-chart-1"}
+    }
+    cli_harness.controls.confirm_answers = [True]
+
+    cli_harness.console.clear()
+    result = cli_harness.runner.invoke(
+        cli_main.cli,
+        [
+            "--source-key",
+            "shared-key",
+            "--dest-key",
+            "shared-key",
+            "--source-url",
+            "https://same.example",
+            "--dest-url",
+            "https://same.example",
+            "charts",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    cli_harness.migrators.chart.migrate_all_charts.assert_called_once_with(same_instance=True)
+    assert "Detected same source and destination instance" in cli_harness.console.text
+
+
+def test_charts_command_uses_saved_project_mapping_for_session_migration(cli_harness):
+    """Session-scoped chart migration should resolve the destination project from saved state."""
+
+    cli_harness.orchestrator_factory.state = build_state(
+        "chart-session",
+        id_mappings={"project": {"source-session": "dest-session"}},
+    )
+    cli_harness.migrators.chart.list_sessions.return_value = [
+        {"id": "source-session", "name": "Session A"},
+    ]
+    cli_harness.migrators.chart.migrate_session_charts.return_value = {
+        "chart-1": "dest-chart-1"
+    }
+
+    result = cli_harness.invoke(["charts", "--session", "Session A"])
+
+    assert result.exit_code == 0
+    cli_harness.migrators.chart.migrate_session_charts.assert_called_once_with(
+        "source-session",
+        "dest-session",
+    )
+    assert "Mapped to destination session" in cli_harness.console.text
+
+
+def test_resume_command_retries_pending_datasets(cli_harness):
+    """Resume should reload a saved session and rerun pending datasets."""
+
+    state = build_state("migration_resume")
+    state.add_item(
+        MigrationItem(
+            id="dataset_dataset-1",
+            type="dataset",
+            name="Dataset One",
+            source_id="dataset-1",
+            status=MigrationStatus.PENDING,
+        )
+    )
+    save_session(cli_harness.state_manager, state)
+    cli_harness.console.inputs = ["1"]
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(["resume"])
+
+    assert result.exit_code == 0
+    orchestrator = cli_harness.orchestrator_factory.instances[0]
+    assert orchestrator.state.session_id == "migration_resume"
+    assert orchestrator.migrate_dataset_calls == [
+        {
+            "dataset_ids": ["dataset-1"],
+            "include_examples": True,
+            "include_experiments": False,
+        }
+    ]
+    assert "Resuming migration of 1 items" in cli_harness.console.text
+
+
+def test_clean_command_deletes_saved_sessions(cli_harness):
+    """Cleaning sessions should remove persisted state files after confirmation."""
+
+    save_session(cli_harness.state_manager, build_state("migration_one"))
+    save_session(cli_harness.state_manager, build_state("migration_two"))
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(["clean"], add_base_args=False)
+
+    assert result.exit_code == 0
+    assert cli_harness.state_manager.list_sessions() == []
+    assert "All sessions deleted" in cli_harness.console.text

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -671,6 +671,48 @@ def test_resume_command_retries_prompt_queue_rule_and_chart_items(cli_harness):
     assert "Resume processing completed" in cli_harness.console.text
 
 
+def test_resume_command_non_interactive_uses_latest_session_without_console_input(cli_harness):
+    """Non-interactive resume should auto-select the latest session and dispatch through the orchestrator."""
+
+    state = build_state("migration_resume_non_interactive")
+    state.add_item(
+        MigrationItem(
+            id="prompt_default_team_prompt-a",
+            type="prompt",
+            name="team/prompt-a",
+            source_id="team/prompt-a",
+            status=MigrationStatus.PENDING,
+            metadata={"include_all_commits": True},
+        )
+    )
+    save_session(cli_harness.state_manager, state)
+    cli_harness.migrators.prompt.migrate_prompt.return_value = "team/prompt-a"
+
+    result = cli_harness.invoke(["--non-interactive", "resume"])
+
+    assert result.exit_code == 0
+    cli_harness.migrators.prompt.migrate_prompt.assert_called_once_with(
+        "team/prompt-a",
+        include_all_commits=True,
+    )
+    assert "Resume processing completed" in cli_harness.console.text
+
+
+def test_queues_command_non_interactive_exits_with_code_2_for_blocked_items(cli_harness):
+    """Non-interactive runs should exit with code 2 when the session requires remediation."""
+
+    cli_harness.migrators.queue.list_queues.return_value = [
+        {"id": "queue-1", "name": "Queue One"},
+    ]
+    cli_harness.migrators.queue.create_queue.side_effect = Exception("queue create failed")
+
+    result = cli_harness.invoke(["--non-interactive", "queues"])
+
+    assert result.exit_code == 2
+    assert "Resolution Summary" in cli_harness.console.text
+    assert "Remediation bundle:" in cli_harness.console.text
+
+
 def test_clean_command_deletes_saved_sessions(cli_harness):
     """Cleaning sessions should remove persisted state files after confirmation."""
 

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -180,6 +180,7 @@ def test_test_command_exits_nonzero_when_connections_fail(cli_harness):
 
     assert result.exit_code == 1
     assert "✗" in cli_harness.console.text
+    assert cli_harness.orchestrator_factory.instances[0].cleanup_called is True
 
 
 def test_datasets_command_migrates_selected_datasets_with_workspace_scope(cli_harness):
@@ -226,6 +227,22 @@ def test_prompts_command_surfaces_unavailable_prompts_api(cli_harness):
     assert result.exit_code == 0
     cli_harness.migrators.prompt.list_prompts.assert_not_called()
     assert "Feature disabled" in cli_harness.console.text
+
+
+def test_prompts_command_cleans_up_on_connection_failure(cli_harness):
+    """Prompt command should clean up the orchestrator even on early connection failures."""
+
+    cli_harness.orchestrator_factory.test_connections_detailed_value = (
+        False,
+        True,
+        "source failure",
+        None,
+    )
+
+    result = cli_harness.invoke(["prompts", "--all"])
+
+    assert result.exit_code == 0
+    assert cli_harness.orchestrator_factory.instances[0].cleanup_called is True
 
 
 def test_prompts_command_reports_405_failures_with_helpful_guidance(cli_harness):
@@ -370,6 +387,35 @@ def test_rules_command_uses_custom_project_mapping_and_create_enabled(cli_harnes
     assert "Rules: 1 migrated, 0 skipped, 0 failed" in cli_harness.console.text
 
 
+def test_rules_command_uses_workspace_project_mappings(cli_harness):
+    """Standalone rules migration should consume per-workspace project mappings from workspace resolution."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={"src-ws": {"Source Project": "Destination Project"}},
+        workspaces_to_create=[],
+    )
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {"id": "source-project-id", "name": "Source Project"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {"id": "dest-project-id", "name": "Destination Project"},
+    ]
+    cli_harness.migrators.rules.list_rules.return_value = [
+        {"id": "rule-1", "display_name": "Rule One", "dataset_id": "dataset-1"},
+    ]
+    cli_harness.migrators.rules.create_rule.return_value = "dest-rule-1"
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(["rules", "--all"])
+
+    assert result.exit_code == 0
+    assert cli_harness.migrators.rules._project_id_map == {
+        "source-project-id": "dest-project-id"
+    }
+    assert "Using workspace-scoped project mapping" in cli_harness.console.text
+
+
 def test_migrate_all_runs_every_step_and_applies_workspace_project_mappings(cli_harness):
     """The all-in-one wizard should thread dataset and project mappings through later steps."""
 
@@ -455,6 +501,34 @@ def test_charts_command_auto_detects_same_instance(cli_harness):
     assert "Detected same source and destination instance" in cli_harness.console.text
 
 
+def test_charts_command_uses_workspace_project_mappings(cli_harness):
+    """Standalone chart migration should consume per-workspace project mappings from workspace resolution."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={"src-ws": {"Source Project": "Destination Project"}},
+        workspaces_to_create=[],
+    )
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {"id": "source-project-id", "name": "Source Project"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {"id": "dest-project-id", "name": "Destination Project"},
+    ]
+    cli_harness.migrators.chart.migrate_all_charts.return_value = {
+        "source-project-id": {"chart-1": "dest-chart-1"}
+    }
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(["charts"])
+
+    assert result.exit_code == 0
+    assert cli_harness.migrators.chart._project_id_map == {
+        "source-project-id": "dest-project-id"
+    }
+    assert "Using workspace-scoped project mapping" in cli_harness.console.text
+
+
 def test_charts_command_uses_saved_project_mapping_for_session_migration(cli_harness):
     """Session-scoped chart migration should resolve the destination project from saved state."""
 
@@ -509,6 +583,92 @@ def test_resume_command_retries_pending_datasets(cli_harness):
         }
     ]
     assert "Resuming migration of 1 items" in cli_harness.console.text
+
+
+def test_resume_command_retries_prompt_queue_rule_and_chart_items(cli_harness):
+    """Resume should replay tracked non-dataset items using their saved state metadata."""
+
+    state = build_state("migration_resume_non_dataset")
+    state.add_item(
+        MigrationItem(
+            id="prompt_default_team_prompt-a",
+            type="prompt",
+            name="team/prompt-a",
+            source_id="team/prompt-a",
+            status=MigrationStatus.PENDING,
+            metadata={"include_all_commits": True},
+        )
+    )
+    state.add_item(
+        MigrationItem(
+            id="queue_default_queue-1",
+            type="queue",
+            name="Queue One",
+            source_id="queue-1",
+            status=MigrationStatus.PENDING,
+            metadata={"queue": {"id": "queue-1", "name": "Queue One"}},
+        )
+    )
+    state.add_item(
+        MigrationItem(
+            id="rule_default_rule-1",
+            type="rule",
+            name="Rule One",
+            source_id="rule-1",
+            status=MigrationStatus.PENDING,
+            metadata={
+                "rule": {"id": "rule-1", "display_name": "Rule One"},
+                "strip_projects": True,
+                "create_disabled": True,
+                "project_id_map": {"source-project-id": "dest-project-id"},
+            },
+        )
+    )
+    state.add_item(
+        MigrationItem(
+            id="chart_default_chart-1",
+            type="chart",
+            name="Chart One",
+            source_id="chart-1",
+            status=MigrationStatus.PENDING,
+            metadata={
+                "chart": {"id": "chart-1", "title": "Chart One", "series": [{"filters": {}}]},
+                "dest_session_id": "dest-session-1",
+            },
+        )
+    )
+    save_session(cli_harness.state_manager, state)
+    cli_harness.console.inputs = ["1"]
+    cli_harness.controls.confirm_answers = [True]
+    cli_harness.migrators.prompt.migrate_prompt.return_value = "team/prompt-a"
+    cli_harness.migrators.queue.create_queue.return_value = "dest-queue-1"
+    cli_harness.migrators.rules.create_rule.return_value = "dest-rule-1"
+    cli_harness.migrators.chart.migrate_chart.return_value = "dest-chart-1"
+
+    result = cli_harness.invoke(["resume"])
+
+    assert result.exit_code == 0
+    cli_harness.migrators.prompt.migrate_prompt.assert_called_once_with(
+        "team/prompt-a",
+        include_all_commits=True,
+    )
+    cli_harness.migrators.queue.create_queue.assert_called_once_with(
+        {"id": "queue-1", "name": "Queue One"}
+    )
+    assert cli_harness.migrators.rules._project_id_map == {
+        "source-project-id": "dest-project-id"
+    }
+    cli_harness.migrators.rules.create_rule.assert_called_once_with(
+        {"id": "rule-1", "display_name": "Rule One"},
+        strip_project_reference=True,
+        ensure_project=False,
+        create_disabled=True,
+    )
+    cli_harness.migrators.chart.migrate_chart.assert_called_once_with(
+        {"id": "chart-1", "title": "Chart One", "series": [{"filters": {}}]},
+        "dest-session-1",
+    )
+    assert "Resume processing completed" in cli_harness.console.text
 
 
 def test_clean_command_deletes_saved_sessions(cli_harness):

--- a/tests/test_chart_migrator.py
+++ b/tests/test_chart_migrator.py
@@ -1,0 +1,38 @@
+"""Unit tests for ChartMigrator."""
+
+from unittest.mock import Mock
+
+from langsmith_migrator.core.api_client import EnhancedAPIClient
+from langsmith_migrator.core.migrators import ChartMigrator
+
+
+def _mock_client() -> Mock:
+    client = Mock(spec=EnhancedAPIClient)
+    client.session = Mock()
+    client.session.headers = {}
+    return client
+
+
+def test_find_existing_chart_checks_destination_not_source(sample_config, migration_state):
+    """Chart dedupe should look at destination charts before deciding to create."""
+
+    source_client = _mock_client()
+    dest_client = _mock_client()
+
+    source_client.post.return_value = [
+        {"id": "source-chart", "title": "Latency"},
+    ]
+    dest_client.post.return_value = [
+        {"id": "dest-chart", "title": "Latency"},
+    ]
+
+    migrator = ChartMigrator(
+        source_client,
+        dest_client,
+        migration_state,
+        sample_config,
+    )
+
+    assert migrator.find_existing_chart("Latency") == "dest-chart"
+    dest_client.post.assert_called_once()
+    source_client.post.assert_not_called()

--- a/tests/test_chart_migrator.py
+++ b/tests/test_chart_migrator.py
@@ -36,3 +36,64 @@ def test_find_existing_chart_checks_destination_not_source(sample_config, migrat
     assert migrator.find_existing_chart("Latency") == "dest-chart"
     dest_client.post.assert_called_once()
     source_client.post.assert_not_called()
+
+
+def test_create_chart_enriches_missing_series_before_create(sample_config, migration_state):
+    """Chart creation should attempt a richer fetch before exporting missing-series charts."""
+
+    source_client = _mock_client()
+    dest_client = _mock_client()
+
+    source_client.post.return_value = [
+        {
+            "id": "source-chart",
+            "title": "Latency",
+            "chart_type": "line",
+            "series": [{"filters": {"project_id": "project-1"}}],
+        }
+    ]
+    dest_client.post.return_value = {"id": "dest-chart"}
+
+    migrator = ChartMigrator(
+        source_client,
+        dest_client,
+        migration_state,
+        sample_config,
+    )
+    migrator.find_existing_chart = Mock(return_value=None)
+    migrator._verify_chart = Mock(return_value=(True, {}))
+
+    chart_id = migrator.create_chart({"id": "source-chart", "title": "Latency"})
+
+    assert chart_id == "dest-chart"
+    dest_client.post.assert_called_with(
+        "/charts/create",
+        {
+            "title": "Latency",
+            "chart_type": "line",
+            "series": [{"filters": {"project_id": "project-1"}}],
+        },
+    )
+
+
+def test_build_project_mapping_skips_duplicate_names(sample_config, migration_state):
+    """Duplicate project names should disable exact-name chart mapping."""
+
+    source_client = _mock_client()
+    dest_client = _mock_client()
+    source_client.get_paginated.return_value = [
+        {"id": "source-a", "name": "Duplicate"},
+        {"id": "source-b", "name": "Duplicate"},
+    ]
+    dest_client.get_paginated.return_value = [
+        {"id": "dest-a", "name": "Duplicate"},
+    ]
+
+    migrator = ChartMigrator(
+        source_client,
+        dest_client,
+        migration_state,
+        sample_config,
+    )
+
+    assert migrator._build_project_mapping() == {}

--- a/tests/test_experiment_resume.py
+++ b/tests/test_experiment_resume.py
@@ -1,0 +1,44 @@
+"""Experiment and feedback resume helper tests."""
+
+from __future__ import annotations
+
+from langsmith_migrator.core.migrators import ExperimentMigrator, FeedbackMigrator
+
+
+def test_deterministic_run_id_is_stable(mock_api_client, sample_config, migration_state):
+    """Run replay IDs should be stable across retries."""
+
+    migrator = ExperimentMigrator(
+        mock_api_client,
+        mock_api_client,
+        migration_state,
+        sample_config,
+    )
+
+    first = migrator._deterministic_run_id("run-123")
+    second = migrator._deterministic_run_id("run-123")
+
+    assert first == second
+    assert first != "run-123"
+
+
+def test_feedback_fingerprint_is_stable_for_equivalent_payloads(mock_api_client, sample_config, migration_state):
+    """Feedback dedupe fingerprints should ignore dictionary key ordering."""
+
+    migrator = FeedbackMigrator(
+        mock_api_client,
+        mock_api_client,
+        migration_state,
+        sample_config,
+    )
+
+    first = migrator._feedback_fingerprint(
+        "experiment-1",
+        {"key": "score", "extra": {"b": 2, "a": 1}},
+    )
+    second = migrator._feedback_fingerprint(
+        "experiment-1",
+        {"extra": {"a": 1, "b": 2}, "key": "score"},
+    )
+
+    assert first == second

--- a/tests/test_package_version.py
+++ b/tests/test_package_version.py
@@ -1,0 +1,15 @@
+"""Version metadata tests."""
+
+from pathlib import Path
+import tomllib
+
+from langsmith_migrator import __version__
+
+
+def test_package_version_matches_pyproject():
+    """The exported package version should stay aligned with pyproject metadata."""
+
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+
+    assert __version__ == data["project"]["version"]

--- a/tests/test_prompt_migrator.py
+++ b/tests/test_prompt_migrator.py
@@ -74,6 +74,79 @@ class TestPromptMigrator:
 
         assert len(result) == 0
 
+    def test_list_prompts_includes_private_and_public_prompts(self, prompt_migrator):
+        """Prompt listing should include both tenant-private and public prompts."""
+        private_response = Mock()
+        private_prompt = Mock()
+        private_prompt.id = "private-1"
+        private_prompt.repo_handle = "team/private-prompt"
+        private_prompt.description = "private"
+        private_prompt.readme = ""
+        private_prompt.is_public = False
+        private_prompt.is_archived = False
+        private_prompt.tags = []
+        private_prompt.num_likes = 0
+        private_prompt.num_downloads = 0
+        private_prompt.num_commits = 1
+        private_prompt.updated_at = None
+        private_response.repos = [private_prompt]
+
+        public_response = Mock()
+        public_prompt = Mock()
+        public_prompt.id = "public-1"
+        public_prompt.repo_handle = "team/public-prompt"
+        public_prompt.description = "public"
+        public_prompt.readme = ""
+        public_prompt.is_public = True
+        public_prompt.is_archived = False
+        public_prompt.tags = []
+        public_prompt.num_likes = 0
+        public_prompt.num_downloads = 0
+        public_prompt.num_commits = 1
+        public_prompt.updated_at = None
+        public_response.repos = [public_prompt]
+
+        empty_response = Mock()
+        empty_response.repos = []
+        prompt_migrator.source_ls_client.list_prompts.side_effect = [
+            private_response,
+            public_response,
+        ]
+
+        result = prompt_migrator.list_prompts()
+
+        assert [prompt["repo_handle"] for prompt in result] == [
+            "team/private-prompt",
+            "team/public-prompt",
+        ]
+        assert prompt_migrator.source_ls_client.list_prompts.call_args_list[0].kwargs["is_public"] is False
+        assert prompt_migrator.source_ls_client.list_prompts.call_args_list[1].kwargs["is_public"] is True
+
+    def test_find_existing_prompt_paginates_destination_results(self, prompt_migrator):
+        """Destination prompt existence checks should scan all pages, not just the first page."""
+        first_page = Mock()
+        first_page.repos = []
+        for index in range(100):
+            prompt = Mock()
+            prompt.repo_handle = f"team/prompt-{index}"
+            first_page.repos.append(prompt)
+
+        second_page = Mock()
+        target_prompt = Mock()
+        target_prompt.repo_handle = "team/target-prompt"
+        second_page.repos = [target_prompt]
+
+        empty_response = Mock()
+        empty_response.repos = []
+        prompt_migrator.dest_ls_client.list_prompts.side_effect = [
+            first_page,
+            second_page,
+        ]
+
+        assert prompt_migrator.find_existing_prompt("team/target-prompt") is True
+        assert prompt_migrator.dest_ls_client.list_prompts.call_args_list[0].kwargs["offset"] == 0
+        assert prompt_migrator.dest_ls_client.list_prompts.call_args_list[1].kwargs["offset"] == 100
+
     def test_migrate_prompt_dry_run(self, prompt_migrator, sample_config):
         """Test migrating prompt in dry-run mode."""
         sample_config.migration.dry_run = True
@@ -94,6 +167,7 @@ class TestPromptMigrator:
             "manifest": mock_manifest
         })
         prompt_migrator._push_prompt_manifest = Mock(return_value="new-commit-hash-123")
+        prompt_migrator._verify_prompt_commit = Mock(return_value=(True, "new-commit-hash-123"))
 
         result = prompt_migrator.migrate_prompt('user/test-prompt')
 
@@ -129,6 +203,7 @@ class TestPromptMigrator:
             "manifest": mock_manifest
         })
         prompt_migrator._push_prompt_manifest = Mock(return_value="new-commit-hash")
+        prompt_migrator._verify_prompt_commit = Mock(return_value=(True, "new-commit-hash"))
 
         result = prompt_migrator.migrate_prompt('user/test-prompt', include_all_commits=True)
 

--- a/tests/test_prompt_migrator.py
+++ b/tests/test_prompt_migrator.py
@@ -224,6 +224,18 @@ class TestPromptMigrator:
 
         assert result is None
 
+    def test_prompts_api_available_via_commit_lookup_when_listing_is_disabled(self, prompt_migrator):
+        """Capability probing should allow migration when commit lookups work but prompt listing does not."""
+
+        prompt_migrator.probe_capabilities = Mock(
+            return_value={
+                "list_read": {"supported": False, "detail": "405_not_allowed"},
+                "repo_lookup": {"supported": True, "detail": "ok"},
+            }
+        )
+
+        assert prompt_migrator.check_prompts_api_available() == (True, "")
+
     def test_get_prompt_commits(self, prompt_migrator):
         """Test getting prompt commits."""
         mock_commit = Mock()

--- a/tests/test_rules_migrator.py
+++ b/tests/test_rules_migrator.py
@@ -12,12 +12,15 @@ class TestRulesMigrator:
     @pytest.fixture
     def rules_migrator(self, mock_api_client, sample_config, migration_state):
         """Create a RulesMigrator instance."""
-        return RulesMigrator(
-            mock_api_client,
-            mock_api_client,
-            migration_state,
-            sample_config
-        )
+        with patch('langsmith_migrator.core.migrators.rules.Client'):
+            migrator = RulesMigrator(
+                mock_api_client,
+                mock_api_client,
+                migration_state,
+                sample_config
+            )
+            migrator.dest_ls_client = Mock()
+            return migrator
 
     @pytest.fixture
     def sample_rule(self):
@@ -215,7 +218,8 @@ class TestRulesMigrator:
             ]
         }
 
-        result = rules_migrator.create_rule(enhanced_rule)
+        with patch.object(rules_migrator, '_find_existing_prompt', return_value=True):
+            result = rules_migrator.create_rule(enhanced_rule)
 
         assert result == 'new-rule-123'
 
@@ -466,7 +470,8 @@ class TestRulesMigrator:
         
         mock_api_client.post.return_value = {'id': 'new-rule-123'}
         
-        result = rules_migrator.create_rule(rule_with_none_evaluators)
+        with patch.object(rules_migrator, '_find_existing_prompt', return_value=True):
+            result = rules_migrator.create_rule(rule_with_none_evaluators)
         
         assert result == 'new-rule-123'
         
@@ -486,3 +491,28 @@ class TestRulesMigrator:
         assert structured['hub_ref'] == 'eval_test:latest'
         assert structured['variable_mapping'] == {'inputs': 'input'}
 
+    def test_find_existing_prompt_paginates_destination_prompts(self, rules_migrator):
+        """Prompt existence checks for rules should scan all destination prompt pages."""
+        rules_migrator.dest.session.headers["X-Tenant-Id"] = "workspace-123"
+
+        first_page = Mock()
+        first_page.repos = []
+        for index in range(100):
+            prompt = Mock()
+            prompt.repo_handle = f"team/prompt-{index}"
+            first_page.repos.append(prompt)
+
+        second_page = Mock()
+        target_prompt = Mock()
+        target_prompt.repo_handle = "team/target-prompt"
+        second_page.repos = [target_prompt]
+
+        rules_migrator.dest_ls_client.list_prompts.side_effect = [
+            first_page,
+            second_page,
+        ]
+
+        assert rules_migrator._find_existing_prompt("team/target-prompt") is True
+        assert rules_migrator.dest_ls_client.list_prompts.call_args_list[0].kwargs["offset"] == 0
+        assert rules_migrator.dest_ls_client.list_prompts.call_args_list[1].kwargs["offset"] == 100
+        assert rules_migrator._dest_session.headers["X-Tenant-Id"] == "workspace-123"

--- a/tests/test_state_resolution.py
+++ b/tests/test_state_resolution.py
@@ -1,0 +1,97 @@
+"""Resolver-state and remediation bundle tests."""
+
+from __future__ import annotations
+
+import json
+import time
+
+from langsmith_migrator.utils.state import (
+    MigrationState,
+    ResolutionOutcome,
+    StateManager,
+    VerificationState,
+)
+
+
+def test_state_manager_writes_remediation_bundle_and_round_trips(tmp_path):
+    """Saving resolver state should emit bundle files and preserve remediation metadata."""
+
+    state_manager = StateManager(tmp_path / "state")
+    state = state_manager.create_session("https://source.example", "https://dest.example")
+    item = state.ensure_item(
+        "prompt_team_prompt-a",
+        "prompt",
+        "team/prompt-a",
+        "team/prompt-a",
+        stage="manual_apply",
+    )
+    export_path = state.export_artifact(item.id, "manual_apply", {"prompt": "payload"})
+    issue = state.add_issue(
+        "capability",
+        "prompt_write_unsupported",
+        "Prompt writes are unavailable on the destination instance",
+        item_id=item.id,
+        next_action="Apply the exported prompt manually, then run resume.",
+        export_path=export_path,
+    )
+    state.queue_remediation(
+        issue_id=issue.id,
+        item_id=item.id,
+        next_action="Apply the exported prompt manually, then run resume.",
+        export_path=export_path,
+        command="langsmith-migrator resume",
+    )
+    state.mark_terminal(
+        item.id,
+        ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY,
+        "prompt_write_unsupported",
+        verification_state=VerificationState.EXPORTED,
+        next_action="Apply the exported prompt manually, then run resume.",
+        export_path=export_path,
+    )
+    state_manager.save()
+
+    bundle_dir = tmp_path / "remediation" / state.session_id
+    assert (bundle_dir / "summary.md").exists()
+    assert (bundle_dir / "issues.json").exists()
+    assert (bundle_dir / "items.json").exists()
+
+    loaded = state_manager.load_session(state.session_id)
+    assert loaded is not None
+    assert loaded.schema_version == 2
+    assert loaded.get_terminal_counts()[ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY.value] == 1
+    assert loaded.remediation_queue[0].command == "langsmith-migrator resume"
+
+
+def test_loading_v1_state_upgrades_to_schema_v2(tmp_path):
+    """Legacy state payloads should load with schema v2 defaults and verification summary."""
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    state_payload = {
+        "session_id": "migration_legacy",
+        "started_at": time.time(),
+        "updated_at": time.time(),
+        "source_url": "https://source.example",
+        "destination_url": "https://dest.example",
+        "items": {
+            "dataset_1": {
+                "id": "dataset_1",
+                "type": "dataset",
+                "name": "Dataset One",
+                "source_id": "dataset-1",
+                "status": "pending",
+                "metadata": {},
+            }
+        },
+        "id_mappings": {},
+        "statistics": {},
+    }
+    (state_dir / "migration_legacy.json").write_text(json.dumps(state_payload), encoding="utf-8")
+
+    state_manager = StateManager(state_dir)
+    loaded = state_manager.load_session("migration_legacy")
+
+    assert loaded is not None
+    assert loaded.schema_version == 2
+    assert loaded.verification_summary["total"] == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -688,6 +688,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/0a/a3871375c7b9727edaeeea994bfff7c63ff7804c9829c19309ba2e058807/greenlet-3.3.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b01548f6e0b9e9784a2c99c5651e5dc89ffcbe870bc5fb2e5ef864e9cc6b5dcb", size = 276379, upload-time = "2025-12-04T14:23:30.498Z" },
     { url = "https://files.pythonhosted.org/packages/43/ab/7ebfe34dce8b87be0d11dae91acbf76f7b8246bf9d6b319c741f99fa59c6/greenlet-3.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349345b770dc88f81506c6861d22a6ccd422207829d2c854ae2af8025af303e3", size = 597294, upload-time = "2025-12-04T14:50:06.847Z" },
     { url = "https://files.pythonhosted.org/packages/a4/39/f1c8da50024feecd0793dbd5e08f526809b8ab5609224a2da40aad3a7641/greenlet-3.3.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8e18ed6995e9e2c0b4ed264d2cf89260ab3ac7e13555b8032b25a74c6d18655", size = 607742, upload-time = "2025-12-04T14:57:42.349Z" },
+    { url = "https://files.pythonhosted.org/packages/77/cb/43692bcd5f7a0da6ec0ec6d58ee7cddb606d055ce94a62ac9b1aa481e969/greenlet-3.3.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c024b1e5696626890038e34f76140ed1daf858e37496d33f2af57f06189e70d7", size = 622297, upload-time = "2025-12-04T15:07:13.552Z" },
     { url = "https://files.pythonhosted.org/packages/75/b0/6bde0b1011a60782108c01de5913c588cf51a839174538d266de15e4bf4d/greenlet-3.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:047ab3df20ede6a57c35c14bf5200fcf04039d50f908270d3f9a7a82064f543b", size = 609885, upload-time = "2025-12-04T14:26:02.368Z" },
     { url = "https://files.pythonhosted.org/packages/49/0e/49b46ac39f931f59f987b7cd9f34bfec8ef81d2a1e6e00682f55be5de9f4/greenlet-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d9ad37fc657b1102ec880e637cccf20191581f75c64087a549e66c57e1ceb53", size = 1567424, upload-time = "2025-12-04T15:04:23.757Z" },
     { url = "https://files.pythonhosted.org/packages/05/f5/49a9ac2dff7f10091935def9165c90236d8f175afb27cbed38fb1d61ab6b/greenlet-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83cd0e36932e0e7f36a64b732a6f60c2fc2df28c351bae79fbaf4f8092fe7614", size = 1636017, upload-time = "2025-12-04T14:27:29.688Z" },
@@ -695,6 +696,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/2f/28592176381b9ab2cafa12829ba7b472d177f3acc35d8fbcf3673d966fff/greenlet-3.3.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a1e41a81c7e2825822f4e068c48cb2196002362619e2d70b148f20a831c00739", size = 275140, upload-time = "2025-12-04T14:23:01.282Z" },
     { url = "https://files.pythonhosted.org/packages/2c/80/fbe937bf81e9fca98c981fe499e59a3f45df2a04da0baa5c2be0dca0d329/greenlet-3.3.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f515a47d02da4d30caaa85b69474cec77b7929b2e936ff7fb853d42f4bf8808", size = 599219, upload-time = "2025-12-04T14:50:08.309Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ff/7c985128f0514271b8268476af89aee6866df5eec04ac17dcfbc676213df/greenlet-3.3.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d2d9fd66bfadf230b385fdc90426fcd6eb64db54b40c495b72ac0feb5766c54", size = 610211, upload-time = "2025-12-04T14:57:43.968Z" },
+    { url = "https://files.pythonhosted.org/packages/79/07/c47a82d881319ec18a4510bb30463ed6891f2ad2c1901ed5ec23d3de351f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30a6e28487a790417d036088b3bcb3f3ac7d8babaa7d0139edbaddebf3af9492", size = 624311, upload-time = "2025-12-04T15:07:14.697Z" },
     { url = "https://files.pythonhosted.org/packages/fd/8e/424b8c6e78bd9837d14ff7df01a9829fc883ba2ab4ea787d4f848435f23f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:087ea5e004437321508a8d6f20efc4cfec5e3c30118e1417ea96ed1d93950527", size = 612833, upload-time = "2025-12-04T14:26:03.669Z" },
     { url = "https://files.pythonhosted.org/packages/b5/ba/56699ff9b7c76ca12f1cdc27a886d0f81f2189c3455ff9f65246780f713d/greenlet-3.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab97cf74045343f6c60a39913fa59710e4bd26a536ce7ab2397adf8b27e67c39", size = 1567256, upload-time = "2025-12-04T15:04:25.276Z" },
     { url = "https://files.pythonhosted.org/packages/1e/37/f31136132967982d698c71a281a8901daf1a8fbab935dce7c0cf15f942cc/greenlet-3.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5375d2e23184629112ca1ea89a53389dddbffcf417dad40125713d88eb5f96e8", size = 1636483, upload-time = "2025-12-04T14:27:30.804Z" },
@@ -702,6 +704,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/7c/f0a6d0ede2c7bf092d00bc83ad5bafb7e6ec9b4aab2fbdfa6f134dc73327/greenlet-3.3.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:60c2ef0f578afb3c8d92ea07ad327f9a062547137afe91f38408f08aacab667f", size = 275671, upload-time = "2025-12-04T14:23:05.267Z" },
     { url = "https://files.pythonhosted.org/packages/44/06/dac639ae1a50f5969d82d2e3dd9767d30d6dbdbab0e1a54010c8fe90263c/greenlet-3.3.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a5d554d0712ba1de0a6c94c640f7aeba3f85b3a6e1f2899c11c2c0428da9365", size = 646360, upload-time = "2025-12-04T14:50:10.026Z" },
     { url = "https://files.pythonhosted.org/packages/e0/94/0fb76fe6c5369fba9bf98529ada6f4c3a1adf19e406a47332245ef0eb357/greenlet-3.3.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3a898b1e9c5f7307ebbde4102908e6cbfcb9ea16284a3abe15cab996bee8b9b3", size = 658160, upload-time = "2025-12-04T14:57:45.41Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/d2c70cae6e823fac36c3bbc9077962105052b7ef81db2f01ec3b9bf17e2b/greenlet-3.3.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dcd2bdbd444ff340e8d6bdf54d2f206ccddbb3ccfdcd3c25bf4afaa7b8f0cf45", size = 671388, upload-time = "2025-12-04T15:07:15.789Z" },
     { url = "https://files.pythonhosted.org/packages/b8/14/bab308fc2c1b5228c3224ec2bf928ce2e4d21d8046c161e44a2012b5203e/greenlet-3.3.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5773edda4dc00e173820722711d043799d3adb4f01731f40619e07ea2750b955", size = 660166, upload-time = "2025-12-04T14:26:05.099Z" },
     { url = "https://files.pythonhosted.org/packages/4b/d2/91465d39164eaa0085177f61983d80ffe746c5a1860f009811d498e7259c/greenlet-3.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac0549373982b36d5fd5d30beb8a7a33ee541ff98d2b502714a09f1169f31b55", size = 1615193, upload-time = "2025-12-04T15:04:27.041Z" },
     { url = "https://files.pythonhosted.org/packages/42/1b/83d110a37044b92423084d52d5d5a3b3a73cafb51b547e6d7366ff62eff1/greenlet-3.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d198d2d977460358c3b3a4dc844f875d1adb33817f0613f663a656f463764ccc", size = 1683653, upload-time = "2025-12-04T14:27:32.366Z" },
@@ -709,6 +712,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/66/bd6317bc5932accf351fc19f177ffba53712a202f9df10587da8df257c7e/greenlet-3.3.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d6ed6f85fae6cdfdb9ce04c9bf7a08d666cfcfb914e7d006f44f840b46741931", size = 282638, upload-time = "2025-12-04T14:25:20.941Z" },
     { url = "https://files.pythonhosted.org/packages/30/cf/cc81cb030b40e738d6e69502ccbd0dd1bced0588e958f9e757945de24404/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9125050fcf24554e69c4cacb086b87b3b55dc395a8b3ebe6487b045b2614388", size = 651145, upload-time = "2025-12-04T14:50:11.039Z" },
     { url = "https://files.pythonhosted.org/packages/9c/ea/1020037b5ecfe95ca7df8d8549959baceb8186031da83d5ecceff8b08cd2/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:87e63ccfa13c0a0f6234ed0add552af24cc67dd886731f2261e46e241608bee3", size = 654236, upload-time = "2025-12-04T14:57:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/cc/1e4bae2e45ca2fa55299f4e85854606a78ecc37fead20d69322f96000504/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2662433acbca297c9153a4023fe2161c8dcfdcc91f10433171cf7e7d94ba2221", size = 662506, upload-time = "2025-12-04T15:07:16.906Z" },
     { url = "https://files.pythonhosted.org/packages/57/b9/f8025d71a6085c441a7eaff0fd928bbb275a6633773667023d19179fe815/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c6e9b9c1527a78520357de498b0e709fb9e2f49c3a513afd5a249007261911b", size = 653783, upload-time = "2025-12-04T14:26:06.225Z" },
     { url = "https://files.pythonhosted.org/packages/f6/c7/876a8c7a7485d5d6b5c6821201d542ef28be645aa024cfe1145b35c120c1/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:286d093f95ec98fdd92fcb955003b8a3d054b4e2cab3e2707a5039e7b50520fd", size = 1614857, upload-time = "2025-12-04T15:04:28.484Z" },
     { url = "https://files.pythonhosted.org/packages/4f/dc/041be1dff9f23dac5f48a43323cd0789cb798342011c19a248d9c9335536/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c10513330af5b8ae16f023e8ddbfb486ab355d04467c4679c5cfe4659975dd9", size = 1676034, upload-time = "2025-12-04T14:27:33.531Z" },
@@ -1324,7 +1328,11 @@ test = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "respx" },
 ]
 
 [package.metadata]
@@ -1361,7 +1369,13 @@ requires-dist = [
 provides-extras = ["test", "models", "all"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.1" }]
+dev = [
+    { name = "httpx", specifier = ">=0.24.0" },
+    { name = "pytest", specifier = ">=9.0.1" },
+    { name = "pytest-asyncio", specifier = ">=0.21.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "respx", specifier = ">=0.20.0" },
+]
 
 [[package]]
 name = "linkify-it-py"


### PR DESCRIPTION
## Summary
- add a reusable CLI functional test harness around fake console, progress, orchestrator, and migrator dependencies
- cover the main Click commands and key branching behavior for datasets, prompts, queues, rules, charts, resume, clean, list helpers, and migrate-all
- fix migration state ID lookups for chart session mappings and update dev/test tracking so the suite runs with the default uv workflow

## Testing
- uv run pytest -q