### PR TITLE
Release v0.0.55: prompt scoping and quieter CLI logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.55] - 2026-04-01
+
+### Fixed
+- **CLI log noise**: Suppressed low-signal `run compression is not enabled` output during normal migration runs
+- **Release workflow reliability**: Made release publishing idempotent when the tag/release already exists
+
 ## [0.0.54] - 2026-03-31
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.56] - 2026-04-01
+
+### Added
+- **migrate-all charts support**: Included chart migration as step 5 in `migrate-all`, with same-instance detection and migration-state tracking.
+- **Charts skip flag for migrate-all**: Added `--skip-charts` to bypass chart migration when desired.
+
+### Improved
+- **Wizard control for charts**: Users can now explicitly skip charts from the interactive `migrate-all` wizard prompt even when charts are available.
+- **Workspace/project mapping parity**: `migrate-all` chart migration now honors workspace-scoped and project-mapped flows consistently.
+
 ## [0.0.55] - 2026-04-01
 
 ### Fixed

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -1,6 +1,7 @@
 """Simplified CLI interface with improved architecture."""
 
 import functools
+import logging
 from typing import Iterable
 import click
 import time
@@ -49,6 +50,26 @@ from ..utils.workspace_resolver import resolve_workspace_context, display_worksp
 
 
 console = Console()
+
+
+class _SuppressRunCompressionNoise(logging.Filter):
+    """Hide known low-signal LangSmith run compression info logs."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage().lower()
+        return "run compression is not enabled" not in message
+
+
+def _install_log_filters() -> None:
+    """Install process-wide filters for noisy third-party logs."""
+    noise_filter = _SuppressRunCompressionNoise()
+    root_logger = logging.getLogger()
+
+    for handler in root_logger.handlers:
+        handler.addFilter(noise_filter)
+
+    # Also attach directly to the common LangSmith logger namespace.
+    logging.getLogger("langsmith").addFilter(noise_filter)
 
 
 def workspace_options(f):
@@ -498,6 +519,7 @@ def ensure_config(config: Config) -> bool:
 def cli(ctx, source_key, dest_key, source_url, dest_url, no_ssl, batch_size, workers, dry_run, skip_existing, non_interactive, verbose):
     """LangSmith Migration Tool - Migrate data between LangSmith instances."""
     ctx.ensure_object(dict)
+    _install_log_filters()
 
     # Create configuration
     config = Config(

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -1459,6 +1459,7 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
 @click.option('--skip-prompts', is_flag=True, help='Skip prompt migration')
 @click.option('--skip-queues', is_flag=True, help='Skip annotation queue migration')
 @click.option('--skip-rules', is_flag=True, help='Skip rules migration')
+@click.option('--skip-charts', is_flag=True, help='Skip chart migration')
 @click.option('--include-all-commits', is_flag=True, help='Include all prompt commit history')
 @click.option('--strip-projects', is_flag=True, help='Strip project associations from rules')
 @click.option('--map-projects', is_flag=True, help='Launch interactive TUI to map source projects to destination projects')
@@ -1471,7 +1472,7 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
 )
 @workspace_options
 @click.pass_context
-def migrate_all(ctx, skip_datasets, skip_experiments, skip_prompts, skip_queues, skip_rules, include_all_commits, strip_projects, map_projects, rules_create_enabled, source_workspace, dest_workspace, map_workspaces):
+def migrate_all(ctx, skip_datasets, skip_experiments, skip_prompts, skip_queues, skip_rules, skip_charts, include_all_commits, strip_projects, map_projects, rules_create_enabled, source_workspace, dest_workspace, map_workspaces):
     """Migrate all resources interactively."""
     config = ctx.obj['config']
     state_manager = ctx.obj['state_manager']
@@ -1525,7 +1526,8 @@ def migrate_all(ctx, skip_datasets, skip_experiments, skip_prompts, skip_queues,
             preflight_resources.append("queues")
         if not skip_rules:
             preflight_resources.append("rules")
-        preflight_resources.append("charts")
+        if not skip_charts:
+            preflight_resources.append("charts")
         _run_preflight(orchestrator, config, preflight_resources)
 
         # Use per-workspace project mapping from the TUI if available
@@ -1534,7 +1536,7 @@ def migrate_all(ctx, skip_datasets, skip_experiments, skip_prompts, skip_queues,
             ws_project_mapping = ws_result.project_mappings[src_ws]
 
         _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_experiments,
-                                   skip_prompts, skip_queues, skip_rules, include_all_commits,
+                                   skip_prompts, skip_queues, skip_rules, skip_charts, include_all_commits,
                                    strip_projects, map_projects, rules_create_enabled, ws_project_mapping)
 
     if ws_result:
@@ -1547,7 +1549,7 @@ def migrate_all(ctx, skip_datasets, skip_experiments, skip_prompts, skip_queues,
 
 
 def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_experiments,
-                                skip_prompts, skip_queues, skip_rules, include_all_commits,
+                                skip_prompts, skip_queues, skip_rules, skip_charts, include_all_commits,
                                 strip_projects, map_projects, rules_create_enabled=None, ws_project_mapping=None):
     """Run the full migrate_all flow for a single workspace pair (or no workspace).
 
