### PR TITLE
Add user and role migration support

### DIFF
--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -35,6 +35,7 @@ from ..core.migrators import (
     PromptMigrator,
     RulesMigrator,
     ChartMigrator,
+    UserRoleMigrator,
 )
 from .tui_selector import select_items
 from .tui_project_mapper import build_project_mapping_tui
@@ -917,6 +918,147 @@ def queues(ctx, source_workspace, dest_workspace, map_workspaces):
 
     if ws_result:
         orchestrator.clear_workspace_context()
+
+    _display_resolution_summary(orchestrator)
+    _exit_for_remediation_if_needed(ctx, config, orchestrator)
+    orchestrator.cleanup()
+
+
+@cli.command()
+@ssl_option
+@click.option('--roles-only', is_flag=True, help='Only migrate custom roles (skip members)')
+@click.option('--skip-workspace-members', is_flag=True, help='Skip workspace member migration')
+@workspace_options
+@click.pass_context
+def users(ctx, roles_only, skip_workspace_members, source_workspace, dest_workspace, map_workspaces):
+    """Migrate users, roles, and workspace memberships."""
+    config = ctx.obj['config']
+    state_manager = ctx.obj['state_manager']
+
+    display_banner()
+
+    if not ensure_config(config):
+        return
+
+    orchestrator = MigrationOrchestrator(config, state_manager)
+
+    if not orchestrator.test_connections():
+        console.print("\n[red]Cannot proceed without valid connections[/red]")
+        orchestrator.cleanup()
+        return
+
+    # Resolve workspace context (needed for phase 3)
+    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces)
+    if ws_result is _WS_CANCELLED:
+        console.print("[yellow]Cancelled[/yellow]")
+        orchestrator.cleanup()
+        return
+
+    ws_pairs = list(ws_result.workspace_mapping.items()) if ws_result else [(None, None)]
+
+    # Clear workspace context for org-scoped phases 1-2
+    orchestrator.clear_workspace_context()
+
+    user_role_migrator = UserRoleMigrator(
+        orchestrator.source_client,
+        orchestrator.dest_client,
+        None,
+        config,
+    )
+
+    _run_preflight(orchestrator, config, ["users"])
+
+    # ── Phase 1: Role synchronisation ──
+    console.print("\n[bold]Phase 1: Synchronising roles...[/bold]")
+
+    try:
+        role_mapping = user_role_migrator.build_role_mapping()
+        console.print(f"  [green]{len(role_mapping)} role(s) mapped[/green]")
+    except Exception as e:
+        console.print(f"  [red]Failed to build role mapping: {e}[/red]")
+        orchestrator.cleanup()
+        return
+
+    if roles_only:
+        console.print("\n[dim]--roles-only: skipping member migration[/dim]")
+        orchestrator.cleanup()
+        return
+
+    # ── Phase 2: Org member migration ──
+    console.print("\n[bold]Phase 2: Migrating organisation members...[/bold]")
+
+    org_members = user_role_migrator.list_source_org_members()
+    pending_members = user_role_migrator.list_source_pending_org_members()
+
+    if not org_members and not pending_members:
+        console.print("  [yellow]No org members found[/yellow]")
+    else:
+        all_members = org_members + [
+            {**p, "_pending": True} for p in pending_members
+        ]
+
+        selected_members = _select_or_all(
+            config,
+            all_members,
+            select_all=config.migration.non_interactive,
+            title="Select Organisation Members to Migrate",
+            columns=[
+                {"key": "email", "title": "Email", "width": 40},
+                {"key": "full_name", "title": "Name", "width": 30},
+                {"key": "role_name", "title": "Role", "width": 25},
+            ],
+        )
+
+        if selected_members:
+            _ensure_migration_session(orchestrator, config)
+            user_role_migrator.state = orchestrator.state
+
+            migrated, skipped, failed = user_role_migrator.migrate_org_members(
+                selected_members
+            )
+            console.print(
+                f"  Org members: [green]{migrated} migrated[/green], "
+                f"{skipped} skipped, [red]{failed} failed[/red]"
+            )
+        else:
+            console.print("  [yellow]No members selected[/yellow]")
+
+    # ── Phase 3: Workspace member migration ──
+    if skip_workspace_members:
+        console.print("\n[dim]--skip-workspace-members: skipping workspace member migration[/dim]")
+    else:
+        has_ws_pairs = any(s and d for s, d in ws_pairs)
+        if has_ws_pairs:
+            console.print("\n[bold]Phase 3: Migrating workspace members...[/bold]")
+            _ensure_migration_session(orchestrator, config)
+            user_role_migrator.state = orchestrator.state
+
+            # Refresh dest org members for workspace member lookups
+            if not user_role_migrator._dest_email_to_identity:
+                dest_members = user_role_migrator.list_dest_org_members()
+                for m in dest_members:
+                    email = (m.get("email") or "").lower()
+                    if email:
+                        user_role_migrator._dest_email_to_identity[email] = m
+
+            for src_ws, dst_ws in ws_pairs:
+                if not src_ws or not dst_ws:
+                    continue
+                orchestrator.set_workspace_context(src_ws, dst_ws)
+                console.print(f"\n  [cyan]Workspace: {src_ws} -> {dst_ws}[/cyan]")
+
+                try:
+                    m, s, f = user_role_migrator.migrate_workspace_members()
+                    console.print(
+                        f"    [green]{m} migrated[/green], {s} skipped, "
+                        f"[red]{f} failed[/red]"
+                    )
+                except Exception as e:
+                    console.print(f"    [red]Failed: {e}[/red]")
+
+            orchestrator.clear_workspace_context()
+        else:
+            console.print("\n[dim]No workspace pairs configured, skipping workspace member migration[/dim]")
 
     _display_resolution_summary(orchestrator)
     _exit_for_remediation_if_needed(ctx, config, orchestrator)

