### PR TITLE
Prepare v0.0.61 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.61] - 2026-04-09
+
+### Added
+- **Single-instance CSV sync mode**: `users --single-instance` / `--instance` now supports applying CSV-driven access changes directly to one LangSmith target, with workspace-ID validation and an explicit preflight summary.
+- **Authoritative CSV reconciliation**: `users --csv-source-of-truth` / `--sync` can now remove org users, pending invites, and workspace memberships that are missing from the CSV during single-instance runs.
+
+### Fixed
+- **Selective custom-role syncing**: custom roles are now created only when they are selected directly or required by the chosen org or workspace members, avoiding unnecessary destination role creation during user migration.
+- **Workspace identity refresh**: workspace member sync now refreshes destination org identities through a shared cache helper before applying workspace memberships.
+- **Release install snippets**: README install commands now point at the current release wheel filename.
+
+### Changed
+- **Dependencies**: refreshed the pinned Python dependency set and bumped `langchain-core` to `1.2.28`.
+- **CI**: bumped `codecov/codecov-action` to `v6`.
+
 ## [0.0.60] - 2026-04-08
 
 ### Added
@@ -234,7 +249,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration documentation
 - API reference for core classes
 
-[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.51...HEAD
+[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.61...HEAD
+[0.0.61]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.60...v0.0.61
+[0.0.60]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.59...v0.0.60
+[0.0.59]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.58...v0.0.59
+[0.0.58]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.57...v0.0.58
+[0.0.57]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.56...v0.0.57
+[0.0.56]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.55...v0.0.56
+[0.0.55]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.54...v0.0.55
+[0.0.54]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.53...v0.0.54
+[0.0.53]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.52...v0.0.53
+[0.0.52]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.51...v0.0.52
 [0.0.51]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.50...v0.0.51
 [0.0.41]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.4...v0.0.41
 [0.0.4]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.3...v0.0.4

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python CLI for migrating datasets, experiments, annotation queues, project rul
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.51-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.61-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -50,20 +50,20 @@ For trace data, use LangSmith's **Bulk Export** functionality: [LangSmith Bulk E
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.51-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.61-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.51-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.61-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.51-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.61-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.51-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.61-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.60"
+version = "0.0.61"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.60"
+version = "0.0.61"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump version metadata and lockfile to 0.0.61
- add a 0.0.61 changelog section for changes merged since v0.0.60
- update README install snippets to the 0.0.61 wheel filename

## Testing
- uv run --extra test pytest -q
- uv build