@@ -1880,6 +1882,98 @@ def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_ex
             console.print("[yellow]none found[/yellow]\n")
     else:
         console.print("[dim]Skipping rules (--skip-rules)[/dim]\n")
+
+    # 5. Charts
+    if not skip_charts:
+        console.print("[bold]Step 5: Charts[/bold]")
+        from ..core.migrators import ChartMigrator
+        chart_migrator = ChartMigrator(
+            orchestrator.source_client,
+            orchestrator.dest_client,
+            orchestrator.state,
+            config
+        )
+
+        if project_id_map:
+            chart_migrator._project_id_map = dict(project_id_map)
+            console.print(f"[dim]Using interactive project mapping ({len(project_id_map)} project(s))[/dim]")
+
+        same_instance = False
+        source_url = config.source.base_url.rstrip('/').lower()
+        dest_url = config.destination.base_url.rstrip('/').lower()
+        if source_url == dest_url:
+            if config.source.api_key == config.destination.api_key:
+                same_instance = True
+                console.print("[dim]Detected same source and destination instance (same URL and API key)[/dim]")
+            else:
+                console.print("[dim]Detected same instance URL but different API keys (likely different workspaces).[/dim]")
+                console.print("[dim]Will use project name matching instead of same session IDs.[/dim]")
+
+        source_charts = chart_migrator.list_charts()
+        if source_charts:
+            console.print(f"found {len(source_charts)}")
+            if _confirm_action(config, f"Migrate {len(source_charts)} chart(s)?", default=True, non_interactive_value=True):
+                _ensure_migration_session(orchestrator, config)
+                chart_migrator.state = orchestrator.state
+                tracked_chart_items = {}
+
+                if not same_instance and not chart_migrator._project_id_map:
+                    chart_migrator._build_project_mapping()
+
+                for chart in source_charts:
+                    chart_id = chart.get("id")
+                    if not chart_id:
+                        continue
+                    chart_title = chart.get("title") or chart.get("name") or "Untitled Chart"
+                    source_session_id = chart_migrator._extract_session_id(chart)
+                    dest_session_id = None
+                    if source_session_id:
+                        if same_instance:
+                            dest_session_id = source_session_id
+                        elif chart_migrator._project_id_map:
+                            dest_session_id = chart_migrator._project_id_map.get(source_session_id)
+                    item_id = _ensure_state_item(
+                        orchestrator,
+                        config,
+                        "chart",
+                        chart_id,
+                        chart_title,
+                        metadata={
+                            "chart": chart,
+                            "dest_session_id": dest_session_id,
+                            "same_instance": same_instance,
+                        },
+                    )
+                    tracked_chart_items[chart_id] = item_id
+                    _mark_state_item_started(orchestrator, item_id)
+
+                all_mappings = chart_migrator.migrate_all_charts(same_instance=same_instance)
+                flat_chart_map = {}
+                for session_chart_map in all_mappings.values():
+                    flat_chart_map.update(session_chart_map)
+
+                for chart_id, item_id in tracked_chart_items.items():
+                    if chart_id in flat_chart_map:
+                        _mark_state_item_completed(
+                            orchestrator,
+                            item_id,
+                            destination_id=flat_chart_map[chart_id],
+                        )
+                    else:
+                        _mark_state_item_failed(
+                            orchestrator,
+                            item_id,
+                            "chart migration returned None",
+                        )
+
+                console.print(f"Charts: {len(flat_chart_map)} migrated, {len(tracked_chart_items) - len(flat_chart_map)} failed")
+                console.print()
+            else:
+                console.print("[yellow]Skipped charts[/yellow]\n")
+        else:
+            console.print("[yellow]none found[/yellow]\n")
+    else:
+        console.print("[dim]Skipping charts (--skip-charts)[/dim]\n")
 
 
 @cli.command()