--- a/langsmith_migrator/core/migrators/__init__.py
+++ b/langsmith_migrator/core/migrators/__init__.py
@@ -8,6 +8,7 @@ from .annotation_queue import AnnotationQueueMigrator
 from .prompt import PromptMigrator
 from .rules import RulesMigrator
 from .chart import ChartMigrator
+from .user_role import UserRoleMigrator
 from .orchestrator import MigrationOrchestrator
 
 __all__ = [
@@ -19,5 +20,6 @@ __all__ = [
     "PromptMigrator",
     "RulesMigrator",
     "ChartMigrator",
+    "UserRoleMigrator",
     "MigrationOrchestrator",
 ]

--- a/langsmith_migrator/core/migrators/orchestrator.py
+++ b/langsmith_migrator/core/migrators/orchestrator.py
@@ -673,6 +673,52 @@ class MigrationOrchestrator:
                                 verification_state=VerificationState.VERIFIED,
                                 evidence={"destination_id": destination_id},
                             )
+                elif item.type in ("org_member", "ws_member"):
+                    from .user_role import UserRoleMigrator
+                    ur_migrator = UserRoleMigrator(
+                        self.source_client,
+                        self.dest_client,
+                        self.state,
+                        self.config,
+                    )
+                    # Restore role mapping from state
+                    role_mappings = self.state.id_mappings.get("roles", {})
+                    ur_migrator._role_id_map = dict(role_mappings)
+                    # Rebuild dest email index
+                    dest_org = ur_migrator.list_dest_org_members()
+                    for m in dest_org:
+                        email = (m.get("email") or "").lower()
+                        if email:
+                            ur_migrator._dest_email_to_identity[email] = m
+                    if item.type == "org_member":
+                        member_payload = item.metadata.get("member")
+                        if member_payload:
+                            migrated, _, _ = ur_migrator.migrate_org_members([member_payload])
+                            if migrated:
+                                self.state.update_item_status(
+                                    item.id, MigrationStatus.COMPLETED,
+                                    stage="completed",
+                                )
+                                self.state.mark_terminal(
+                                    item.id,
+                                    ResolutionOutcome.MIGRATED,
+                                    "org_member_migrated",
+                                    verification_state=VerificationState.VERIFIED,
+                                )
+                    else:  # ws_member
+                        # Workspace members are migrated per-workspace
+                        migrated, _, _ = ur_migrator.migrate_workspace_members()
+                        if migrated:
+                            self.state.update_item_status(
+                                item.id, MigrationStatus.COMPLETED,
+                                stage="completed",
+                            )
+                            self.state.mark_terminal(
+                                item.id,
+                                ResolutionOutcome.MIGRATED,
+                                "ws_member_migrated",
+                                verification_state=VerificationState.VERIFIED,
+                            )
                 else:
                     issue = self.state.add_issue(
                         "capability",

--- a/langsmith_migrator/core/migrators/user_role.py
+++ b/langsmith_migrator/core/migrators/user_role.py
@@ -1,0 +1,535 @@
+"""User and role migration logic."""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from .base import BaseMigrator
+from ...utils.retry import APIError, AuthenticationError, ConflictError
+
+
+class UserRoleMigrator(BaseMigrator):
+    """Handles migration of custom roles, org members, and workspace members.
+
+    Migration proceeds in three strict phases:
+      1. Role sync      – match built-in roles by name, create/update custom roles
+      2. Org members     – invite missing members, update roles for existing ones
+      3. Workspace members – per workspace pair, add/update workspace memberships
+
+    Phases 1-2 are org-scoped (no X-Tenant-Id). Phase 3 requires workspace context.
+    """
+
+    def __init__(self, source_client, dest_client, state, config):
+        super().__init__(source_client, dest_client, state, config)
+        self._role_id_map: Dict[str, str] = {}
+        self._dest_email_to_identity: Dict[str, Dict[str, Any]] = {}
+
+    # ------------------------------------------------------------------
+    # Phase 0: data fetching
+    # ------------------------------------------------------------------
+
+    def list_source_roles(self) -> List[Dict[str, Any]]:
+        """Fetch all roles from the source organisation."""
+        return self.source.get("/orgs/current/roles")
+
+    def list_dest_roles(self) -> List[Dict[str, Any]]:
+        """Fetch all roles from the destination organisation."""
+        return self.dest.get("/orgs/current/roles")
+
+    def list_source_org_members(self) -> List[Dict[str, Any]]:
+        """Fetch active org members from source (paginated)."""
+        members = []
+        for member in self.source.get_paginated("/orgs/current/members/active"):
+            if isinstance(member, dict):
+                members.append(member)
+        return members
+
+    def list_dest_org_members(self) -> List[Dict[str, Any]]:
+        """Fetch active org members from destination (paginated)."""
+        members = []
+        for member in self.dest.get_paginated("/orgs/current/members/active"):
+            if isinstance(member, dict):
+                members.append(member)
+        return members
+
+    def list_source_pending_org_members(self) -> List[Dict[str, Any]]:
+        """Fetch pending org invites from source (paginated)."""
+        members = []
+        for member in self.source.get_paginated("/orgs/current/members/pending"):
+            if isinstance(member, dict):
+                members.append(member)
+        return members
+
+    def list_source_workspace_members(self) -> List[Dict[str, Any]]:
+        """Fetch active workspace members from source (requires X-Tenant-Id)."""
+        members = []
+        for member in self.source.get_paginated("/tenants/current/members/active"):
+            if isinstance(member, dict):
+                members.append(member)
+        return members
+
+    def list_dest_workspace_members(self) -> List[Dict[str, Any]]:
+        """Fetch active workspace members from destination (requires X-Tenant-Id)."""
+        members = []
+        for member in self.dest.get_paginated("/tenants/current/members/active"):
+            if isinstance(member, dict):
+                members.append(member)
+        return members
+
+    # ------------------------------------------------------------------
+    # Phase 1: role synchronisation
+    # ------------------------------------------------------------------
+
+    def build_role_mapping(self) -> Dict[str, str]:
+        """Build source_role_id -> dest_role_id mapping.
+
+        1. Fetches roles from both sides.
+        2. Matches built-in roles by ``name``.
+        3. Creates/updates custom roles on destination, matched by ``display_name``.
+        4. Persists the mapping in ``state.id_mappings["roles"]``.
+        """
+        source_roles = self.list_source_roles()
+        dest_roles = self.list_dest_roles()
+
+        self.log(
+            f"Found {len(source_roles)} source roles, {len(dest_roles)} destination roles"
+        )
+
+        # Match built-in roles
+        mapping = self._match_builtin_roles(source_roles, dest_roles)
+
+        # Sync custom roles
+        custom_mapping = self._sync_custom_roles(source_roles, dest_roles)
+        mapping.update(custom_mapping)
+
+        self._role_id_map = mapping
+
+        # Persist in state for resume
+        if self.state:
+            for src_id, dst_id in mapping.items():
+                self.state.set_mapped_id("roles", src_id, dst_id)
+            self.persist_state()
+
+        return mapping
+
+    def _match_builtin_roles(
+        self,
+        source_roles: List[Dict[str, Any]],
+        dest_roles: List[Dict[str, Any]],
+    ) -> Dict[str, str]:
+        """Match built-in roles by their ``name`` field."""
+        dest_by_name: Dict[str, str] = {}
+        for role in dest_roles:
+            if role.get("name") != "CUSTOM":
+                dest_by_name[role["name"]] = role["id"]
+
+        mapping: Dict[str, str] = {}
+        for role in source_roles:
+            name = role.get("name", "")
+            if name == "CUSTOM":
+                continue
+            dest_id = dest_by_name.get(name)
+            if dest_id:
+                mapping[role["id"]] = dest_id
+                self.log(f"Matched built-in role: {name}")
+            else:
+                self.log(
+                    f"Built-in role '{name}' not found on destination", "warning"
+                )
+
+        return mapping
+
+    def _sync_custom_roles(
+        self,
+        source_roles: List[Dict[str, Any]],
+        dest_roles: List[Dict[str, Any]],
+    ) -> Dict[str, str]:
+        """Sync custom roles by ``display_name``.
+
+        Creates missing custom roles on the destination, or updates existing
+        ones when permissions differ (unless skip_existing is set).
+        """
+        dest_by_display: Dict[str, Dict[str, Any]] = {}
+        for role in dest_roles:
+            if role.get("name") == "CUSTOM":
+                dest_by_display[role.get("display_name", "")] = role
+
+        mapping: Dict[str, str] = {}
+
+        for role in source_roles:
+            if role.get("name") != "CUSTOM":
+                continue
+
+            display_name = role.get("display_name", "")
+            existing = dest_by_display.get(display_name)
+
+            if existing:
+                mapping[role["id"]] = existing["id"]
+                if self.config.migration.skip_existing:
+                    self.log(f"Custom role '{display_name}' exists, skipping")
+                    continue
+
+                # Check if permissions differ
+                src_perms = set(role.get("permissions", []))
+                dst_perms = set(existing.get("permissions", []))
+                if src_perms != dst_perms:
+                    self._update_custom_role(existing["id"], role)
+                else:
+                    self.log(f"Custom role '{display_name}' already up to date")
+            else:
+                dest_id = self._create_custom_role(role)
+                if dest_id:
+                    mapping[role["id"]] = dest_id
+
+        return mapping
+
+    def _create_custom_role(self, role: Dict[str, Any]) -> Optional[str]:
+        """Create a custom role on the destination."""
+        display_name = role.get("display_name", "")
+        if self.config.migration.dry_run:
+            self.log(f"[DRY RUN] Would create custom role: {display_name}")
+            return f"dry-run-{role['id']}"
+
+        payload = {
+            "display_name": display_name,
+            "description": role.get("description", ""),
+            "permissions": role.get("permissions", []),
+        }
+
+        try:
+            response = self.dest.post("/orgs/current/roles", payload)
+            dest_id = response.get("id") if isinstance(response, dict) else None
+            if not dest_id:
+                raise APIError(
+                    f"Invalid response creating role: {response}"
+                )
+            self.log(f"Created custom role: {display_name}", "success")
+            return dest_id
+        except APIError as e:
+            self.log(f"Failed to create custom role '{display_name}': {e}", "error")
+            self.record_issue(
+                "capability",
+                "custom_role_create_failed",
+                f"Failed to create custom role '{display_name}': {e}",
+                evidence={"role": role, "error": str(e)},
+            )
+            return None
+
+    def _update_custom_role(
+        self, dest_role_id: str, source_role: Dict[str, Any]
+    ) -> None:
+        """Update a custom role's permissions on the destination."""
+        display_name = source_role.get("display_name", "")
+        if self.config.migration.dry_run:
+            self.log(f"[DRY RUN] Would update custom role: {display_name}")
+            return
+
+        payload = {
+            "display_name": display_name,
+            "description": source_role.get("description", ""),
+            "permissions": source_role.get("permissions", []),
+        }
+
+        try:
+            self.dest.patch(f"/orgs/current/roles/{dest_role_id}", payload)
+            self.log(f"Updated custom role: {display_name}", "success")
+        except APIError as e:
+            self.log(
+                f"Failed to update custom role '{display_name}': {e}", "error"
+            )
+
+    # ------------------------------------------------------------------
+    # Phase 2: organisation member migration
+    # ------------------------------------------------------------------
+
+    def migrate_org_members(
+        self, selected_members: List[Dict[str, Any]]
+    ) -> Tuple[int, int, int]:
+        """Migrate selected org members from source to destination.
+
+        Returns ``(migrated, skipped, failed)`` counts.
+        """
+        dest_members = self.list_dest_org_members()
+        dest_by_email: Dict[str, Dict[str, Any]] = {}
+        for m in dest_members:
+            email = (m.get("email") or "").lower()
+            if email:
+                dest_by_email[email] = m
+
+        self._dest_email_to_identity = dest_by_email
+
+        migrated = skipped = failed = 0
+
+        for member in selected_members:
+            email = (member.get("email") or "").lower()
+            if not email:
+                self.log("Skipping member with no email", "warning")
+                skipped += 1
+                continue
+
+            source_role_id = member.get("role_id")
+            mapped_role_id = self._role_id_map.get(source_role_id) if source_role_id else None
+
+            if source_role_id and not mapped_role_id:
+                self.log(
+                    f"No role mapping for {email} (role_id={source_role_id})",
+                    "warning",
+                )
+                self.record_issue(
+                    "dependency",
+                    "unmapped_role",
+                    f"No role mapping for org member '{email}' "
+                    f"(source role_id={source_role_id})",
+                    evidence={"email": email, "source_role_id": source_role_id},
+                )
+                failed += 1
+                continue
+
+            dest_member = dest_by_email.get(email)
+
+            if dest_member:
+                # Already exists on destination
+                if self.config.migration.skip_existing:
+                    self.log(f"Org member '{email}' exists, skipping")
+                    skipped += 1
+                    continue
+
+                # Check if role needs updating
+                dest_role_id = dest_member.get("role_id")
+                if mapped_role_id and dest_role_id != mapped_role_id:
+                    try:
+                        self._update_org_member_role(
+                            dest_member["id"], mapped_role_id
+                        )
+                        migrated += 1
+                    except (AuthenticationError, APIError) as e:
+                        self.log(
+                            f"Failed to update role for '{email}': {e}",
+                            "error",
+                        )
+                        failed += 1
+                else:
+                    self.log(f"Org member '{email}' already has correct role")
+                    skipped += 1
+            else:
+                # Invite new member
+                try:
+                    self._invite_org_member(email, mapped_role_id)
+                    migrated += 1
+                except ConflictError:
+                    self.log(
+                        f"Invite for '{email}' already pending, skipping",
+                        "warning",
+                    )
+                    skipped += 1
+                except (AuthenticationError, APIError) as e:
+                    self.log(f"Failed to invite '{email}': {e}", "error")
+                    failed += 1
+
+        return migrated, skipped, failed
+
+    def _invite_org_member(
+        self,
+        email: str,
+        role_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Invite a new member to the destination org."""
+        if self.config.migration.dry_run:
+            self.log(f"[DRY RUN] Would invite {email}")
+            return {"id": f"dry-run-{email}"}
+
+        payload: Dict[str, Any] = {"email": email}
+        if role_id:
+            payload["role_id"] = role_id
+
+        response = self.dest.post("/orgs/current/members", payload)
+        self.log(f"Invited {email}", "success")
+        return response
+
+    def _update_org_member_role(self, identity_id: str, role_id: str) -> None:
+        """Update an existing org member's role."""
+        if self.config.migration.dry_run:
+            self.log(f"[DRY RUN] Would update org member role: {identity_id}")
+            return
+
+        self.dest.patch(
+            f"/orgs/current/members/{identity_id}", {"role_id": role_id}
+        )
+        self.log(f"Updated org member role: {identity_id}", "success")
+
+    # ------------------------------------------------------------------
+    # Phase 3: workspace member migration
+    # ------------------------------------------------------------------
+
+    def migrate_workspace_members(self) -> Tuple[int, int, int]:
+        """Migrate workspace members for the currently scoped workspace pair.
+
+        Assumes:
+          - Role mapping is built (phase 1).
+          - Org members are migrated (phase 2).
+          - X-Tenant-Id is set on both clients.
+
+        Returns ``(migrated, skipped, failed)`` counts.
+        """
+        source_members = self.list_source_workspace_members()
+        dest_members = self.list_dest_workspace_members()
+
+        dest_by_email: Dict[str, Dict[str, Any]] = {}
+        for m in dest_members:
+            email = (m.get("email") or "").lower()
+            if email:
+                dest_by_email[email] = m
+
+        migrated = skipped = failed = 0
+
+        for member in source_members:
+            email = (member.get("email") or "").lower()
+            if not email:
+                skipped += 1
+                continue
+
+            source_role_id = member.get("role_id")
+            mapped_role_id = (
+                self._role_id_map.get(source_role_id)
+                if source_role_id
+                else None
+            )
+
+            if source_role_id and not mapped_role_id:
+                self.log(
+                    f"No role mapping for workspace member {email}", "warning"
+                )
+                failed += 1
+                continue
+
+            dest_member = dest_by_email.get(email)
+
+            if dest_member:
+                if self.config.migration.skip_existing:
+                    skipped += 1
+                    continue
+
+                dest_role_id = dest_member.get("role_id")
+                if mapped_role_id and dest_role_id != mapped_role_id:
+                    try:
+                        self._update_workspace_member_role(
+                            dest_member["id"], mapped_role_id
+                        )
+                        migrated += 1
+                    except (AuthenticationError, APIError) as e:
+                        self.log(
+                            f"Failed to update workspace role for '{email}': {e}",
+                            "error",
+                        )
+                        failed += 1
+                else:
+                    skipped += 1
+            else:
+                # Find the dest org identity for this user
+                dest_org_member = self._dest_email_to_identity.get(email)
+                if not dest_org_member:
+                    self.log(
+                        f"Cannot add '{email}' to workspace: not an org member",
+                        "warning",
+                    )
+                    self.record_issue(
+                        "dependency",
+                        "ws_member_not_in_org",
+                        f"User '{email}' is not an org member on destination",
+                        evidence={"email": email},
+                    )
+                    failed += 1
+                    continue
+
+                try:
+                    self._add_workspace_member(
+                        dest_org_member["id"], mapped_role_id
+                    )
+                    migrated += 1
+                except ConflictError:
+                    self.log(
+                        f"Workspace member '{email}' already exists",
+                        "warning",
+                    )
+                    skipped += 1
+                except (AuthenticationError, APIError) as e:
+                    self.log(
+                        f"Failed to add '{email}' to workspace: {e}", "error"
+                    )
+                    failed += 1
+
+        return migrated, skipped, failed
+
+    def _add_workspace_member(
+        self, org_identity_id: str, role_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Add an org member to the current workspace."""
+        if self.config.migration.dry_run:
+            self.log(f"[DRY RUN] Would add workspace member: {org_identity_id}")
+            return {"id": f"dry-run-{org_identity_id}"}
+
+        payload: Dict[str, Any] = {"org_identity_id": org_identity_id}
+        if role_id:
+            payload["role_id"] = role_id
+
+        response = self.dest.post("/tenants/current/members", payload)
+        self.log(f"Added workspace member: {org_identity_id}", "success")
+        return response
+
+    def _update_workspace_member_role(
+        self, identity_id: str, role_id: str
+    ) -> None:
+        """Update a workspace member's role."""
+        if self.config.migration.dry_run:
+            self.log(
+                f"[DRY RUN] Would update workspace member role: {identity_id}"
+            )
+            return
+
+        self.dest.patch(
+            f"/tenants/current/members/{identity_id}", {"role_id": role_id}
+        )
+        self.log(f"Updated workspace member role: {identity_id}", "success")
+
+    # ------------------------------------------------------------------
+    # Capability probing
+    # ------------------------------------------------------------------
+
+    def probe_capabilities(self) -> None:
+        """Test API endpoints to verify roles/members APIs are accessible."""
+        for label, client, scope in [
+            ("source", self.source, "source"),
+            ("destination", self.dest, "dest"),
+        ]:
+            # Roles endpoint
+            try:
+                client.get("/orgs/current/roles")
+                self.record_capability(
+                    scope, "roles_api", supported=True, probe="/orgs/current/roles"
+                )
+            except Exception as e:
+                self.record_capability(
+                    scope,
+                    "roles_api",
+                    supported=False,
+                    detail=str(e),
+                    probe="/orgs/current/roles",
+                )
+
+            # Members endpoint
+            try:
+                client.get(
+                    "/orgs/current/members/active", params={"limit": 1}
+                )
+                self.record_capability(
+                    scope,
+                    "members_api",
+                    supported=True,
+                    probe="/orgs/current/members/active",
+                )
+            except Exception as e:
+                self.record_capability(
+                    scope,
+                    "members_api",
+                    supported=False,
+                    detail=str(e),
+                    probe="/orgs/current/members/active",
+                )

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -48,6 +48,7 @@ def test_registered_command_names_match_public_cli_surface():
         "resume",
         "rules",
         "test",
+        "users",
     ]
 
 

--- a/tests/test_user_role_migrator.py
+++ b/tests/test_user_role_migrator.py
@@ -1,0 +1,318 @@
+"""Unit tests for UserRoleMigrator."""
+
+import pytest
+from unittest.mock import Mock
+from langsmith_migrator.core.migrators import UserRoleMigrator
+from langsmith_migrator.utils.retry import APIError, AuthenticationError, ConflictError
+
+
+class TestUserRoleMigrator:
+    """Test cases for UserRoleMigrator."""
+
+    @pytest.fixture
+    def migrator(self, sample_config, migration_state):
+        """Create a UserRoleMigrator with separate source/dest clients."""
+        from langsmith_migrator.core.api_client import EnhancedAPIClient
+
+        source = Mock(spec=EnhancedAPIClient)
+        source.base_url = "https://source.api.test.com"
+        source.session = Mock()
+        source.session.headers = {}
+
+        dest = Mock(spec=EnhancedAPIClient)
+        dest.base_url = "https://dest.api.test.com"
+        dest.session = Mock()
+        dest.session.headers = {}
+
+        return UserRoleMigrator(source, dest, migration_state, sample_config)
+
+    @pytest.fixture
+    def source_roles(self):
+        return [
+            {"id": "src-admin", "name": "ORGANIZATION_ADMIN", "display_name": "Admin", "permissions": []},
+            {"id": "src-user", "name": "ORGANIZATION_USER", "display_name": "User", "permissions": []},
+            {"id": "src-ws-admin", "name": "WORKSPACE_ADMIN", "display_name": "Workspace Admin", "permissions": []},
+            {"id": "src-custom-1", "name": "CUSTOM", "display_name": "Data Scientist",
+             "description": "Custom DS role", "permissions": ["datasets:read", "datasets:create", "runs:read"]},
+        ]
+
+    @pytest.fixture
+    def dest_roles(self):
+        return [
+            {"id": "dst-admin", "name": "ORGANIZATION_ADMIN", "display_name": "Admin", "permissions": []},
+            {"id": "dst-user", "name": "ORGANIZATION_USER", "display_name": "User", "permissions": []},
+            {"id": "dst-ws-admin", "name": "WORKSPACE_ADMIN", "display_name": "Workspace Admin", "permissions": []},
+        ]
+
+    # ── Phase 1: Role mapping ──
+
+    def test_match_builtin_roles(self, migrator, source_roles, dest_roles):
+        """Built-in roles are matched by name."""
+        mapping = migrator._match_builtin_roles(source_roles, dest_roles)
+
+        assert mapping["src-admin"] == "dst-admin"
+        assert mapping["src-user"] == "dst-user"
+        assert mapping["src-ws-admin"] == "dst-ws-admin"
+        assert "src-custom-1" not in mapping
+
+    def test_sync_custom_roles_create(self, migrator, source_roles, dest_roles):
+        """Custom roles missing on destination are created."""
+        migrator.dest.post.return_value = {"id": "dst-custom-1"}
+
+        mapping = migrator._sync_custom_roles(source_roles, dest_roles)
+
+        assert mapping["src-custom-1"] == "dst-custom-1"
+        migrator.dest.post.assert_called_once_with(
+            "/orgs/current/roles",
+            {
+                "display_name": "Data Scientist",
+                "description": "Custom DS role",
+                "permissions": ["datasets:read", "datasets:create", "runs:read"],
+            },
+        )
+
+    def test_sync_custom_roles_skip_existing(self, migrator, source_roles, sample_config):
+        """When skip_existing, existing custom roles are mapped but not updated."""
+        sample_config.migration.skip_existing = True
+
+        dest_roles_with_custom = [
+            {"id": "dst-custom-1", "name": "CUSTOM", "display_name": "Data Scientist",
+             "permissions": ["datasets:read"]},  # Fewer permissions
+        ]
+
+        mapping = migrator._sync_custom_roles(source_roles, dest_roles_with_custom)
+
+        assert mapping["src-custom-1"] == "dst-custom-1"
+        migrator.dest.patch.assert_not_called()
+        migrator.dest.post.assert_not_called()
+
+    def test_sync_custom_roles_update_permissions(self, migrator, source_roles, sample_config):
+        """Existing custom roles with different permissions are updated."""
+        sample_config.migration.skip_existing = False
+
+        dest_roles_with_custom = [
+            {"id": "dst-custom-1", "name": "CUSTOM", "display_name": "Data Scientist",
+             "description": "Old desc", "permissions": ["datasets:read"]},
+        ]
+
+        mapping = migrator._sync_custom_roles(source_roles, dest_roles_with_custom)
+
+        assert mapping["src-custom-1"] == "dst-custom-1"
+        migrator.dest.patch.assert_called_once_with(
+            "/orgs/current/roles/dst-custom-1",
+            {
+                "display_name": "Data Scientist",
+                "description": "Custom DS role",
+                "permissions": ["datasets:read", "datasets:create", "runs:read"],
+            },
+        )
+
+    def test_sync_custom_roles_no_update_when_permissions_match(self, migrator, source_roles, sample_config):
+        """No PATCH when permissions already match."""
+        sample_config.migration.skip_existing = False
+
+        dest_roles_with_custom = [
+            {"id": "dst-custom-1", "name": "CUSTOM", "display_name": "Data Scientist",
+             "description": "Custom DS role",
+             "permissions": ["datasets:read", "datasets:create", "runs:read"]},
+        ]
+
+        migrator._sync_custom_roles(source_roles, dest_roles_with_custom)
+
+        migrator.dest.patch.assert_not_called()
+
+    def test_build_role_mapping_persists_to_state(self, migrator, source_roles, dest_roles, migration_state):
+        """Role mapping is persisted in state.id_mappings['roles']."""
+        migrator.source.get.return_value = source_roles
+        migrator.dest.get.return_value = dest_roles
+        migrator.dest.post.return_value = {"id": "dst-custom-1"}
+
+        migrator.build_role_mapping()
+
+        assert migration_state.id_mappings.get("roles", {}).get("src-admin") == "dst-admin"
+        assert migration_state.id_mappings.get("roles", {}).get("src-custom-1") == "dst-custom-1"
+
+    # ── Phase 2: Org member migration ──
+
+    def test_migrate_org_members_invite_new(self, migrator):
+        """New users are invited to the destination org."""
+        migrator._role_id_map = {"src-role": "dst-role"}
+        migrator.dest.get_paginated.return_value = iter([])  # No dest members
+        migrator.dest.post.return_value = {"id": "new-identity-1"}
+
+        members = [
+            {"id": "src-m1", "email": "alice@example.com", "role_id": "src-role", "full_name": "Alice"},
+        ]
+
+        m, s, f = migrator.migrate_org_members(members)
+
+        assert m == 1
+        assert s == 0
+        assert f == 0
+        migrator.dest.post.assert_called_once_with(
+            "/orgs/current/members",
+            {"email": "alice@example.com", "role_id": "dst-role"},
+        )
+
+    def test_migrate_org_members_update_role(self, migrator):
+        """Existing members with different roles get updated."""
+        migrator._role_id_map = {"src-role": "dst-role-new"}
+        migrator.dest.get_paginated.return_value = iter([
+            {"id": "dst-m1", "email": "alice@example.com", "role_id": "dst-role-old"},
+        ])
+
+        members = [
+            {"id": "src-m1", "email": "alice@example.com", "role_id": "src-role"},
+        ]
+
+        m, s, f = migrator.migrate_org_members(members)
+
+        assert m == 1
+        migrator.dest.patch.assert_called_once_with(
+            "/orgs/current/members/dst-m1",
+            {"role_id": "dst-role-new"},
+        )
+
+    def test_migrate_org_members_skip_existing(self, migrator, sample_config):
+        """With skip_existing, existing members are skipped."""
+        sample_config.migration.skip_existing = True
+        migrator._role_id_map = {"src-role": "dst-role"}
+        migrator.dest.get_paginated.return_value = iter([
+            {"id": "dst-m1", "email": "alice@example.com", "role_id": "dst-role-old"},
+        ])
+
+        members = [
+            {"id": "src-m1", "email": "alice@example.com", "role_id": "src-role"},
+        ]
+
+        m, s, f = migrator.migrate_org_members(members)
+
+        assert s == 1
+        assert m == 0
+        migrator.dest.patch.assert_not_called()
+
+    def test_migrate_org_members_conflict_treated_as_skip(self, migrator):
+        """409 Conflict on invite is treated as skip."""
+        migrator._role_id_map = {"src-role": "dst-role"}
+        migrator.dest.get_paginated.return_value = iter([])
+        migrator.dest.post.side_effect = ConflictError(
+            "Already pending", request_info={}
+        )
+
+        members = [
+            {"id": "src-m1", "email": "alice@example.com", "role_id": "src-role"},
+        ]
+
+        m, s, f = migrator.migrate_org_members(members)
+
+        assert s == 1
+        assert m == 0
+        assert f == 0
+
+    def test_migrate_org_members_unmapped_role(self, migrator):
+        """Members with unmapped role_id are counted as failed."""
+        migrator._role_id_map = {}  # No mappings
+        migrator.dest.get_paginated.return_value = iter([])
+
+        members = [
+            {"id": "src-m1", "email": "alice@example.com", "role_id": "unknown-role"},
+        ]
+
+        m, s, f = migrator.migrate_org_members(members)
+
+        assert f == 1
+        assert m == 0
+
+    # ── Phase 3: Workspace member migration ──
+
+    def test_migrate_workspace_members_add(self, migrator):
+        """Users not in workspace are added."""
+        migrator._role_id_map = {"src-ws-role": "dst-ws-role"}
+        migrator._dest_email_to_identity = {
+            "alice@example.com": {"id": "dst-org-identity-1"},
+        }
+        migrator.source.get_paginated.return_value = iter([
+            {"id": "src-ws-m1", "email": "alice@example.com", "role_id": "src-ws-role"},
+        ])
+        migrator.dest.get_paginated.return_value = iter([])
+        migrator.dest.post.return_value = {"id": "dst-ws-identity-1"}
+
+        m, s, f = migrator.migrate_workspace_members()
+
+        assert m == 1
+        migrator.dest.post.assert_called_once_with(
+            "/tenants/current/members",
+            {"org_identity_id": "dst-org-identity-1", "role_id": "dst-ws-role"},
+        )
+
+    def test_migrate_workspace_members_update_role(self, migrator):
+        """Workspace members with wrong role get updated."""
+        migrator._role_id_map = {"src-ws-role": "dst-ws-role-new"}
+        migrator.source.get_paginated.return_value = iter([
+            {"id": "src-ws-m1", "email": "alice@example.com", "role_id": "src-ws-role"},
+        ])
+        migrator.dest.get_paginated.return_value = iter([
+            {"id": "dst-ws-m1", "email": "alice@example.com", "role_id": "dst-ws-role-old"},
+        ])
+
+        m, s, f = migrator.migrate_workspace_members()
+
+        assert m == 1
+        migrator.dest.patch.assert_called_once_with(
+            "/tenants/current/members/dst-ws-m1",
+            {"role_id": "dst-ws-role-new"},
+        )
+
+    def test_migrate_workspace_members_not_in_org(self, migrator):
+        """User not an org member on dest is recorded as failed."""
+        migrator._role_id_map = {"src-ws-role": "dst-ws-role"}
+        migrator._dest_email_to_identity = {}  # Not in org
+        migrator.source.get_paginated.return_value = iter([
+            {"id": "src-ws-m1", "email": "bob@example.com", "role_id": "src-ws-role"},
+        ])
+        migrator.dest.get_paginated.return_value = iter([])
+
+        m, s, f = migrator.migrate_workspace_members()
+
+        assert f == 1
+        assert m == 0
+
+    # ── Dry run ──
+
+    def test_dry_run_no_mutations(self, migrator, sample_config, source_roles, dest_roles):
+        """In dry run mode, no POST/PATCH calls are made."""
+        sample_config.migration.dry_run = True
+        migrator.source.get.return_value = source_roles
+        migrator.dest.get.return_value = dest_roles
+
+        migrator.build_role_mapping()
+
+        # Custom role should NOT be created via POST
+        migrator.dest.post.assert_not_called()
+        migrator.dest.patch.assert_not_called()
+
+    def test_dry_run_org_member_invite(self, migrator, sample_config):
+        """Dry run skips actual invites."""
+        sample_config.migration.dry_run = True
+        migrator._role_id_map = {"src-role": "dst-role"}
+        migrator.dest.get_paginated.return_value = iter([])
+
+        members = [
+            {"id": "src-m1", "email": "alice@example.com", "role_id": "src-role"},
+        ]
+
+        m, s, f = migrator.migrate_org_members(members)
+
+        assert m == 1
+        migrator.dest.post.assert_not_called()
+
+    # ── Capability probing ──
+
+    def test_probe_capabilities_success(self, migrator):
+        """Probe records capabilities when endpoints succeed."""
+        migrator.source.get.return_value = []
+        migrator.dest.get.return_value = []
+
+        migrator.probe_capabilities()
+
+        # Should not raise


### PR DESCRIPTION
## Summary
- New `users` CLI command that migrates custom workspace roles, org members, and workspace memberships between LangSmith instances
- Three-phase migration: role sync (built-in + custom), org member invite/update, workspace member add/update per workspace pair
- Supports `--roles-only`, `--skip-workspace-members`, `--map-workspaces`, dry run, and skip-existing
- Resume support for `org_member` and `ws_member` item types in the orchestrator

## Test plan
- [x] 17 new unit tests covering role matching, custom role CRUD, org member invite/update/skip, workspace members, unmapped roles, dry run, conflict handling
- [x] All 61 tests pass
- [x] `langsmith-migrator users --help` outputs correctly
- [ ] Manual test with real LangSmith instances (dry run first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)