### PR TITLE
Release v0.0.54: workspace-scoped prompt migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,14 +43,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release create '${{ github.ref_name }}' \
-            --repo '${{ github.repository }}' \
-            --notes-file release_notes.md \
-            --title 'Release ${{ github.ref_name }}'
+          if gh release view '${{ github.ref_name }}' --repo '${{ github.repository }}' >/dev/null 2>&1; then
+            echo "Release '${{ github.ref_name }}' already exists, updating metadata."
+            gh release edit '${{ github.ref_name }}' \
+              --repo '${{ github.repository }}' \
+              --notes-file release_notes.md \
+              --title 'Release ${{ github.ref_name }}'
+          else
+            gh release create '${{ github.ref_name }}' \
+              --repo '${{ github.repository }}' \
+              --notes-file release_notes.md \
+              --title 'Release ${{ github.ref_name }}'
+          fi
 
       - name: Upload distribution files to release
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           gh release upload '${{ github.ref_name }}' dist/** \
-            --repo '${{ github.repository }}'
+            --repo '${{ github.repository }}' \
+            --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.54] - 2026-03-31
+
+### Removed
+- **Trivy vulnerability scanner**: Removed Trivy scan and SARIF upload steps from security workflow
+
+### Fixed
+- **Workspace mapper cursor**: Preserve cursor position when navigating workspace mapper TUI
+
+### Changed
+- **LangSmith SDK**: Bumped minimum `langsmith` dependency to `>=0.7.23`
+
 ## [0.0.53] - 2026-03-31
 
 ### Added

--- a/langsmith_migrator/core/migrators/prompt.py
+++ b/langsmith_migrator/core/migrators/prompt.py
@@ -587,38 +587,40 @@ class PromptMigrator(BaseMigrator):
             self.log(f"Fetching prompts (archived={is_archived})...", "info")
             seen_handles = set()
 
-            for visibility in (False, True):
-                try:
-                    for prompt in self._iter_prompt_repos(
-                        self.source_ls_client,
-                        is_archived=is_archived,
-                        is_public=visibility,
-                    ):
-                        if prompt.repo_handle in seen_handles:
-                            continue
-                        seen_handles.add(prompt.repo_handle)
-                        prompts.append({
-                            'id': str(prompt.id),
-                            'repo_handle': prompt.repo_handle,
-                            'description': prompt.description,
-                            'readme': prompt.readme,
-                            'is_public': prompt.is_public,
-                            'is_archived': prompt.is_archived,
-                            'tags': prompt.tags or [],
-                            'num_likes': prompt.num_likes,
-                            'num_downloads': prompt.num_downloads,
-                            'num_commits': prompt.num_commits,
-                            'updated_at': str(prompt.updated_at) if prompt.updated_at else None,
-                        })
-                except Exception as api_error:
-                    self.log(f"API error while listing prompts: {api_error}", "error")
-                    if prompts:
-                        self.log(
-                            f"Returning {len(prompts)} prompts fetched before error",
-                            "warning",
-                        )
-                        return prompts
-                    raise
+            try:
+                # Do not force visibility filters here. With workspace scoping enabled
+                # (X-Tenant-Id), this keeps discovery limited to the selected workspace
+                # instead of unioning broad public catalogs.
+                for prompt in self._iter_prompt_repos(
+                    self.source_ls_client,
+                    is_archived=is_archived,
+                    is_public=None,
+                ):
+                    if prompt.repo_handle in seen_handles:
+                        continue
+                    seen_handles.add(prompt.repo_handle)
+                    prompts.append({
+                        'id': str(prompt.id),
+                        'repo_handle': prompt.repo_handle,
+                        'description': prompt.description,
+                        'readme': prompt.readme,
+                        'is_public': prompt.is_public,
+                        'is_archived': prompt.is_archived,
+                        'tags': prompt.tags or [],
+                        'num_likes': prompt.num_likes,
+                        'num_downloads': prompt.num_downloads,
+                        'num_commits': prompt.num_commits,
+                        'updated_at': str(prompt.updated_at) if prompt.updated_at else None,
+                    })
+            except Exception as api_error:
+                self.log(f"API error while listing prompts: {api_error}", "error")
+                if prompts:
+                    self.log(
+                        f"Returning {len(prompts)} prompts fetched before error",
+                        "warning",
+                    )
+                    return prompts
+                raise
 
             self.log(f"Total prompts fetched: {len(prompts)}", "success")
             return prompts
@@ -654,13 +656,12 @@ class PromptMigrator(BaseMigrator):
         """
         self._sync_workspace_headers()
         try:
-            for visibility in (False, True):
-                for prompt in self._iter_prompt_repos(
-                    self.dest_ls_client,
-                    is_public=visibility,
-                ):
-                    if prompt.repo_handle == prompt_identifier:
-                        return True
+            for prompt in self._iter_prompt_repos(
+                self.dest_ls_client,
+                is_public=None,
+            ):
+                if prompt.repo_handle == prompt_identifier:
+                    return True
             return False
         except Exception as e:
             self.log(f"Could not check if prompt exists: {e}", "warning")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.53"
+version = "0.0.54"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_prompt_migrator.py
+++ b/tests/test_prompt_migrator.py
@@ -74,9 +74,9 @@ class TestPromptMigrator:
 
         assert len(result) == 0
 
-    def test_list_prompts_includes_private_and_public_prompts(self, prompt_migrator):
-        """Prompt listing should include both tenant-private and public prompts."""
-        private_response = Mock()
+    def test_list_prompts_uses_workspace_scoped_listing(self, prompt_migrator):
+        """Prompt listing should rely on workspace scoping rather than visibility sweeps."""
+        scoped_response = Mock()
         private_prompt = Mock()
         private_prompt.id = "private-1"
         private_prompt.repo_handle = "team/private-prompt"
@@ -89,38 +89,13 @@ class TestPromptMigrator:
         private_prompt.num_downloads = 0
         private_prompt.num_commits = 1
         private_prompt.updated_at = None
-        private_response.repos = [private_prompt]
-
-        public_response = Mock()
-        public_prompt = Mock()
-        public_prompt.id = "public-1"
-        public_prompt.repo_handle = "team/public-prompt"
-        public_prompt.description = "public"
-        public_prompt.readme = ""
-        public_prompt.is_public = True
-        public_prompt.is_archived = False
-        public_prompt.tags = []
-        public_prompt.num_likes = 0
-        public_prompt.num_downloads = 0
-        public_prompt.num_commits = 1
-        public_prompt.updated_at = None
-        public_response.repos = [public_prompt]
-
-        empty_response = Mock()
-        empty_response.repos = []
-        prompt_migrator.source_ls_client.list_prompts.side_effect = [
-            private_response,
-            public_response,
-        ]
+        scoped_response.repos = [private_prompt]
+        prompt_migrator.source_ls_client.list_prompts.return_value = scoped_response
 
         result = prompt_migrator.list_prompts()
 
-        assert [prompt["repo_handle"] for prompt in result] == [
-            "team/private-prompt",
-            "team/public-prompt",
-        ]
-        assert prompt_migrator.source_ls_client.list_prompts.call_args_list[0].kwargs["is_public"] is False
-        assert prompt_migrator.source_ls_client.list_prompts.call_args_list[1].kwargs["is_public"] is True
+        assert [prompt["repo_handle"] for prompt in result] == ["team/private-prompt"]
+        assert "is_public" not in prompt_migrator.source_ls_client.list_prompts.call_args.kwargs
 
     def test_find_existing_prompt_paginates_destination_results(self, prompt_migrator):
         """Destination prompt existence checks should scan all pages, not just the first page."""

--- a/uv.lock
+++ b/uv.lock
@@ -1286,7 +1286,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.53"
+version = "0.0.54"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- release `v0.0.54` by bumping package version and changelog entries
- scope prompt discovery to the active workspace context instead of sweeping public/private visibility
- update prompt migrator tests to validate workspace-scoped listing behavior

## Test plan
- [x] `uv run pytest tests/test_prompt_migrator.py -v`
- [x] `uv run pytest tests/functional/test_cli_functional.py -k "prompts_command" -v`

Made with [Cursor](https://cursor.com)