--- a/langsmith_migrator/core/migrators/prompt.py
+++ b/langsmith_migrator/core/migrators/prompt.py
@@ -588,13 +588,12 @@ class PromptMigrator(BaseMigrator):
             seen_handles = set()
 
             try:
-                # Do not force visibility filters here. With workspace scoping enabled
-                # (X-Tenant-Id), this keeps discovery limited to the selected workspace
-                # instead of unioning broad public catalogs.
+                # Explicitly scope to tenant-private prompts. Some instances return
+                # a broad public catalog unless is_public is set to False.
                 for prompt in self._iter_prompt_repos(
                     self.source_ls_client,
                     is_archived=is_archived,
-                    is_public=None,
+                    is_public=False,
                 ):
                     if prompt.repo_handle in seen_handles:
                         continue
@@ -658,7 +657,7 @@ class PromptMigrator(BaseMigrator):
         try:
             for prompt in self._iter_prompt_repos(
                 self.dest_ls_client,
-                is_public=None,
+                is_public=False,
             ):
                 if prompt.repo_handle == prompt_identifier:
                     return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.54"
+version = "0.0.55"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.55"
+version = "0.0.56"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/cli_migrate_all_rules_test.py
+++ b/tests/cli_migrate_all_rules_test.py
@@ -1,5 +1,6 @@
 """Tests for migrate-all rule enable/disable behavior."""
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -38,18 +39,69 @@ class _FakeRulesMigrator:
         return "new-rule-id"
 
 
+class _FakeChartMigrator:
+    def __init__(self, source_client, dest_client, state, config):
+        self._project_id_map = None
+
+    def list_charts(self):
+        return []
+
+
+class _FakeState:
+    def __init__(self):
+        self.session_id = "test-session"
+        self.remediation_bundle_path = None
+
+    def ensure_item(self, *args, **kwargs):
+        return None
+
+    def update_item_status(self, *args, **kwargs):
+        return None
+
+    def update_item_checkpoint(self, *args, **kwargs):
+        return None
+
+    def get_item(self, *args, **kwargs):
+        return None
+
+
+class _FakeStateManager:
+    def __init__(self):
+        self.current_state = None
+
+    def create_session(self, source_url, destination_url):
+        return _FakeState()
+
+    def _default_bundle_path(self, session_id):
+        return Path(f"/tmp/{session_id}")
+
+    def save(self):
+        return None
+
+
 def _make_config():
-    return SimpleNamespace(migration=SimpleNamespace(verbose=False))
+    return SimpleNamespace(
+        migration=SimpleNamespace(verbose=False, non_interactive=False),
+        source=SimpleNamespace(base_url="https://source.example", api_key="src-key"),
+        destination=SimpleNamespace(base_url="https://dest.example", api_key="dest-key"),
+    )
 
 
 def _make_orchestrator():
