### PR TITLE
Release v0.0.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.57] - 2026-03-31
+
+### Added
+- **User and role migration**: New `users` CLI command migrates custom workspace roles, org members, and workspace memberships between LangSmith instances.
+- **Custom role sync**: Matches built-in roles by name and creates/updates custom roles by display name with full permission mapping.
+- **Workspace member migration**: Per-workspace-pair member migration with `--map-workspaces` support.
+- **Granular control**: `--roles-only` to sync only custom roles, `--skip-workspace-members` to skip workspace-level migration.
+- **Resume support**: Added `org_member` and `ws_member` item types to the resume workflow.
+
 ## [0.0.56] - 2026-04-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.56"
+version = "0.0.57"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1286,7 +1286,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.56"
+version = "0.0.57"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump version to 0.0.57
- Add changelog entry for user and role migration support

## Test plan
- [x] No code changes, version bump only

🤖 Generated with [Claude Code](https://claude.com/claude-code)