### PR TITLE
chore: remove Trivy checks from security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   security-checks:
@@ -53,22 +52,6 @@ jobs:
               exit 1
             fi
           fi
-
-      # Trivy Vulnerability Scan
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        with:
-          scan-type: 'fs'
-          scan-ref: '.'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-
-      - name: Upload Trivy scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
 
       # License Compliance
       - name: Check licenses


### PR DESCRIPTION
## Summary
- Remove Trivy filesystem vulnerability scanner step and SARIF upload step from `.github/workflows/security.yml`
- Drop the `security-events: write` permission that was only needed for the SARIF upload
- Supersedes #33 which had merge conflicts

## Test plan
- [ ] Verify the Security workflow still runs successfully (secret detection + license compliance steps remain intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)