### PR TITLE
Harden users CSV migration and resume flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.60] - 2026-04-08
+
+### Added
+- **Role-name CSV input for user migration**: `users --members-csv` now accepts human-readable `langsmith_role` values with optional `workspace_id` / `workspace_name`, making org-scoped and workspace-scoped membership imports easier to author.
+- **Role-name resolution safeguards**: Built-in LangSmith roles and custom role display names are resolved deterministically, with clear validation for ambiguous or unknown CSV role labels.
+
+### Fixed
+- **Headless workspace safety**: Non-interactive multi-workspace runs now fail safely when no valid workspace mapping is available instead of falling through unscoped.
+- **Saved workspace mapping validation**: Persisted workspace mappings now record source/destination instance URLs and are ignored when they no longer match the current migration context.
+- **Experiment reference example migration**: Unmapped `reference_example_id` values are now dropped with a warning instead of replaying invalid source IDs into the destination instance.
+- **Resume session selection**: Interactive `resume` once again honors the selected saved session, while non-interactive runs keep latest-session behavior.
+- **Resume command cleanup**: Resume execution now uses explicit orchestrator cleanup without depending on context-manager support, preserving CLI reliability in tests and real runs.
+
 ## [0.0.57] - 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -153,14 +153,17 @@ langsmith-migrator users --members-csv examples/users_members_example.csv --map-
 CSV schema:
 
 ```csv
-email,role_id,workspace_id
-alice@example.com,role_org_user_abc123,ws_src_prod_us
+email,langsmith_role,workspace_id,workspace_name
+alice@example.com,Organization Admin,,
+alice@example.com,Workspace Admin,ws_src_prod_us,Production US
 ```
 
 Notes:
-- `email`, `role_id`, and `workspace_id` are required.
-- `role_id` must be consistent for each `email` across rows.
-- `workspace_id` should be the source workspace ID (used to filter workspace memberships per mapped workspace pair).
+- `email` and `langsmith_role` are required.
+- `workspace_id` is optional. Leave it empty for org-level role assignments.
+- `workspace_name` is optional and informational only.
+- `langsmith_role` should be a built-in LangSmith role name (for example `Organization Admin`, `Organization User`, `Workspace Admin`) or a custom role `display_name`.
+- Users who only appear in workspace rows are invited to the org with the source `ORGANIZATION_USER` role before workspace membership is applied.
 
 ### CLI Options
 
