### PR TITLE
Fix resume handling for checkpointed items and stale remediation tasks

### DIFF
--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -27,7 +27,13 @@ def ssl_option(f):
         # The global cli() already handles --no-ssl via the config object
         return f(*args, **kwargs)
     return wrapper
-from ..utils.state import MigrationStatus, ResolutionOutcome, StateManager, VerificationState
+from ..utils.state import (
+    MANUAL_FOLLOW_UP_STATES,
+    MigrationStatus,
+    ResolutionOutcome,
+    StateManager,
+    VerificationState,
+)
 from ..core.migrators import (
     MigrationOrchestrator,
     DatasetMigrator,
@@ -432,9 +438,8 @@ def _needs_operator_action(state) -> bool:
         return False
     terminal = state.get_terminal_counts()
     return bool(
-        terminal.get(ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value)
-        or terminal.get(ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY.value)
-        or state.remediation_queue
+        any(terminal.get(outcome) for outcome in MANUAL_FOLLOW_UP_STATES)
+        or state.get_active_remediation_tasks()
     )
 
 

--- a/langsmith_migrator/utils/state.py
+++ b/langsmith_migrator/utils/state.py
@@ -42,6 +42,12 @@ class VerificationState(Enum):
     EXPORTED = "exported"
 
 
+MANUAL_FOLLOW_UP_STATES = {
+    ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value,
+    ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY.value,
+}
+
+
 class IssueClass(Enum):
     """Typed incident classes for resolver workflows."""
 
@@ -470,18 +476,45 @@ class MigrationState:
 
     def get_resume_items(self, max_attempts: int = 3) -> List[MigrationItem]:
         """Return items that should be reconsidered by resume."""
-        items = self.get_pending_items(include_in_progress=True)
-        items.extend(self.get_failed_items(max_attempts=max_attempts))
-        return items
+        resumable: Dict[str, MigrationItem] = {}
+        for item in self.get_pending_items(include_in_progress=True):
+            resumable[item.id] = item
+        for item in self.get_failed_items(max_attempts=max_attempts):
+            resumable[item.id] = item
+        for item in self.get_checkpoint_items():
+            resumable[item.id] = item
+        return list(resumable.values())
+
+    def get_active_remediation_tasks(self) -> List[RemediationTask]:
+        """Return remediation tasks that still require operator follow-up."""
+        active_tasks: List[RemediationTask] = []
+        for task in self.remediation_queue:
+            if task.status not in {"pending", "in_progress"}:
+                continue
+            if not task.item_id:
+                active_tasks.append(task)
+                continue
+            item = self.items.get(task.item_id)
+            if item is None:
+                active_tasks.append(task)
+                continue
+            if (
+                item.status == MigrationStatus.COMPLETED
+                or item.terminal_state
+                in (
+                    ResolutionOutcome.MIGRATED.value,
+                    ResolutionOutcome.MIGRATED_WITH_VERIFIED_DOWNGRADE.value,
+                )
+            ):
+                continue
+            active_tasks.append(task)
+        return active_tasks
 
     def get_checkpoint_items(self) -> List[MigrationItem]:
         """Return items that landed in a checkpoint/export terminal state."""
         items = []
         for item in self.items.values():
-            if item.terminal_state in (
-                ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value,
-                ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY.value,
-            ):
+            if item.terminal_state in MANUAL_FOLLOW_UP_STATES:
                 items.append(item)
         return items
 
@@ -943,6 +976,8 @@ class StateManager:
         exported = stats["terminal"].get(
             ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY.value, 0
         )
+        resumable_items = state.get_resume_items()
+        active_remediation_tasks = state.get_active_remediation_tasks()
         return {
             "session_id": state.session_id,
             "total_items": stats["total"],
@@ -951,13 +986,9 @@ class StateManager:
             "pending": stats["pending"],
             "blocked": blocked,
             "exported": exported,
-            "can_resume": (
-                stats["pending"] > 0
-                or stats["failed"] > 0
-                or len(state.remediation_queue) > 0
-            ),
+            "can_resume": len(resumable_items) > 0,
             "elapsed_time": stats["elapsed_time"],
             "by_type": stats["by_type"],
             "remediation_bundle_path": state.remediation_bundle_path,
-            "remediation_tasks": len(state.remediation_queue),
+            "remediation_tasks": len(active_remediation_tasks),
         }

--- a/tests/test_state_resolution.py
+++ b/tests/test_state_resolution.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 import time
 
+from langsmith_migrator.cli.main import _needs_operator_action
 from langsmith_migrator.utils.state import (
+    MigrationStatus,
     MigrationState,
     ResolutionOutcome,
     StateManager,
@@ -95,3 +97,61 @@ def test_loading_v1_state_upgrades_to_schema_v2(tmp_path):
     assert loaded is not None
     assert loaded.schema_version == 2
     assert loaded.verification_summary["total"] == 1
+
+
+def test_resume_items_include_exported_and_resume_info_marks_resumable(tmp_path):
+    """Exported items should be eligible for resume and visible as resumable."""
+
+    state_manager = StateManager(tmp_path / "state")
+    state = state_manager.create_session("https://source.example", "https://dest.example")
+    item = state.ensure_item("prompt_1", "prompt", "prompt-1", "prompt-1")
+    state.mark_terminal(
+        item.id,
+        ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY,
+        "prompt_write_unsupported",
+        verification_state=VerificationState.EXPORTED,
+        next_action="Apply exported prompt then run resume.",
+    )
+
+    resume_items = state.get_resume_items()
+    assert {resume_item.id for resume_item in resume_items} == {item.id}
+
+    resume_info = state_manager.get_resume_info(state)
+    assert resume_info["can_resume"] is True
+    assert resume_info["exported"] == 1
+
+
+def test_completed_items_do_not_leave_stale_operator_action_tasks(tmp_path):
+    """Resolved items should not keep non-interactive runs in operator-action mode."""
+
+    state = MigrationState(
+        session_id="migration_test",
+        started_at=time.time(),
+        updated_at=time.time(),
+        source_url="https://source.example",
+        destination_url="https://dest.example",
+    )
+    item = state.ensure_item("prompt_2", "prompt", "prompt-2", "prompt-2")
+    issue = state.add_issue(
+        "transient",
+        "resume_dispatch_failed",
+        "Resume failed",
+        item_id=item.id,
+        next_action="Run resume again.",
+    )
+    state.queue_remediation(
+        issue_id=issue.id,
+        item_id=item.id,
+        next_action="Run resume again.",
+        command="langsmith-migrator resume",
+    )
+    state.update_item_status(item.id, MigrationStatus.COMPLETED)
+    state.mark_terminal(
+        item.id,
+        ResolutionOutcome.MIGRATED,
+        "prompt_migrated",
+        verification_state=VerificationState.VERIFIED,
+    )
+
+    assert state.get_active_remediation_tasks() == []
+    assert _needs_operator_action(state) is False


### PR DESCRIPTION
## Summary
- include checkpoint/exported items in `get_resume_items()` so `resume` can actually reconsider manual-follow-up records
- treat remediation requirements as active work only by adding `get_active_remediation_tasks()` and using it in CLI operator-action gating
- add regression tests for resume eligibility and for ignoring stale remediation tasks after successful completion

## Test plan
- [x] `uv run pytest tests/test_state_resolution.py -q`
- [x] `uv run pytest`

Made with [Cursor](https://cursor.com)