-    return SimpleNamespace(source_client=object(), dest_client=object())
+    return SimpleNamespace(
+        source_client=SimpleNamespace(session=SimpleNamespace(headers={})),
+        dest_client=SimpleNamespace(session=SimpleNamespace(headers={})),
+        state=None,
+        state_manager=_FakeStateManager(),
+    )
 
 
 def test_migrate_all_rules_create_enabled_flag_sets_create_disabled_false():
     _FakeRulesMigrator.create_rule_calls = []
 
     with patch("langsmith_migrator.core.migrators.RulesMigrator", _FakeRulesMigrator), patch(
+        "langsmith_migrator.core.migrators.ChartMigrator", _FakeChartMigrator
+    ), patch(
         "langsmith_migrator.cli.main.Progress", _DummyProgress
     ), patch("langsmith_migrator.cli.main.Confirm.ask", side_effect=[True]):
         cli_main._migrate_all_for_workspace(
@@ -61,6 +113,7 @@ def test_migrate_all_rules_create_enabled_flag_sets_create_disabled_false():
             skip_prompts=True,
             skip_queues=True,
             skip_rules=False,
+            skip_charts=True,
             include_all_commits=False,
             strip_projects=False,
             map_projects=False,
@@ -75,6 +128,8 @@ def test_migrate_all_rules_prompt_defaults_to_disabled_when_flag_omitted():
     _FakeRulesMigrator.create_rule_calls = []
 
     with patch("langsmith_migrator.core.migrators.RulesMigrator", _FakeRulesMigrator), patch(
+        "langsmith_migrator.core.migrators.ChartMigrator", _FakeChartMigrator
+    ), patch(
         "langsmith_migrator.cli.main.Progress", _DummyProgress
     ), patch("langsmith_migrator.cli.main.Confirm.ask", side_effect=[True, False]):
         cli_main._migrate_all_for_workspace(
@@ -86,6 +141,7 @@ def test_migrate_all_rules_prompt_defaults_to_disabled_when_flag_omitted():
             skip_prompts=True,
             skip_queues=True,
             skip_rules=False,
+            skip_charts=True,
             include_all_commits=False,
             strip_projects=False,
             map_projects=False,

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -442,11 +442,17 @@ def test_migrate_all_runs_every_step_and_applies_workspace_project_mappings(cli_
     cli_harness.migrators.rules.list_rules.return_value = [
         {"id": "rule-1", "display_name": "Rule One", "dataset_id": "dataset-1"},
     ]
+    cli_harness.migrators.chart.list_charts.return_value = [
+        {"id": "chart-1", "title": "Chart One", "project_id": "source-project-id"},
+    ]
     cli_harness.orchestrator_factory.migrate_datasets_return = {"dataset-1": "dest-dataset-1"}
     cli_harness.migrators.prompt.migrate_prompt.return_value = True
     cli_harness.migrators.queue.create_queue.return_value = "dest-queue-1"
     cli_harness.migrators.rules.create_rule.return_value = "dest-rule-1"
-    cli_harness.controls.confirm_answers = [True, True, True, True, True]
+    cli_harness.migrators.chart.migrate_all_charts.return_value = {
+        "source-project-id": {"chart-1": "dest-chart-1"}
+    }
+    cli_harness.controls.confirm_answers = [True, True, True, True, True, True]
 
     result = cli_harness.invoke(["migrate-all", "--include-all-commits"])
 
@@ -467,8 +473,49 @@ def test_migrate_all_runs_every_step_and_applies_workspace_project_mappings(cli_
     assert cli_harness.migrators.prompt.migrate_prompt.call_count == 1
     assert cli_harness.migrators.queue.create_queue.call_count == 1
     assert cli_harness.migrators.rules.create_rule.call_count == 1
+    cli_harness.migrators.chart.migrate_all_charts.assert_called_once_with(same_instance=False)
+    assert cli_harness.migrators.chart._project_id_map == {
+        "source-project-id": "dest-project-id"
+    }
     assert orchestrator.clear_workspace_called is True
     assert "Migration wizard completed!" in cli_harness.console.text
+
+
+def test_migrate_all_supports_skipping_charts_via_flag_and_prompt(cli_harness):
+    """migrate-all should support chart skipping through both CLI flag and wizard confirmation."""
+
+    # Flag path: charts step is bypassed entirely.
+    cli_harness.migrators.chart.list_charts.return_value = [
+        {"id": "chart-1", "title": "Chart One"},
+    ]
+    result_flag = cli_harness.invoke(["migrate-all", "--skip-charts"])
+    assert result_flag.exit_code == 0
+    cli_harness.migrators.chart.list_charts.assert_not_called()
+    assert "Skipping charts (--skip-charts)" in cli_harness.console.text
+
+    # Prompt path: charts are discovered but user opts out interactively.
+    cli_harness.migrators.chart.reset_mock()
+    cli_harness.migrators.chart.list_charts.return_value = [
+        {"id": "chart-1", "title": "Chart One", "project_id": "source-project-id"},
+    ]
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={"src-ws": {"Source Project": "Destination Project"}},
+        workspaces_to_create=[],
+    )
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {"id": "source-project-id", "name": "Source Project"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {"id": "dest-project-id", "name": "Destination Project"},
+    ]
+    cli_harness.controls.confirm_answers = [False]
+
+    result_prompt = cli_harness.invoke(["migrate-all"])
+    assert result_prompt.exit_code == 0
+    cli_harness.migrators.chart.list_charts.assert_called_once()
+    cli_harness.migrators.chart.migrate_all_charts.assert_not_called()
+    assert "Skipped charts" in cli_harness.console.text
 
 
 def test_charts_command_auto_detects_same_instance(cli_harness):

--- a/tests/test_prompt_migrator.py
+++ b/tests/test_prompt_migrator.py
@@ -95,7 +95,7 @@ class TestPromptMigrator:
         result = prompt_migrator.list_prompts()
 
         assert [prompt["repo_handle"] for prompt in result] == ["team/private-prompt"]
-        assert "is_public" not in prompt_migrator.source_ls_client.list_prompts.call_args.kwargs
+        assert prompt_migrator.source_ls_client.list_prompts.call_args.kwargs["is_public"] is False
 
     def test_find_existing_prompt_paginates_destination_results(self, prompt_migrator):
         """Destination prompt existence checks should scan all pages, not just the first page."""
@@ -121,6 +121,7 @@ class TestPromptMigrator:
         assert prompt_migrator.find_existing_prompt("team/target-prompt") is True
         assert prompt_migrator.dest_ls_client.list_prompts.call_args_list[0].kwargs["offset"] == 0
         assert prompt_migrator.dest_ls_client.list_prompts.call_args_list[1].kwargs["offset"] == 100
+        assert prompt_migrator.dest_ls_client.list_prompts.call_args_list[0].kwargs["is_public"] is False
 
     def test_migrate_prompt_dry_run(self, prompt_migrator, sample_config):
         """Test migrating prompt in dry-run mode."""

--- a/uv.lock
+++ b/uv.lock
@@ -1286,7 +1286,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.55"
+version = "0.0.56"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -1286,7 +1286,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.54"
+version = "0.0.55"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- release `v0.0.55` (version + lock + changelog)
- limit prompt discovery and destination existence checks to private/workspace prompts (`is_public=False`) to avoid broad public prompt catalogs
- suppress low-signal `run compression is not enabled` log noise in CLI output

## Test plan
- [x] `uv run pytest tests/test_prompt_migrator.py -q`
- [x] `uv run pytest tests/functional/test_cli_functional.py -k "prompts_command" -q`

Made with [Cursor](https://cursor.com)