@@ -211,6 +214,28 @@ The prompt default is `No` (rules are created disabled).
 --same-instance         Reuse source project/session IDs on destination
 ```
 
+### Users Options
+
+```bash
+--roles-only               Only sync custom roles (skip member migration)
+--skip-workspace-members   Skip workspace member migration (phases 1-2 only)
+--members-csv PATH         CSV file with member details (email, langsmith_role, workspace_id, workspace_name)
+```
+
+Migration proceeds in three phases:
+1. **Role sync** (org-scoped): match built-in roles by name, create/update custom roles
+2. **Org members** (org-scoped): invite missing members, update roles for existing ones
+3. **Workspace members** (per workspace pair): add members to workspaces with correct roles
+
+Rules are created disabled by default. Use `--create-enabled` on the `rules` command to override.
+
+### Migrate-All Users Options
+
+```bash
+--skip-users               Skip user and role migration in migrate-all wizard
+```
+
+When `--skip-users` is omitted, `migrate-all` runs user/role migration as Step 0 before all other resources. Phases 1-2 (roles + org members) run once; phase 3 (workspace members) runs per workspace pair.
 ### Project Mapping
 
 Rules and charts reference projects by ID. When migrating between instances, project IDs differ.

--- a/examples/users_members_example.csv
+++ b/examples/users_members_example.csv
@@ -1,7 +1,6 @@
-email,role_id,workspace_id
-amelia.nguyen@example.com,role_org_user_3f6ab9d1,ws_src_prod_us
-amelia.nguyen@example.com,role_org_user_3f6ab9d1,ws_src_prod_eu
-jordan.lee@example.com,role_workspace_admin_91c2a7f4,ws_src_prod_us
-priya.patel@example.com,role_custom_data_steward_7e4d22c8,ws_src_ml_platform
-mateo.garcia@example.com,role_org_admin_b2e9f631,ws_src_shared_services
-sana.khan@example.com,role_workspace_user_0a8d6be5,ws_src_analytics
+email,langsmith_role,workspace_id,workspace_name
+amelia.nguyen@example.com,Organization Admin,,
+jordan.lee@example.com,Workspace Admin,ws_src_prod_us,Production US
+priya.patel@example.com,Data Scientist,ws_src_ml_platform,ML Platform
+mateo.garcia@example.com,Organization User,,
+sana.khan@example.com,Workspace Admin,ws_src_analytics,Analytics

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -111,7 +111,13 @@ _WS_CANCELLED = "__cancelled__"
 _WS_ABORTED = "__aborted__"
 
 
-def _resolve_workspaces(orchestrator, source_workspace=None, dest_workspace=None, map_workspaces=False):
+def _resolve_workspaces(
+    orchestrator,
+    source_workspace=None,
+    dest_workspace=None,
+    map_workspaces=False,
+    non_interactive=False,
+):
     """Resolve workspace context from explicit IDs or auto-detection.
 
     Returns:
@@ -2737,83 +2743,86 @@ def resume(ctx):
         console.print(f"[red]Failed to load session {session_id}[/red]")
         return
 
-    # Create orchestrator and attach state
-    orchestrator = ctx.with_resource(MigrationOrchestrator(config, state_manager))
+    orchestrator = MigrationOrchestrator(config, state_manager)
+    try:
+        # Test connections first
+        console.print("Testing connections... ", end="")
+        source_ok, dest_ok, source_error, dest_error = orchestrator.test_connections_detailed()
+        if not source_ok:
+            console.print("[red]✗ Source connection failed[/red]")
+            if source_error:
+                console.print(f"[red]  {source_error}[/red]")
+            return
+        if not dest_ok:
+            console.print("[yellow]⚠ Source OK, destination connection failed[/yellow]")
+            if dest_error:
+                console.print(f"[yellow]  {dest_error}[/yellow]")
+            console.print("Continuing with source-only operations...")
+        else:
+            console.print("[green]✓[/green]")
 
-    # Test connections first
-    console.print("Testing connections... ", end="")
-    source_ok, dest_ok, source_error, dest_error = orchestrator.test_connections_detailed()
-    if not source_ok:
-        console.print("[red]✗ Source connection failed[/red]")
-        if source_error:
-            console.print(f"[red]  {source_error}[/red]")
-        return
-    if not dest_ok:
-        console.print("[yellow]⚠ Source OK, destination connection failed[/yellow]")
-        if dest_error:
-            console.print(f"[yellow]  {dest_error}[/yellow]")
-        console.print("Continuing with source-only operations...")
-    else:
-        console.print("[green]✓[/green]")
+        # Attach state to orchestrator
+        orchestrator.state = state
+        orchestrator.state_manager.current_state = state
+        config.state_manager = state_manager
 
-    # Attach state to orchestrator
-    orchestrator.state = state
-    orchestrator.state_manager.current_state = state
-    config.state_manager = state_manager
+        # Get resumable items
+        resume_items = state.get_resume_items()
+        checkpoint_items = state.get_checkpoint_items()
 
-    # Get resumable items
-    resume_items = state.get_resume_items()
-    checkpoint_items = state.get_checkpoint_items()
+        console.print(f"\nResumable items: {len(resume_items)}")
+        console.print(f"Checkpoint/manual items: {len(checkpoint_items)}")
 
-    console.print(f"\nResumable items: {len(resume_items)}")
-    console.print(f"Checkpoint/manual items: {len(checkpoint_items)}")
-
-    if checkpoint_items:
-        console.print("\n[bold]Items requiring manual attention:[/bold]")
-        for item in checkpoint_items[:10]:
-            console.print(f"  • {item.name}: {item.next_action or item.outcome_code or 'needs attention'}")
-
-    if not resume_items:
-        console.print("\n[yellow]No items to resume automatically.[/yellow]")
         if checkpoint_items:
-            console.print("[dim]Review the checkpoint items above and resolve them manually.[/dim]")
-        return
+            console.print("\n[bold]Items requiring manual attention:[/bold]")
+            for item in checkpoint_items[:10]:
+                console.print(f"  • {item.name}: {item.next_action or item.outcome_code or 'needs attention'}")
 
-    # Show what will be resumed
-    console.print(f"\n[bold]Items to resume ({len(resume_items)}):[/bold]")
-    type_counts: dict[str, int] = {}
-    for item in resume_items:
-        type_counts[item.type] = type_counts.get(item.type, 0) + 1
-    for item_type, count in sorted(type_counts.items()):
-        console.print(f"  {item_type}: {count}")
+        if not resume_items:
+            console.print("\n[yellow]No items to resume automatically.[/yellow]")
+            if checkpoint_items:
+                console.print("[dim]Review the checkpoint items above and resolve them manually.[/dim]")
+            return
 
-    if not _confirm_action(config, "\nProceed with resume?", default=True, non_interactive_value=True):
-        console.print("[yellow]Cancelled[/yellow]")
-        return
+        # Show what will be resumed
+        console.print(f"\n[bold]Items to resume ({len(resume_items)}):[/bold]")
+        type_counts: dict[str, int] = {}
+        for item in resume_items:
+            type_counts[item.type] = type_counts.get(item.type, 0) + 1
+        for item_type, count in sorted(type_counts.items()):
+            console.print(f"  {item_type}: {count}")
 
-    # Run resume
-    console.print(f"\n[bold]Resuming migration of {len(resume_items)} items[/bold]")
-    results = orchestrator.resume_items(resume_items)
+        if not _confirm_action(config, "\nProceed with resume?", default=True, non_interactive_value=True):
+            console.print("[yellow]Cancelled[/yellow]")
+            return
 
-    # Save state
-    state_manager.save()
+        # Run resume
+        console.print(f"\n[bold]Resuming migration of {len(resume_items)} items[/bold]")
+        results = orchestrator.resume_items(resume_items)
 
-    console.print("[green]Resume processing completed[/green]")
+        # Save state
+        state_manager.save()
 
-    # Report results
-    resumed = results.get("resumed", [])
-    blocked = results.get("blocked", [])
-    console.print(f"\n[bold]Resume Results:[/bold]")
-    console.print(f"  [green]Resumed successfully: {len(resumed)}[/green]")
-    console.print(f"  [yellow]Blocked/needs attention: {len(blocked)}[/yellow]")
+        console.print("[green]Resume processing completed[/green]")
 
-    if blocked and config.migration.verbose:
-        console.print("\n[dim]Blocked items:[/dim]")
-        for item_ref in blocked[:20]:
-            console.print(f"  • {item_ref}")
+        # Report results
+        resumed = results.get("resumed", [])
+        blocked = results.get("blocked", [])
+        console.print(f"\n[bold]Resume Results:[/bold]")
+        console.print(f"  [green]Resumed successfully: {len(resumed)}[/green]")
+        console.print(f"  [yellow]Blocked/needs attention: {len(blocked)}[/yellow]")
 
-    _display_resolution_summary(orchestrator)
-    _exit_for_remediation_if_needed(ctx, config, orchestrator)
+        if blocked and config.migration.verbose:
+            console.print("\n[dim]Blocked items:[/dim]")
+            for item_ref in blocked[:20]:
+                console.print(f"  • {item_ref}")
+
+        _display_resolution_summary(orchestrator)
+        _exit_for_remediation_if_needed(ctx, config, orchestrator)
+    finally:
+        orchestrator.cleanup()
+
+
 def main():
     """Main entry point."""
     try:

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -49,7 +49,11 @@ from ..utils.workspace import (
     list_projects as _list_projects,
     list_workspaces as _list_workspaces,
 )
-from ..utils.workspace_resolver import resolve_workspace_context, display_workspaces
+from ..utils.workspace_resolver import (
+    WorkspaceResolutionError,
+    display_workspaces,
+    resolve_workspace_context,
+)
 
 
 console = Console()
@@ -104,6 +108,7 @@ def _name_mapping_to_id_mapping(
 
 
 _WS_CANCELLED = "__cancelled__"
+_WS_ABORTED = "__aborted__"
 
 
 def _resolve_workspaces(orchestrator, source_workspace=None, dest_workspace=None, map_workspaces=False):
@@ -113,6 +118,7 @@ def _resolve_workspaces(orchestrator, source_workspace=None, dest_workspace=None
         - WorkspaceProjectResult if workspace scoping is active
         - None if no workspace scoping is needed (single-workspace or none found)
         - _WS_CANCELLED sentinel if the user explicitly cancelled the TUI
+        - _WS_ABORTED sentinel if workspace resolution failed safely
     """
     # Explicit single-pair override
     if source_workspace and dest_workspace:
@@ -129,12 +135,16 @@ def _resolve_workspaces(orchestrator, source_workspace=None, dest_workspace=None
         return _WS_CANCELLED
 
     # Auto-detect (config is lazy-loaded inside resolve_workspace_context)
-    result = resolve_workspace_context(
-        orchestrator.source_client,
-        orchestrator.dest_client,
-        console,
-        force_tui=map_workspaces,
-    )
+    try:
+        result = resolve_workspace_context(
+            orchestrator.source_client,
+            orchestrator.dest_client,
+            console,
+            force_tui=map_workspaces,
+            non_interactive=non_interactive,
+        )
+    except WorkspaceResolutionError:
+        return _WS_ABORTED
 
     # If force_tui was set and user cancelled, treat as abort
     if result is None and map_workspaces:
@@ -307,11 +317,15 @@ def _select_or_all(config: Config, items: list, *, select_all: bool, title: str,
 def _load_members_csv(path: str) -> list[dict]:
     """Load and validate a members CSV file.
 
+    Expected columns: ``email``, ``langsmith_role``.
+    Optional columns: ``workspace_id`` (empty for org-level rows),
+    ``workspace_name`` (informational, ignored).
+
     Click's ``type=click.Path(exists=True, dir_okay=False)`` already
     validates existence and file-type before this function is called.
     """
     csv_path = Path(path)
-    required_columns = {"email", "role_id", "workspace_id"}
+    required_columns = {"email", "langsmith_role"}
 
     try:
         # utf-8-sig allows BOM-prefixed files exported by spreadsheet tools.
@@ -328,26 +342,22 @@ def _load_members_csv(path: str) -> list[dict]:
             rows: list[dict] = []
             for index, row in enumerate(reader, start=2):
                 email = (row.get("email") or "").strip().lower()
-                role_id = (row.get("role_id") or "").strip()
+                langsmith_role = (row.get("langsmith_role") or "").strip()
                 workspace_id = (row.get("workspace_id") or "").strip()
 
                 if not email:
                     raise click.ClickException(
                         f"Members CSV row {index} has an empty email value"
                     )
-                if not role_id:
+                if not langsmith_role:
                     raise click.ClickException(
-                        f"Members CSV row {index} has an empty role_id value"
-                    )
-                if not workspace_id:
-                    raise click.ClickException(
-                        f"Members CSV row {index} has an empty workspace_id value"
+                        f"Members CSV row {index} has an empty langsmith_role value"
                     )
 
                 rows.append(
                     {
                         "email": email,
-                        "role_id": role_id,
+                        "langsmith_role": langsmith_role,
                         "workspace_id": workspace_id,
                     }
                 )
@@ -363,19 +373,126 @@ def _load_members_csv(path: str) -> list[dict]:
     return rows
 
 
-def _csv_rows_to_org_members(csv_rows: list[dict]) -> list[dict]:
+_BUILTIN_ROLE_ALIASES: dict[str, str] = {
+    "organization admin": "ORGANIZATION_ADMIN",
+    "organization user": "ORGANIZATION_USER",
+    "workspace admin": "WORKSPACE_ADMIN",
+}
+
+
+def _resolve_csv_role_names(
+    csv_rows: list[dict], source_roles: list[dict]
+) -> tuple[list[dict], str | None]:
+    """Resolve human-readable role names to source role IDs.
+
+    Returns ``(resolved_rows, org_user_role_id)`` where each resolved row
+    has ``role_id`` instead of ``langsmith_role``, and *org_user_role_id*
+    is the source role ID for ORGANIZATION_USER (used as the default org
+    role for users who only appear in workspace rows). Built-in role
+    identifiers and documented aliases take precedence over colliding
+    custom role display names.
+    """
+    role_lookup: dict[str, list[tuple[str, str]]] = {}
+    builtin_by_name: dict[str, str] = {}
+    preferred_builtin_by_label: dict[str, str] = {}
+    org_user_role_id: str | None = None
+
+    def register_role_label(label: str, role_id: str, role_name: str) -> None:
+        candidates = role_lookup.setdefault(label, [])
+        if not any(existing_role_id == role_id for existing_role_id, _ in candidates):
+            candidates.append((role_id, role_name))
+
+    for role in source_roles:
+        role_name = role.get("name", "")
+        role_id = role["id"]
+        dn = (role.get("display_name") or "").strip().lower()
+
+        if role_name != "CUSTOM":
+            builtin_by_name[role_name] = role_id
+            if dn:
+                register_role_label(dn, role_id, role_name)
+            builtin_label = role_name.lower()
+            register_role_label(builtin_label, role_id, role_name)
+            preferred_builtin_by_label[builtin_label] = role_id
+            if role_name == "ORGANIZATION_USER":
+                org_user_role_id = role_id
+        elif dn:
+            register_role_label(dn, role_id, role_name)
+
+    for alias, builtin_name in _BUILTIN_ROLE_ALIASES.items():
+        builtin_role_id = builtin_by_name.get(builtin_name)
+        if builtin_role_id:
+            register_role_label(alias, builtin_role_id, builtin_name)
+            preferred_builtin_by_label[alias] = builtin_role_id
+
+    ambiguous: set[str] = set()
+    unresolved: set[str] = set()
+    resolved_rows: list[dict] = []
+    for row in csv_rows:
+        label = row["langsmith_role"].strip().lower()
+        candidates = role_lookup.get(label, [])
+        if not candidates:
+            unresolved.add(row["langsmith_role"])
+            continue
+
+        preferred_role_id = preferred_builtin_by_label.get(label)
+        if preferred_role_id and any(
+            candidate_role_id == preferred_role_id
+            for candidate_role_id, _ in candidates
+        ):
+            role_id = preferred_role_id
+        else:
+            unique_role_ids = {candidate_role_id for candidate_role_id, _ in candidates}
+            if len(unique_role_ids) != 1:
+                ambiguous.add(row["langsmith_role"])
+                continue
+            role_id = next(iter(unique_role_ids))
+
+        resolved_rows.append(
+            {
+                "email": row["email"],
+                "role_id": role_id,
+                "workspace_id": row.get("workspace_id", ""),
+            }
+        )
+
+    if ambiguous or unresolved:
+        available = sorted(role_lookup.keys())
+        errors: list[str] = []
+        if ambiguous:
+            errors.append("Ambiguous role name(s): " + ", ".join(sorted(ambiguous)))
+        if unresolved:
+            errors.append(
+                "Could not resolve role name(s): "
+                + ", ".join(sorted(unresolved))
+            )
+        errors.append("Available roles: " + ", ".join(available))
+        raise click.ClickException(". ".join(errors))
+
+    return resolved_rows, org_user_role_id
+
+
+def _csv_rows_to_org_members(
+    csv_rows: list[dict], default_org_role_id: str | None = None
+) -> list[dict]:
     """Build org member payloads from CSV rows.
 
-    A single org role is applied per email, so conflicting role_id values
-    for the same email across workspaces are rejected.
+    Rows with an empty ``workspace_id`` are org-level assignments whose
+    ``role_id`` is used directly.  Users who only appear in workspace
+    rows (non-empty ``workspace_id``) are assigned *default_org_role_id*
+    (typically ORGANIZATION_USER) so they can be invited to the org.
     """
+    org_rows = [r for r in csv_rows if not r.get("workspace_id")]
+    ws_rows = [r for r in csv_rows if r.get("workspace_id")]
+
     members_by_email: dict[str, dict] = {}
-    for row in csv_rows:
+
+    for row in org_rows:
         email = row["email"]
         existing = members_by_email.get(email)
         if existing and existing["role_id"] != row["role_id"]:
             raise click.ClickException(
-                "Members CSV has conflicting role_id values for "
+                "Members CSV has conflicting org-level roles for "
                 f"{email}: '{existing['role_id']}' vs '{row['role_id']}'"
             )
         if not existing:
@@ -385,6 +502,17 @@ def _csv_rows_to_org_members(csv_rows: list[dict]) -> list[dict]:
                 "role_id": row["role_id"],
                 "full_name": "",
             }
+
+    for row in ws_rows:
+        email = row["email"]
+        if email not in members_by_email and default_org_role_id:
+            members_by_email[email] = {
+                "id": email,
+                "email": email,
+                "role_id": default_org_role_id,
+                "full_name": "",
+            }
+
     return list(members_by_email.values())
 
 
@@ -732,7 +860,10 @@ def datasets(ctx, include_experiments, select_all, source_workspace, dest_worksp
         console.print("[green]✓[/green]")
 
     # Resolve workspace context
-    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces)
+    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces, non_interactive=config.migration.non_interactive)
+    if ws_result is _WS_ABORTED:
+        ctx.exit(1)
+        return
     if ws_result is _WS_CANCELLED:
         console.print("[yellow]Cancelled[/yellow]")
         return
@@ -840,23 +971,14 @@ def datasets(ctx, include_experiments, select_all, source_workspace, dest_worksp
         orchestrator.cleanup()
 
 
-@cli.command()
-@ssl_option
-@click.pass_context
-def resume(ctx):
-    """Resume a previous migration session."""
-    state_manager = ctx.obj['state_manager']
-
-    display_banner()
-
-    # List available sessions
+def _select_resume_session(config: Config, state_manager: StateManager):
+    """Return the selected migration session, or None if the user cancels."""
     sessions = state_manager.list_sessions()
 
     if not sessions:
         console.print("[yellow]No previous migration sessions found[/yellow]")
-        return
+        return None
 
-    # Display sessions
     table = Table(title="Available Migration Sessions", show_header=True)
     table.add_column("#", style="cyan", width=3)
     table.add_column("Session ID", style="dim")
@@ -875,79 +997,27 @@ def resume(ctx):
             session["session_id"],
             started,
             status,
-            progress
+            progress,
         )
 
     console.print(table)
 
-    # Select session
-    if ctx.obj["config"].migration.non_interactive:
-        choice = "1"
-    else:
-        choice = console.input("\nEnter session number to resume (or 'q' to quit): ")
+    if config.migration.non_interactive:
+        return sessions[0]
 
+    choice = console.input("\nEnter session number to resume (or 'q' to quit): ")
     if choice.lower() == 'q':
-        return
+        return None
 
     try:
         session_idx = int(choice) - 1
         if 0 <= session_idx < len(sessions):
-            selected_session = sessions[session_idx]
-        else:
-            console.print("[red]Invalid selection[/red]")
-            return
+            return sessions[session_idx]
+        console.print("[red]Invalid selection[/red]")
+        return None
     except ValueError:
         console.print("[red]Invalid input[/red]")
-        return
-
-    # Load session
-    state = state_manager.load_session(selected_session["session_id"])
-
-    if not state:
-        console.print("[red]Failed to load session[/red]")
-        return
-
-    # Display resume info
-    resume_info = state_manager.get_resume_info(state)
-
-    console.print("\n[bold]Resume Information:[/bold]")
-    console.print(f"  Session: {resume_info['session_id']}")
-    console.print(f"  Pending: {resume_info['pending']}")
-    console.print(f"  Failed: {resume_info['failed']}")
-    console.print(f"  Blocked: {resume_info['blocked']}")
-    console.print(f"  Exported: {resume_info['exported']}")
-    if resume_info.get("remediation_bundle_path"):
-        console.print(f"  Remediation bundle: {resume_info['remediation_bundle_path']}")
-    console.print(f"  Can resume: {'Yes' if resume_info['can_resume'] else 'No'}")
-
-    if not resume_info['can_resume']:
-        console.print("[yellow]Nothing to resume in this session[/yellow]")
-        return
-
-    if not _confirm_action(ctx.obj["config"], "Resume this migration?", default=True, non_interactive_value=True):
-        return
-
-    # Resume migration
-    config = ctx.obj['config']
-    orchestrator = MigrationOrchestrator(config, state_manager)
-    orchestrator.state = state
-    config.state_manager = state_manager
-
-    # Get items that need processing
-    items_to_process = state.get_resume_items()
-
-    console.print(f"\n[bold]Resuming migration of {len(items_to_process)} items...[/bold]")
-    if not items_to_process:
-        console.print("[yellow]No resumable items to process[/yellow]")
-    else:
-        results = orchestrator.resume_items(items_to_process)
-        console.print("\n[green]✓ Resume processing completed[/green]")
-        console.print(f"  Resumed: {len(results['resumed'])}")
-        console.print(f"  Remaining blocked/exported: {len(results['blocked'])}")
-
-    _display_resolution_summary(orchestrator)
-    _exit_for_remediation_if_needed(ctx, config, orchestrator)
-    orchestrator.cleanup()
+        return None
 
 
 @cli.command()
@@ -973,7 +1043,10 @@ def queues(ctx, source_workspace, dest_workspace, map_workspaces):
         return
 
     # Resolve workspace context
-    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces)
+    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces, non_interactive=config.migration.non_interactive)
+    if ws_result is _WS_ABORTED:
+        ctx.exit(1)
+        return
     if ws_result is _WS_CANCELLED:
         console.print("[yellow]Cancelled[/yellow]")
         orchestrator.cleanup()
@@ -1070,8 +1143,9 @@ def queues(ctx, source_workspace, dest_workspace, map_workspaces):
     '--members-csv',
     type=click.Path(exists=True, dir_okay=False, path_type=str),
     help=(
-        "CSV file with member details (email, role_id, workspace_id). "
-        "Replaces source member API lookups; role_id must be consistent per email."
+        "CSV file with member details (email, langsmith_role, workspace_id, "
+        "workspace_name). Replaces source member API lookups. Rows with an "
+        "empty workspace_id are org-level role assignments."
     ),
 )
 @workspace_options
@@ -1102,7 +1176,10 @@ def users(
         return
 
     # Resolve workspace context (needed for phase 3)
-    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces)
+    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces, non_interactive=config.migration.non_interactive)
+    if ws_result is _WS_ABORTED:
+        ctx.exit(1)
+        return
     if ws_result is _WS_CANCELLED:
         console.print("[yellow]Cancelled[/yellow]")
         orchestrator.cleanup()
@@ -1141,12 +1218,33 @@ def users(
         return
 
     csv_member_rows = _load_members_csv(members_csv) if members_csv else None
+    default_org_role_id: str | None = None
+
+    if csv_member_rows is not None:
+        source_roles = user_role_migrator.list_source_roles()
+        csv_member_rows, default_org_role_id = _resolve_csv_role_names(
+            csv_member_rows, source_roles
+        )
+        if default_org_role_id is None:
+            org_emails: set[str] = set()
+            ws_emails: set[str] = set()
+            for r in csv_member_rows:
+                (ws_emails if r.get("workspace_id") else org_emails).add(r["email"])
+            ws_only_emails = ws_emails - org_emails
+            if ws_only_emails:
+                console.print(
+                    f"  [yellow]Warning: no ORGANIZATION_USER role found on source; "
+                    f"{len(ws_only_emails)} workspace-only user(s) will not be "
+                    f"invited to the org.[/yellow]"
+                )
 
     # ── Phase 2: Org member migration ──
     console.print("\n[bold]Phase 2: Migrating organisation members...[/bold]")
 
     if csv_member_rows is not None:
-        all_members = _csv_rows_to_org_members(csv_member_rows)
+        all_members = _csv_rows_to_org_members(
+            csv_member_rows, default_org_role_id=default_org_role_id
+        )
     else:
         org_members = user_role_migrator.list_source_org_members()
         pending_members = user_role_migrator.list_source_pending_org_members()
@@ -1273,7 +1371,10 @@ def prompts(ctx, select_all, include_all_commits, source_workspace, dest_workspa
     console.print("[green]✓[/green]")
 
     # Resolve workspace context
-    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces)
+    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces, non_interactive=config.migration.non_interactive)
+    if ws_result is _WS_ABORTED:
+        ctx.exit(1)
+        return
     if ws_result is _WS_CANCELLED:
         console.print("[yellow]Cancelled[/yellow]")
         orchestrator.cleanup()
@@ -1515,7 +1616,10 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
     console.print("[green]✓[/green]")
 
     # Resolve workspace context
-    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces)
+    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces, non_interactive=config.migration.non_interactive)
+    if ws_result is _WS_ABORTED:
+        ctx.exit(1)
+        return
     if ws_result is _WS_CANCELLED:
         console.print("[yellow]Cancelled[/yellow]")
         orchestrator.cleanup()
@@ -1796,7 +1900,10 @@ def migrate_all(ctx, skip_users, skip_datasets, skip_experiments, skip_prompts, 
     console.print("[green]✓[/green]\n")
 
     # Resolve workspace context (runs before asset discovery)
-    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces)
+    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces, non_interactive=config.migration.non_interactive)
+    if ws_result is _WS_ABORTED:
+        ctx.exit(1)
+        return
     if ws_result is _WS_CANCELLED:
         console.print("[yellow]Cancelled[/yellow]")
         orchestrator.cleanup()
@@ -2349,7 +2456,10 @@ def charts(ctx, session, same_instance, map_projects, source_workspace, dest_wor
     console.print("[green]✓[/green]")
 
     # Resolve workspace context
-    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces)
+    ws_result = _resolve_workspaces(orchestrator, source_workspace, dest_workspace, map_workspaces, non_interactive=config.migration.non_interactive)
+    if ws_result is _WS_ABORTED:
+        ctx.exit(1)
+        return
     if ws_result is _WS_CANCELLED:
         console.print("[yellow]Cancelled[/yellow]")
         orchestrator.cleanup()
@@ -2602,6 +2712,108 @@ def clean(ctx):
         console.print("[yellow]Cleanup cancelled[/yellow]")
 
 
+@cli.command()
+@ssl_option
+@click.pass_context
+def resume(ctx):
+    """Resume a previous migration session (retry pending/failed items)."""
+    config = ctx.obj['config']
+    state_manager = ctx.obj['state_manager']
+
+    display_banner()
+
+    if not ensure_config(config):
+        return
+
+    selected_session = _select_resume_session(config, state_manager)
+    if not selected_session:
+        return
+
+    session_id = selected_session["session_id"]
+    console.print(f"\nLoading session: {session_id[:16]}...")
+
+    state = state_manager.load_session(session_id)
+    if not state:
+        console.print(f"[red]Failed to load session {session_id}[/red]")
+        return
+
+    # Create orchestrator and attach state
+    orchestrator = ctx.with_resource(MigrationOrchestrator(config, state_manager))
+
+    # Test connections first
+    console.print("Testing connections... ", end="")
+    source_ok, dest_ok, source_error, dest_error = orchestrator.test_connections_detailed()
+    if not source_ok:
+        console.print("[red]✗ Source connection failed[/red]")
+        if source_error:
+            console.print(f"[red]  {source_error}[/red]")
+        return
+    if not dest_ok:
+        console.print("[yellow]⚠ Source OK, destination connection failed[/yellow]")
+        if dest_error:
+            console.print(f"[yellow]  {dest_error}[/yellow]")
+        console.print("Continuing with source-only operations...")
+    else:
+        console.print("[green]✓[/green]")
+
+    # Attach state to orchestrator
+    orchestrator.state = state
+    orchestrator.state_manager.current_state = state
+    config.state_manager = state_manager
+
+    # Get resumable items
+    resume_items = state.get_resume_items()
+    checkpoint_items = state.get_checkpoint_items()
+
+    console.print(f"\nResumable items: {len(resume_items)}")
+    console.print(f"Checkpoint/manual items: {len(checkpoint_items)}")
+
+    if checkpoint_items:
+        console.print("\n[bold]Items requiring manual attention:[/bold]")
+        for item in checkpoint_items[:10]:
+            console.print(f"  • {item.name}: {item.next_action or item.outcome_code or 'needs attention'}")
+
+    if not resume_items:
+        console.print("\n[yellow]No items to resume automatically.[/yellow]")
+        if checkpoint_items:
+            console.print("[dim]Review the checkpoint items above and resolve them manually.[/dim]")
+        return
+
+    # Show what will be resumed
+    console.print(f"\n[bold]Items to resume ({len(resume_items)}):[/bold]")
+    type_counts: dict[str, int] = {}
+    for item in resume_items:
+        type_counts[item.type] = type_counts.get(item.type, 0) + 1
+    for item_type, count in sorted(type_counts.items()):
+        console.print(f"  {item_type}: {count}")
+
+    if not _confirm_action(config, "\nProceed with resume?", default=True, non_interactive_value=True):
+        console.print("[yellow]Cancelled[/yellow]")
+        return
+
+    # Run resume
+    console.print(f"\n[bold]Resuming migration of {len(resume_items)} items[/bold]")
+    results = orchestrator.resume_items(resume_items)
+
+    # Save state
+    state_manager.save()
+
+    console.print("[green]Resume processing completed[/green]")
+
+    # Report results
+    resumed = results.get("resumed", [])
+    blocked = results.get("blocked", [])
+    console.print(f"\n[bold]Resume Results:[/bold]")
+    console.print(f"  [green]Resumed successfully: {len(resumed)}[/green]")
+    console.print(f"  [yellow]Blocked/needs attention: {len(blocked)}[/yellow]")
+
+    if blocked and config.migration.verbose:
+        console.print("\n[dim]Blocked items:[/dim]")
+        for item_ref in blocked[:20]:
+            console.print(f"  • {item_ref}")
+
+    _display_resolution_summary(orchestrator)
+    _exit_for_remediation_if_needed(ctx, config, orchestrator)
 def main():
     """Main entry point."""
     try:

--- a/langsmith_migrator/core/migrators/experiment.py
+++ b/langsmith_migrator/core/migrators/experiment.py
@@ -437,7 +437,14 @@ class ExperimentMigrator(BaseMigrator):
 
                     # Map reference_example_id if present
                     source_example_id = run.get("reference_example_id")
-                    mapped_example_id = example_mapping.get(source_example_id) if source_example_id else None
+                    mapped_example_id = None
+                    if source_example_id:
+                        mapped_example_id = example_mapping.get(source_example_id)
+                        if not mapped_example_id:
+                            self.log(
+                                f"Warning: run references unmapped example {source_example_id}, dropping example link",
+                                "warning",
+                            )
 
                     # Deterministic IDs make interrupted batches safe to replay.
                     new_run_id = self._deterministic_run_id(source_run_id)

--- a/langsmith_migrator/utils/migration_config.py
+++ b/langsmith_migrator/utils/migration_config.py
@@ -41,6 +41,8 @@ class MigrationFileConfig:
     destination_workspace: Optional[WorkspaceConfig] = None
     project_name_mapping: Dict[str, str] = field(default_factory=dict)
     workspace_mapping: Dict[str, str] = field(default_factory=dict)  # source_ws_id -> dest_ws_id
+    workspace_mapping_source_url: str = ""
+    workspace_mapping_destination_url: str = ""
     created_at: str = ""
     updated_at: str = ""
 
@@ -52,6 +54,8 @@ class MigrationFileConfig:
             "destination_workspace": asdict(self.destination_workspace) if self.destination_workspace else None,
             "project_name_mapping": self.project_name_mapping,
             "workspace_mapping": self.workspace_mapping,
+            "workspace_mapping_source_url": self.workspace_mapping_source_url,
+            "workspace_mapping_destination_url": self.workspace_mapping_destination_url,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }
@@ -63,6 +67,8 @@ class MigrationFileConfig:
         config.version = data.get("version", CONFIG_VERSION)
         config.project_name_mapping = data.get("project_name_mapping", {})
         config.workspace_mapping = data.get("workspace_mapping", {})
+        config.workspace_mapping_source_url = data.get("workspace_mapping_source_url", "")
+        config.workspace_mapping_destination_url = data.get("workspace_mapping_destination_url", "")
         config.created_at = data.get("created_at", "")
         config.updated_at = data.get("updated_at", "")
         config.source_workspace = _parse_workspace(data.get("source_workspace"))

--- a/langsmith_migrator/utils/workspace_resolver.py
+++ b/langsmith_migrator/utils/workspace_resolver.py
@@ -12,12 +12,70 @@ from .migration_config import MigrationFileConfig, load_config, save_config
 from ..cli.tui_workspace_mapper import WorkspaceProjectResult, build_workspace_mapping_tui
 
 
+class WorkspaceResolutionError(RuntimeError):
+    """Workspace resolution could not complete safely."""
+
+
+def _normalize_base_url(url: str) -> str:
+    """Normalize instance URLs before comparing persisted mapping context."""
+    return (url or "").rstrip("/").lower()
+
+
+def _validate_saved_mapping(
+    saved_config: MigrationFileConfig,
+    source_workspaces: List[Dict],
+    dest_workspaces: List[Dict],
+    source_client: EnhancedAPIClient,
+    dest_client: EnhancedAPIClient,
+) -> tuple[Optional[Dict[str, str]], List[str]]:
+    """Return a reusable saved mapping, or validation errors explaining why not."""
+    mapping = saved_config.workspace_mapping
+    if not mapping:
+        return None, []
+
+    errors: List[str] = []
+
+    saved_source_url = _normalize_base_url(saved_config.workspace_mapping_source_url)
+    current_source_url = _normalize_base_url(getattr(source_client, "base_url", ""))
+    if saved_source_url and saved_source_url != current_source_url:
+        errors.append("saved source instance does not match the current source URL")
+
+    saved_dest_url = _normalize_base_url(saved_config.workspace_mapping_destination_url)
+    current_dest_url = _normalize_base_url(getattr(dest_client, "base_url", ""))
+    if saved_dest_url and saved_dest_url != current_dest_url:
+        errors.append(
+            "saved destination instance does not match the current destination URL"
+        )
+
+    source_ids = {ws.get("id", "") for ws in source_workspaces if ws.get("id")}
+    invalid_source_ids = sorted(src_id for src_id in mapping if src_id not in source_ids)
+    if invalid_source_ids:
+        errors.append(
+            "saved source workspace IDs were not found: "
+            + ", ".join(invalid_source_ids)
+        )
+
+    dest_ids = {ws.get("id", "") for ws in dest_workspaces if ws.get("id")}
+    invalid_dest_ids = sorted({dst_id for dst_id in mapping.values() if dst_id not in dest_ids})
+    if invalid_dest_ids:
+        errors.append(
+            "saved destination workspace IDs were not found: "
+            + ", ".join(invalid_dest_ids)
+        )
+
+    if errors:
+        return None, errors
+
+    return mapping, []
+
+
 def resolve_workspace_context(
     source_client: EnhancedAPIClient,
     dest_client: EnhancedAPIClient,
     console: Console,
     saved_config: Optional[MigrationFileConfig] = None,
     force_tui: bool = False,
+    non_interactive: bool = False,
 ) -> Optional[WorkspaceProjectResult]:
     """Detect workspaces on both sides and resolve a mapping if needed.
 
@@ -48,16 +106,45 @@ def resolve_workspace_context(
     if saved_config is None:
         saved_config = load_config()
 
+    reusable_mapping: Optional[Dict[str, str]] = None
     # Check for saved mapping
     if saved_config and saved_config.workspace_mapping:
-        _display_saved_mapping(console, saved_config.workspace_mapping, source_workspaces, dest_workspaces)
-        if Confirm.ask("Reuse this workspace mapping?", default=True):
-            return WorkspaceProjectResult(
-                workspace_mapping=saved_config.workspace_mapping,
-                project_mappings={},
-                workspaces_to_create=[],
+        reusable_mapping, validation_errors = _validate_saved_mapping(
+            saved_config,
+            source_workspaces,
+            dest_workspaces,
+            source_client,
+            dest_client,
+        )
+        if reusable_mapping is None:
+            console.print(
+                "[yellow]Saved workspace mapping does not match the current instances; ignoring it.[/yellow]"
             )
+            for error in validation_errors:
+                console.print(f"  [yellow]- {error}[/yellow]")
+        else:
+            _display_saved_mapping(
+                console,
+                reusable_mapping,
+                source_workspaces,
+                dest_workspaces,
+            )
+            if non_interactive or Confirm.ask("Reuse this workspace mapping?", default=True):
+                return WorkspaceProjectResult(
+                    workspace_mapping=reusable_mapping,
+                    project_mappings={},
+                    workspaces_to_create=[],
+                )
 
+    # In non-interactive mode, we cannot launch the TUI
+    if non_interactive:
+        message = (
+            "Workspace mapping is required in non-interactive mode for "
+            "multi-workspace instances. Provide --source-workspace and "
+            "--dest-workspace together, or create a saved mapping first."
+        )
+        console.print(f"[red]Error: {message}[/red]")
+        raise WorkspaceResolutionError(message)
     # Build a callback for fetching projects scoped to a workspace
     def fetch_projects(ws_id: str, side: str) -> List[Dict]:
         client = source_client if side == "source" else dest_client
@@ -77,7 +164,7 @@ def resolve_workspace_context(
         source_workspaces,
         dest_workspaces,
         fetch_projects=fetch_projects,
-        existing_mapping=(saved_config.workspace_mapping if saved_config else None),
+        existing_mapping=reusable_mapping,
     )
 
     if tui_result is None:
@@ -99,6 +186,8 @@ def resolve_workspace_context(
     if tui_result.workspace_mapping:
         config = saved_config or load_config() or MigrationFileConfig()
         config.workspace_mapping = tui_result.workspace_mapping
+        config.workspace_mapping_source_url = getattr(source_client, "base_url", "")
+        config.workspace_mapping_destination_url = getattr(dest_client, "base_url", "")
         path = save_config(config)
         console.print(f"[dim]Workspace mapping saved to {path}[/dim]")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.57"
+version = "0.0.60"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -136,6 +136,26 @@ def test_resolve_workspaces_returns_cancelled_when_forced_tui_is_cancelled(monke
     assert result == cli_main._WS_CANCELLED
 
 
+def test_resolve_workspaces_returns_aborted_when_headless_resolution_fails(monkeypatch):
+    """Headless workspace-resolution failures should map to the abort sentinel."""
+
+    class StubOrchestrator:
+        source_client = object()
+        dest_client = object()
+
+    def _raise(*args, **kwargs):
+        raise cli_main.WorkspaceResolutionError("workspace mapping required")
+
+    monkeypatch.setattr(cli_main, "resolve_workspace_context", _raise)
+
+    result = cli_main._resolve_workspaces(
+        StubOrchestrator(),
+        non_interactive=True,
+    )
+
+    assert result == cli_main._WS_ABORTED
+
+
 def test_test_command_uses_global_options_and_lists_workspaces(cli_harness):
     """The smoke-test command should honor global config flags and verbose workspace listing."""
 
@@ -193,7 +213,10 @@ def test_users_command_members_csv_replaces_source_member_apis(cli_harness, monk
         workspaces_to_create=[],
     )
     csv_path = tmp_path / "members.csv"
-    csv_path.write_text("email,role_id,workspace_id\nalice@example.com,src-role,src-ws\n", encoding="utf-8")
+    csv_path.write_text(
+        "email,langsmith_role,workspace_id\nalice@example.com,Workspace Admin,src-ws\n",
+        encoding="utf-8",
+    )
 
     user_role_migrator = Mock()
     user_role_migrator.build_role_mapping.return_value = {"src-role": "dst-role"}
@@ -211,11 +234,12 @@ def test_users_command_members_csv_replaces_source_member_apis(cli_harness, monk
 
     monkeypatch.setattr(cli_main, "UserRoleMigrator", lambda *args, **kwargs: user_role_migrator)
 
-    csv_rows = [{"email": "alice@example.com", "role_id": "src-role", "workspace_id": "src-ws"}]
+    resolved_rows = [{"email": "alice@example.com", "role_id": "src-role", "workspace_id": "src-ws"}]
     org_members = [{"id": "alice@example.com", "email": "alice@example.com", "role_id": "src-role"}]
     ws_members = [{"id": "src-ws:alice@example.com", "email": "alice@example.com", "role_id": "src-role"}]
-    monkeypatch.setattr(cli_main, "_load_members_csv", lambda _: csv_rows)
-    monkeypatch.setattr(cli_main, "_csv_rows_to_org_members", lambda rows: org_members)
+    monkeypatch.setattr(cli_main, "_load_members_csv", lambda _: resolved_rows)
+    monkeypatch.setattr(cli_main, "_resolve_csv_role_names", lambda rows, roles: (resolved_rows, "src-user"))
+    monkeypatch.setattr(cli_main, "_csv_rows_to_org_members", lambda rows, **kw: org_members)
     monkeypatch.setattr(cli_main, "_csv_rows_for_workspace", lambda rows, ws_id: ws_members)
 
     result = cli_harness.invoke(["users", "--members-csv", str(csv_path)])
@@ -236,30 +260,36 @@ def test_users_command_members_csv_supports_utf8_bom(cli_harness, monkeypatch, t
     )
     csv_path = tmp_path / "members_bom.csv"
     csv_path.write_text(
-        "email,role_id,workspace_id\nalice@example.com,src-role,src-ws\n",
+        "email,langsmith_role,workspace_id\nalice@example.com,Workspace Admin,src-ws\n",
         encoding="utf-8-sig",
     )
 
     user_role_migrator = Mock()
-    user_role_migrator.build_role_mapping.return_value = {"src-role": "dst-role"}
+    user_role_migrator.build_role_mapping.return_value = {"src-ws-admin": "dst-ws-admin"}
     user_role_migrator._dest_email_to_identity = {}
     user_role_migrator.list_dest_org_members.return_value = []
     user_role_migrator.migrate_org_members.return_value = (1, 0, 0)
     user_role_migrator.migrate_workspace_members.return_value = (1, 0, 0)
+    user_role_migrator.list_source_roles.return_value = [
+        {"id": "src-admin", "name": "ORGANIZATION_ADMIN", "display_name": "Admin"},
+        {"id": "src-user", "name": "ORGANIZATION_USER", "display_name": "User"},
+        {"id": "src-ws-admin", "name": "WORKSPACE_ADMIN", "display_name": "Workspace Admin"},
+    ]
     monkeypatch.setattr(cli_main, "UserRoleMigrator", lambda *args, **kwargs: user_role_migrator)
 
     result = cli_harness.invoke(["users", "--members-csv", str(csv_path)])
 
     assert result.exit_code == 0
+    # alice only appears in a workspace row, so she gets the default org role (ORGANIZATION_USER)
     user_role_migrator.migrate_org_members.assert_called_once_with(
-        [{"id": "alice@example.com", "email": "alice@example.com", "role_id": "src-role", "full_name": ""}]
+        [{"id": "alice@example.com", "email": "alice@example.com", "role_id": "src-user", "full_name": ""}]
     )
     user_role_migrator.migrate_workspace_members.assert_called_once_with(
         selected_members=[
             {
                 "id": "src-ws:alice@example.com",
                 "email": "alice@example.com",
-                "role_id": "src-role",
+                "role_id": "src-ws-admin",
                 "full_name": "",
             }
         ]
@@ -388,6 +418,17 @@ def test_datasets_command_migrates_selected_datasets_with_workspace_scope(cli_ha
     ]
     assert orchestrator.clear_workspace_called is True
     assert "Migration completed" in cli_harness.console.text
+
+
+def test_datasets_command_exits_nonzero_when_workspace_resolution_aborts(cli_harness):
+    """Commands should stop instead of migrating unscoped after workspace-resolution errors."""
+
+    cli_harness.controls.workspace_result = cli_main._WS_ABORTED
+
+    result = cli_harness.invoke(["datasets"])
+
+    assert result.exit_code == 1
+    assert cli_harness.orchestrator_factory.instances[0].migrate_dataset_calls == []
 
 
 def test_prompts_command_surfaces_unavailable_prompts_api(cli_harness):
@@ -916,6 +957,51 @@ def test_resume_command_non_interactive_uses_latest_session_without_console_inpu
         include_all_commits=True,
     )
     assert "Resume processing completed" in cli_harness.console.text
+
+
+def test_resume_command_interactive_can_select_non_latest_session(cli_harness):
+    """Interactive resume should honor the user's chosen session, not always pick the latest."""
+
+    latest = build_state("migration_resume_latest")
+    latest.updated_at = 20.0
+    latest.add_item(
+        MigrationItem(
+            id="prompt_default_latest",
+            type="prompt",
+            name="team/latest",
+            source_id="team/latest",
+            status=MigrationStatus.PENDING,
+            metadata={"include_all_commits": False},
+        )
+    )
+    latest.updated_at = 20.0
+    older = build_state("migration_resume_older")
+    older.add_item(
+        MigrationItem(
+            id="prompt_default_older",
+            type="prompt",
+            name="team/older",
+            source_id="team/older",
+            status=MigrationStatus.PENDING,
+            metadata={"include_all_commits": True},
+        )
+    )
+    older.updated_at = 10.0
+    save_session(cli_harness.state_manager, latest)
+    save_session(cli_harness.state_manager, older)
+    cli_harness.console.inputs = ["2"]
+    cli_harness.controls.confirm_answers = [True]
+    cli_harness.migrators.prompt.migrate_prompt.return_value = "team/older"
+
+    result = cli_harness.invoke(["resume"])
+
+    assert result.exit_code == 0
+    orchestrator = cli_harness.orchestrator_factory.instances[0]
+    assert orchestrator.state.session_id == "migration_resume_older"
+    cli_harness.migrators.prompt.migrate_prompt.assert_called_once_with(
+        "team/older",
+        include_all_commits=True,
+    )
 
 
 def test_queues_command_non_interactive_exits_with_code_2_for_blocked_items(cli_harness):

--- a/tests/test_experiment_resume.py
+++ b/tests/test_experiment_resume.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
+from langsmith_migrator.core.api_client import EnhancedAPIClient
 from langsmith_migrator.core.migrators import ExperimentMigrator, FeedbackMigrator
 
 
@@ -42,3 +45,56 @@ def test_feedback_fingerprint_is_stable_for_equivalent_payloads(mock_api_client,
     )
 
     assert first == second
+
+
+def test_migrate_runs_streaming_drops_unmapped_reference_example_id(
+    sample_config,
+    migration_state,
+):
+    """Runs should still replay when their example link cannot be preserved."""
+
+    source = Mock(spec=EnhancedAPIClient)
+    source.base_url = "https://source.example/api/v1"
+    source.session = Mock()
+    source.session.headers = {}
+    source.post.return_value = {
+        "runs": [
+            {
+                "id": "run-1",
+                "name": "Example Run",
+                "run_type": "chain",
+                "session_id": "exp-src",
+                "reference_example_id": "example-src",
+            }
+        ],
+        "cursors": {"next": None},
+    }
+
+    captured_payloads: list[dict] = []
+    dest = Mock(spec=EnhancedAPIClient)
+    dest.base_url = "https://dest.example/api/v1"
+    dest.session = Mock()
+    dest.session.headers = {}
+
+    def _dest_post(endpoint: str, payload: dict):
+        if endpoint == "/runs/batch":
+            captured_payloads.append(payload)
+            return {}
+        raise AssertionError(f"Unexpected destination endpoint: {endpoint}")
+
+    dest.post.side_effect = _dest_post
+
+    migrator = ExperimentMigrator(source, dest, migration_state, sample_config)
+
+    total_runs, run_mapping, failed_runs = migrator.migrate_runs_streaming(
+        ["exp-src"],
+        {
+            "experiments": {"exp-src": "exp-dst"},
+            "examples": {},
+        },
+    )
+
+    assert total_runs == 1
+    assert failed_runs == 0
+    assert run_mapping["run-1"] == captured_payloads[0]["post"][0]["id"]
+    assert "reference_example_id" not in captured_payloads[0]["post"][0]

--- a/tests/test_users_csv_input.py
+++ b/tests/test_users_csv_input.py
@@ -9,7 +9,11 @@ from langsmith_migrator.cli.main import (
     _csv_rows_for_workspace,
     _csv_rows_to_org_members,
     _load_members_csv,
+    _resolve_csv_role_names,
 )
+
+
+# ── _load_members_csv ──
 
 
 def test_load_members_csv_requires_columns(tmp_path: Path):
@@ -20,20 +24,20 @@ def test_load_members_csv_requires_columns(tmp_path: Path):
         _load_members_csv(str(csv_path))
 
 
-def test_load_members_csv_rejects_empty_values(tmp_path: Path):
+def test_load_members_csv_rejects_empty_langsmith_role(tmp_path: Path):
     csv_path = tmp_path / "members.csv"
     csv_path.write_text(
-        "email,role_id,workspace_id\nalice@example.com,,ws-1\n",
+        "email,langsmith_role,workspace_id\nalice@example.com,,ws-1\n",
         encoding="utf-8",
     )
 
-    with pytest.raises(click.ClickException, match="empty role_id"):
+    with pytest.raises(click.ClickException, match="empty langsmith_role"):
         _load_members_csv(str(csv_path))
 
 
 def test_load_members_csv_rejects_empty_file(tmp_path: Path):
     csv_path = tmp_path / "members.csv"
-    csv_path.write_text("email,role_id,workspace_id\n", encoding="utf-8")
+    csv_path.write_text("email,langsmith_role,workspace_id\n", encoding="utf-8")
 
     with pytest.raises(click.ClickException, match="empty"):
         _load_members_csv(str(csv_path))
@@ -42,57 +46,243 @@ def test_load_members_csv_rejects_empty_file(tmp_path: Path):
 def test_load_members_csv_normalizes_email(tmp_path: Path):
     csv_path = tmp_path / "members.csv"
     csv_path.write_text(
-        "email,role_id,workspace_id\nAlice@Example.COM,role-1,ws-1\n",
+        "email,langsmith_role,workspace_id\nAlice@Example.COM,Workspace Admin,ws-1\n",
         encoding="utf-8",
     )
 
     rows = _load_members_csv(str(csv_path))
 
     assert rows == [
-        {"email": "alice@example.com", "role_id": "role-1", "workspace_id": "ws-1"}
+        {"email": "alice@example.com", "langsmith_role": "Workspace Admin", "workspace_id": "ws-1"}
     ]
 
 
 def test_load_members_csv_accepts_utf8_bom_header(tmp_path: Path):
     csv_path = tmp_path / "members.csv"
     csv_path.write_text(
-        "email,role_id,workspace_id\nalice@example.com,role-1,ws-1\n",
+        "email,langsmith_role,workspace_id\nalice@example.com,Organization Admin,\n",
         encoding="utf-8-sig",
     )
 
     rows = _load_members_csv(str(csv_path))
 
     assert rows == [
-        {"email": "alice@example.com", "role_id": "role-1", "workspace_id": "ws-1"}
+        {"email": "alice@example.com", "langsmith_role": "Organization Admin", "workspace_id": ""}
     ]
 
 
-def test_csv_rows_to_org_members_rejects_conflicting_roles():
+def test_load_members_csv_allows_empty_workspace_id(tmp_path: Path):
+    csv_path = tmp_path / "members.csv"
+    csv_path.write_text(
+        "email,langsmith_role,workspace_id,workspace_name\n"
+        "alice@example.com,Organization Admin,,\n",
+        encoding="utf-8",
+    )
+
+    rows = _load_members_csv(str(csv_path))
+
+    assert rows == [
+        {"email": "alice@example.com", "langsmith_role": "Organization Admin", "workspace_id": ""}
+    ]
+
+
+def test_load_members_csv_strips_whitespace(tmp_path: Path):
+    csv_path = tmp_path / "members.csv"
+    csv_path.write_text(
+        "email,langsmith_role,workspace_id\n"
+        "alice@example.com, Workspace Admin ,ws-1\n",
+        encoding="utf-8",
+    )
+
+    rows = _load_members_csv(str(csv_path))
+
+    assert rows[0]["langsmith_role"] == "Workspace Admin"
+
+
+# ── _resolve_csv_role_names ──
+
+
+SOURCE_ROLES = [
+    {"id": "src-admin", "name": "ORGANIZATION_ADMIN", "display_name": "Admin", "permissions": []},
+    {"id": "src-user", "name": "ORGANIZATION_USER", "display_name": "User", "permissions": []},
+    {"id": "src-ws-admin", "name": "WORKSPACE_ADMIN", "display_name": "Workspace Admin", "permissions": []},
+    {"id": "src-custom-1", "name": "CUSTOM", "display_name": "Data Scientist", "permissions": []},
+    {"id": "src-custom-2", "name": "CUSTOM", "display_name": "maintainer-dl-general", "permissions": []},
+]
+
+
+def test_resolve_csv_role_names_builtin_roles():
     rows = [
-        {"email": "alice@example.com", "role_id": "role-1", "workspace_id": "ws-1"},
-        {"email": "alice@example.com", "role_id": "role-2", "workspace_id": "ws-2"},
+        {"email": "a@example.com", "langsmith_role": "Organization Admin", "workspace_id": ""},
+        {"email": "b@example.com", "langsmith_role": "Workspace Admin", "workspace_id": "ws-1"},
     ]
 
-    with pytest.raises(click.ClickException, match="conflicting role_id"):
-        _csv_rows_to_org_members(rows)
+    resolved, org_user_id = _resolve_csv_role_names(rows, SOURCE_ROLES)
+
+    assert resolved[0]["role_id"] == "src-admin"
+    assert resolved[1]["role_id"] == "src-ws-admin"
+    assert org_user_id == "src-user"
 
 
-def test_csv_rows_to_org_members_dedupes_identical_rows():
+def test_resolve_csv_role_names_custom_roles():
     rows = [
-        {"email": "alice@example.com", "role_id": "role-1", "workspace_id": "ws-1"},
-        {"email": "alice@example.com", "role_id": "role-1", "workspace_id": "ws-2"},
+        {"email": "a@example.com", "langsmith_role": "Data Scientist", "workspace_id": "ws-1"},
     ]
 
-    members = _csv_rows_to_org_members(rows)
+    resolved, _ = _resolve_csv_role_names(rows, SOURCE_ROLES)
 
-    assert members == [
-        {
-            "id": "alice@example.com",
-            "email": "alice@example.com",
-            "role_id": "role-1",
-            "full_name": "",
-        }
+    assert resolved[0]["role_id"] == "src-custom-1"
+
+
+def test_resolve_csv_role_names_case_insensitive():
+    rows = [
+        {"email": "a@example.com", "langsmith_role": "organization admin", "workspace_id": ""},
+        {"email": "b@example.com", "langsmith_role": "ORGANIZATION_ADMIN", "workspace_id": ""},
+        {"email": "c@example.com", "langsmith_role": "data scientist", "workspace_id": "ws-1"},
     ]
+
+    resolved, _ = _resolve_csv_role_names(rows, SOURCE_ROLES)
+
+    assert resolved[0]["role_id"] == "src-admin"
+    assert resolved[1]["role_id"] == "src-admin"
+    assert resolved[2]["role_id"] == "src-custom-1"
+
+
+def test_resolve_csv_role_names_unknown_role_error():
+    rows = [
+        {"email": "a@example.com", "langsmith_role": "Nonexistent Role", "workspace_id": ""},
+    ]
+
+    with pytest.raises(click.ClickException, match="Could not resolve role name"):
+        _resolve_csv_role_names(rows, SOURCE_ROLES)
+
+
+def test_resolve_csv_role_names_builtin_alias_ignores_unrelated_collision():
+    rows = [
+        {"email": "a@example.com", "langsmith_role": "Organization Admin", "workspace_id": ""},
+    ]
+    source_roles = [
+        {"id": "src-custom-admin", "name": "CUSTOM", "display_name": "Admin", "permissions": []},
+        {"id": "src-admin", "name": "ORGANIZATION_ADMIN", "display_name": "Admin", "permissions": []},
+    ]
+
+    resolved, _ = _resolve_csv_role_names(rows, source_roles)
+
+    assert resolved[0]["role_id"] == "src-admin"
+
+
+def test_resolve_csv_role_names_builtin_alias_preferred_over_custom_collision():
+    rows = [
+        {"email": "a@example.com", "langsmith_role": "Organization Admin", "workspace_id": ""},
+    ]
+    source_roles = [
+        {"id": "src-custom-admin", "name": "CUSTOM", "display_name": "Organization Admin", "permissions": []},
+        {"id": "src-admin", "name": "ORGANIZATION_ADMIN", "display_name": "Admin", "permissions": []},
+    ]
+
+    resolved, _ = _resolve_csv_role_names(rows, source_roles)
+
+    assert resolved[0]["role_id"] == "src-admin"
+
+
+def test_resolve_csv_role_names_ambiguous_display_name_rejected_regardless_of_order():
+    rows = [
+        {"email": "a@example.com", "langsmith_role": "Admin", "workspace_id": ""},
+    ]
+    source_roles = [
+        {"id": "src-custom-admin", "name": "CUSTOM", "display_name": "Admin", "permissions": []},
+        {"id": "src-admin", "name": "ORGANIZATION_ADMIN", "display_name": "Admin", "permissions": []},
+    ]
+
+    with pytest.raises(click.ClickException, match="Ambiguous role name"):
+        _resolve_csv_role_names(rows, source_roles)
+
+
+def test_resolve_csv_role_names_builtin_identifier_preferred_over_custom_collision():
+    rows = [
+        {"email": "a@example.com", "langsmith_role": "ORGANIZATION_ADMIN", "workspace_id": ""},
+    ]
+    source_roles = [
+        {"id": "src-admin", "name": "ORGANIZATION_ADMIN", "display_name": "Admin", "permissions": []},
+        {"id": "src-custom-admin", "name": "CUSTOM", "display_name": "ORGANIZATION_ADMIN", "permissions": []},
+    ]
+
+    resolved, _ = _resolve_csv_role_names(rows, source_roles)
+
+    assert resolved[0]["role_id"] == "src-admin"
+
+
+def test_resolve_csv_role_names_whitespace_trimmed():
+    """The resolver strips whitespace from langsmith_role before lookup."""
+    rows = [
+        {"email": "a@example.com", "langsmith_role": " Organization Admin ", "workspace_id": ""},
+    ]
+
+    resolved, _ = _resolve_csv_role_names(rows, SOURCE_ROLES)
+    assert resolved[0]["role_id"] == "src-admin"
+
+
+def test_resolve_csv_role_names_returns_org_user_role_id():
+    rows = [
+        {"email": "a@example.com", "langsmith_role": "Workspace Admin", "workspace_id": "ws-1"},
+    ]
+
+    _, org_user_id = _resolve_csv_role_names(rows, SOURCE_ROLES)
+
+    assert org_user_id == "src-user"
+
+
+# ── _csv_rows_to_org_members ──
+
+
+def test_csv_rows_to_org_members_org_rows_used():
+    rows = [
+        {"email": "alice@example.com", "role_id": "role-admin", "workspace_id": ""},
+        {"email": "bob@example.com", "role_id": "role-ws-admin", "workspace_id": "ws-1"},
+    ]
+
+    members = _csv_rows_to_org_members(rows, default_org_role_id="role-user")
+
+    by_email = {m["email"]: m for m in members}
+    assert by_email["alice@example.com"]["role_id"] == "role-admin"
+    assert by_email["bob@example.com"]["role_id"] == "role-user"
+
+
+def test_csv_rows_to_org_members_workspace_only_gets_default():
+    rows = [
+        {"email": "alice@example.com", "role_id": "role-ws-admin", "workspace_id": "ws-1"},
+        {"email": "alice@example.com", "role_id": "role-ws-admin", "workspace_id": "ws-2"},
+    ]
+
+    members = _csv_rows_to_org_members(rows, default_org_role_id="role-user")
+
+    assert len(members) == 1
+    assert members[0]["role_id"] == "role-user"
+
+
+def test_csv_rows_to_org_members_conflicting_org_roles_rejected():
+    rows = [
+        {"email": "alice@example.com", "role_id": "role-admin", "workspace_id": ""},
+        {"email": "alice@example.com", "role_id": "role-user", "workspace_id": ""},
+    ]
+
+    with pytest.raises(click.ClickException, match="conflicting org-level roles"):
+        _csv_rows_to_org_members(rows, default_org_role_id="role-user")
+
+
+def test_csv_rows_to_org_members_dedupes_identical_org_rows():
+    rows = [
+        {"email": "alice@example.com", "role_id": "role-admin", "workspace_id": ""},
+        {"email": "alice@example.com", "role_id": "role-admin", "workspace_id": ""},
+    ]
+
+    members = _csv_rows_to_org_members(rows, default_org_role_id="role-user")
+
+    assert len(members) == 1
+    assert members[0]["role_id"] == "role-admin"
+
+
+# ── _csv_rows_for_workspace ──
 
 
 def test_csv_rows_for_workspace_dedupes_by_email():
@@ -122,3 +312,15 @@ def test_csv_rows_for_workspace_rejects_conflicting_roles():
 
     with pytest.raises(click.ClickException, match="conflicting role_id"):
         _csv_rows_for_workspace(rows, "ws-1")
+
+
+def test_csv_rows_for_workspace_ignores_org_rows():
+    rows = [
+        {"email": "alice@example.com", "role_id": "role-admin", "workspace_id": ""},
+        {"email": "alice@example.com", "role_id": "role-ws", "workspace_id": "ws-1"},
+    ]
+
+    selected = _csv_rows_for_workspace(rows, "ws-1")
+
+    assert len(selected) == 1
+    assert selected[0]["role_id"] == "role-ws"

--- a/tests/test_workspace_resolver.py
+++ b/tests/test_workspace_resolver.py
@@ -1,0 +1,153 @@
+"""Tests for workspace resolution safeguards."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from langsmith_migrator.cli.tui_workspace_mapper import WorkspaceProjectResult
+from langsmith_migrator.utils.migration_config import MigrationFileConfig
+from langsmith_migrator.utils import workspace_resolver
+
+
+class _FakeClient:
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url
+        self.session = SimpleNamespace(headers={})
+
+    def set_workspace(self, workspace_id: str | None) -> None:
+        if workspace_id is None:
+            self.session.headers.pop("X-Tenant-Id", None)
+        else:
+            self.session.headers["X-Tenant-Id"] = workspace_id
+
+
+class _FakeConsole:
+    def __init__(self) -> None:
+        self.buffer = ""
+
+    def print(self, *args, end: str = "\n", **kwargs) -> None:  # noqa: ANN001
+        del kwargs
+        self.buffer += "".join(str(arg) for arg in args) + end
+
+    @property
+    def text(self) -> str:
+        return self.buffer
+
+
+def test_resolve_workspace_context_reuses_valid_saved_mapping_non_interactive(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source_client = _FakeClient("https://source.example/api/v1")
+    dest_client = _FakeClient("https://dest.example/api/v1")
+    console = _FakeConsole()
+
+    source_workspaces = [
+        {"id": "src-1", "display_name": "Source One"},
+        {"id": "src-2", "display_name": "Source Two"},
+    ]
+    dest_workspaces = [{"id": "dst-1", "display_name": "Dest One"}]
+    monkeypatch.setattr(
+        workspace_resolver,
+        "list_workspaces",
+        lambda client: source_workspaces if client is source_client else dest_workspaces,
+    )
+
+    saved_config = MigrationFileConfig(
+        workspace_mapping={"src-1": "dst-1"},
+        workspace_mapping_source_url="https://source.example/api/v1",
+        workspace_mapping_destination_url="https://dest.example/api/v1",
+    )
+
+    result = workspace_resolver.resolve_workspace_context(
+        source_client,
+        dest_client,
+        console,
+        saved_config=saved_config,
+        non_interactive=True,
+    )
+
+    assert result is not None
+    assert result.workspace_mapping == {"src-1": "dst-1"}
+
+
+def test_resolve_workspace_context_ignores_stale_saved_mapping_before_launching_tui(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source_client = _FakeClient("https://source.example/api/v1")
+    dest_client = _FakeClient("https://dest.example/api/v1")
+    console = _FakeConsole()
+
+    source_workspaces = [
+        {"id": "src-1", "display_name": "Source One"},
+        {"id": "src-2", "display_name": "Source Two"},
+    ]
+    dest_workspaces = [
+        {"id": "dst-1", "display_name": "Dest One"},
+        {"id": "dst-2", "display_name": "Dest Two"},
+    ]
+    monkeypatch.setattr(
+        workspace_resolver,
+        "list_workspaces",
+        lambda client: source_workspaces if client is source_client else dest_workspaces,
+    )
+
+    saved_config = MigrationFileConfig(
+        workspace_mapping={"src-1": "dst-1"},
+        workspace_mapping_source_url="https://other-source.example/api/v1",
+        workspace_mapping_destination_url="https://other-dest.example/api/v1",
+    )
+
+    tui_result = WorkspaceProjectResult(
+        workspace_mapping={"src-2": "dst-2"},
+        project_mappings={},
+        workspaces_to_create=[],
+    )
+    build_tui = Mock(return_value=tui_result)
+    monkeypatch.setattr(workspace_resolver, "build_workspace_mapping_tui", build_tui)
+    monkeypatch.setattr(workspace_resolver, "save_config", lambda config: Path("/tmp/config.json"))
+
+    result = workspace_resolver.resolve_workspace_context(
+        source_client,
+        dest_client,
+        console,
+        saved_config=saved_config,
+        non_interactive=False,
+    )
+
+    assert result == tui_result
+    assert build_tui.call_args.kwargs["existing_mapping"] is None
+    assert "Saved workspace mapping does not match the current instances" in console.text
+
+
+def test_resolve_workspace_context_raises_in_non_interactive_mode_without_valid_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    source_client = _FakeClient("https://source.example/api/v1")
+    dest_client = _FakeClient("https://dest.example/api/v1")
+    console = _FakeConsole()
+
+    source_workspaces = [
+        {"id": "src-1", "display_name": "Source One"},
+        {"id": "src-2", "display_name": "Source Two"},
+    ]
+    dest_workspaces = [{"id": "dst-1", "display_name": "Dest One"}]
+    monkeypatch.setattr(
+        workspace_resolver,
+        "list_workspaces",
+        lambda client: source_workspaces if client is source_client else dest_workspaces,
+    )
+
+    with pytest.raises(workspace_resolver.WorkspaceResolutionError):
+        workspace_resolver.resolve_workspace_context(
+            source_client,
+            dest_client,
+            console,
+            saved_config=None,
+            non_interactive=True,
+        )
+
+    assert "Workspace mapping is required in non-interactive mode" in console.text

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.57"
+version = "0.0.60"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- update the users CSV flow, docs, and examples around `langsmith_role` input and workspace/org member handling
- harden workspace resolution so headless multi-workspace runs fail safely and saved mappings are validated before reuse
- restore explicit resume session selection and drop invalid `reference_example_id` links during run replay
- add regression coverage for workspace resolution, resume selection, and run replay behavior

## Testing
- uv run pytest -q