### PR TITLE
Add more user sync integration coverage

### DIFF
--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -587,6 +587,28 @@ def test_users_command_single_instance_rejects_workspace_flags(cli_harness, tmp_
     assert "cannot be combined with workspace mapping flags" in result.output
 
 
+def test_users_command_single_instance_rejects_roles_only(cli_harness):
+    """Single-instance mode should fail before pretending roles-only is supported."""
+    result = cli_harness.invoke(["users", "--single-instance", "--roles-only"])
+
+    assert result.exit_code != 0
+    assert "--roles-only cannot be combined with --single-instance" in result.output
+
+
+def test_users_command_rejects_roles_only_with_members_csv(cli_harness, tmp_path):
+    """CSV input is member-only and should not be accepted with --roles-only."""
+    csv_path = tmp_path / "members.csv"
+    csv_path.write_text(
+        "email,langsmith_role,workspace_id\nalice@example.com,Organization Admin,\n",
+        encoding="utf-8",
+    )
+
+    result = cli_harness.invoke(["users", "--roles-only", "--members-csv", str(csv_path)])
+
+    assert result.exit_code != 0
+    assert "--roles-only cannot be combined with --members-csv" in result.output
+
+
 def test_users_command_single_instance_rejects_ambiguous_configured_targets(cli_harness, tmp_path):
     """Single-instance sync should fail instead of guessing between configured source/dest targets."""
     csv_path = tmp_path / "members.csv"
@@ -616,6 +638,40 @@ def test_users_command_single_instance_requires_api_key_and_url_together(cli_har
         result = cli_harness.invoke(args, add_base_args=False)
         assert result.exit_code != 0
         assert "--api-key and --url must be provided together" in result.output
+
+
+def test_users_command_rejects_sync_without_members_csv(cli_harness):
+    """Authoritative single-instance sync must always be driven by a CSV."""
+    result = cli_harness.invoke(["users", "--sync"])
+
+    assert result.exit_code != 0
+    assert "--csv-source-of-truth requires --members-csv" in result.output
+
+
+def test_users_command_rejects_sync_with_skip_existing(cli_harness, tmp_path):
+    """Authoritative CSV sync should not combine with global skip-existing mode."""
+    csv_path = tmp_path / "members.csv"
+    csv_path.write_text(
+        "email,langsmith_role,workspace_id\nalice@example.com,Organization Admin,\n",
+        encoding="utf-8",
+    )
+
+    result = cli_harness.invoke(
+        [
+            "--skip-existing",
+            "users",
+            "--api-key",
+            "sync-key",
+            "--url",
+            "https://sync.example",
+            "--csv",
+            str(csv_path),
+            "--sync",
+        ]
+    )
+
+    assert result.exit_code != 0
+    assert "--csv-source-of-truth cannot be combined with --skip-existing" in result.output
 
 
 def test_users_command_single_instance_csv_apply_auto_applies_all_rows(
@@ -697,6 +753,87 @@ def test_users_command_single_instance_csv_apply_auto_applies_all_rows(
                 "id": "ws-1:bob@example.com",
                 "email": "bob@example.com",
                 "role_id": "src-ws-admin",
+                "full_name": "",
+            }
+        ],
+        remove_missing=False,
+    )
+
+
+def test_users_command_single_instance_syncs_custom_roles_only_when_csv_rows_need_them(
+    cli_harness, monkeypatch, tmp_path
+):
+    """Single-instance CSV mode should defer custom-role syncing until org/workspace rows require it."""
+    cli_harness.orchestrator_factory.dest_client.get_responses["/api/v1/workspaces"] = [
+        {"id": "ws-1", "display_name": "Workspace 1"},
+    ]
+    csv_path = tmp_path / "members.csv"
+    csv_path.write_text(
+        "email,langsmith_role,workspace_id\n"
+        "alice@example.com,Data Scientist,\n"
+        "alice@example.com,Workspace Steward,ws-1\n",
+        encoding="utf-8",
+    )
+
+    user_role_migrator = Mock()
+    user_role_migrator.build_role_mapping.side_effect = [
+        {
+            "src-admin": "dst-admin",
+            "src-user": "dst-user",
+            "src-ws-admin": "dst-ws-admin",
+        },
+        {"src-org-custom": "dst-org-custom"},
+        {"src-ws-custom": "dst-ws-custom"},
+    ]
+    user_role_migrator.list_source_roles.return_value = [
+        {"id": "src-admin", "name": "ORGANIZATION_ADMIN", "display_name": "Admin"},
+        {"id": "src-user", "name": "ORGANIZATION_USER", "display_name": "User"},
+        {"id": "src-ws-admin", "name": "WORKSPACE_ADMIN", "display_name": "Workspace Admin"},
+        {"id": "src-org-custom", "name": "CUSTOM", "display_name": "Data Scientist"},
+        {"id": "src-ws-custom", "name": "CUSTOM", "display_name": "Workspace Steward"},
+    ]
+    user_role_migrator.list_dest_org_members.return_value = []
+    user_role_migrator.migrate_org_members.return_value = (1, 0, 0)
+    user_role_migrator.migrate_workspace_members.return_value = (1, 0, 0)
+    monkeypatch.setattr(cli_main, "UserRoleMigrator", lambda *args, **kwargs: user_role_migrator)
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(
+        [
+            "users",
+            "--api-key",
+            "sync-key",
+            "--url",
+            "https://sync.example",
+            "--csv",
+            str(csv_path),
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert user_role_migrator.build_role_mapping.call_args_list == [
+        call(custom_role_ids=set()),
+        call(custom_role_ids={"src-org-custom"}),
+        call(custom_role_ids={"src-ws-custom"}),
+    ]
+    user_role_migrator.migrate_org_members.assert_called_once_with(
+        [
+            {
+                "id": "alice@example.com",
+                "email": "alice@example.com",
+                "role_id": "src-org-custom",
+                "full_name": "",
+            }
+        ],
+        remove_missing=False,
+        remove_pending=False,
+    )
+    user_role_migrator.migrate_workspace_members.assert_called_once_with(
+        selected_members=[
+            {
+                "id": "ws-1:alice@example.com",
+                "email": "alice@example.com",
+                "role_id": "src-ws-custom",
                 "full_name": "",
             }
         ],

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -13,6 +13,7 @@ from langsmith_migrator.core.api_client import (
     EnhancedAPIClient,
     NotFoundError,
 )
+from langsmith_migrator.utils.retry import APIError, AuthenticationError, RateLimitError
 
 
 def _response(
@@ -66,6 +67,34 @@ def test_post_uses_prepared_url_payload_and_timeout(monkeypatch):
     )
 
 
+def test_get_uses_prepared_url_query_params_and_timeout(monkeypatch):
+    client = _client()
+    url = "https://langsmith.example.com/api/v1/workspaces"
+    get_mock = Mock(
+        return_value=_response("GET", url, 200, json_body=[{"id": "ws-1"}])
+    )
+    monkeypatch.setattr(client.session, "get", get_mock)
+
+    result = client.get("/workspaces", params={"limit": 10})
+
+    assert result == [{"id": "ws-1"}]
+    get_mock.assert_called_once_with(
+        url,
+        params={"limit": 10},
+        timeout=12,
+    )
+
+
+def test_set_workspace_updates_scoping_header():
+    client = _client()
+
+    client.set_workspace("ws-1")
+    assert client.session.headers["X-Tenant-Id"] == "ws-1"
+
+    client.set_workspace(None)
+    assert "X-Tenant-Id" not in client.session.headers
+
+
 def test_post_translates_conflict_to_conflict_error(monkeypatch):
     client = _client()
     url = "https://langsmith.example.com/api/v1/orgs/current/members"
@@ -76,6 +105,20 @@ def test_post_translates_conflict_to_conflict_error(monkeypatch):
 
     with pytest.raises(ConflictError, match="Resource conflict"):
         client.post("/orgs/current/members", {"email": "alice@example.com"})
+
+
+def test_get_translates_authentication_error_without_retry(monkeypatch):
+    client = _client()
+    url = "https://langsmith.example.com/api/v1/orgs/current/members"
+    get_mock = Mock(
+        return_value=_response("GET", url, 401, json_body={"detail": "invalid API key"})
+    )
+    monkeypatch.setattr(client.session, "get", get_mock)
+
+    with pytest.raises(AuthenticationError, match="Authentication failed"):
+        client.get("/orgs/current/members")
+
+    assert get_mock.call_count == 1
 
 
 def test_patch_uses_fixed_timeout_and_handles_no_content(monkeypatch):
@@ -116,3 +159,32 @@ def test_delete_translates_not_found_to_not_found_error(monkeypatch):
 
     with pytest.raises(NotFoundError, match="Resource not found"):
         client.delete("/orgs/current/members/member-1")
+
+
+def test_handle_response_surfaces_retry_after_on_rate_limit():
+    client = _client()
+    url = "https://langsmith.example.com/api/v1/orgs/current/members"
+    response = _response(
+        "GET",
+        url,
+        429,
+        json_body={"detail": "too many requests"},
+        headers={"Retry-After": "7"},
+    )
+
+    with pytest.raises(RateLimitError, match="Rate limit exceeded") as exc_info:
+        client._handle_response(response, "/orgs/current/members")
+
+    assert exc_info.value.retry_after == 7.0
+
+
+def test_get_raises_api_error_on_invalid_json_success_response(monkeypatch):
+    client = _client()
+    url = "https://langsmith.example.com/api/v1/workspaces"
+    get_mock = Mock(return_value=_response("GET", url, 200, text_body="not-json"))
+    monkeypatch.setattr(client.session, "get", get_mock)
+
+    with pytest.raises(APIError, match="Invalid JSON response"):
+        client.get("/workspaces")
+
+    assert get_mock.call_count == 1

--- a/tests/test_users_csv_input.py
+++ b/tests/test_users_csv_input.py
@@ -10,6 +10,7 @@ from langsmith_migrator.cli.main import (
     _csv_rows_for_workspace,
     _csv_rows_to_org_members,
     _load_members_csv,
+    _normalize_single_instance_url,
     _normalize_csv_role_scopes,
     _resolve_single_instance_workspace_ids,
     _resolve_csv_role_names,
@@ -386,6 +387,21 @@ def test_csv_rows_for_workspace_ignores_org_rows():
 
     assert len(selected) == 1
     assert selected[0]["role_id"] == "role-ws"
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://same.example/api/v1", "https://same.example"),
+        ("https://same.example/api/v2/", "https://same.example"),
+        ("HTTPS://Same.Example/API/V2///", "https://same.example"),
+        ("https://same.example/custom/path/", "https://same.example/custom/path"),
+    ],
+)
+def test_normalize_single_instance_url_strips_api_suffixes_and_normalizes_case(
+    url: str, expected: str
+):
+    assert _normalize_single_instance_url(url) == expected
 
 
 def test_configure_single_instance_uses_destination_when_available():


### PR DESCRIPTION
## Summary
- add missing single-instance users CLI guardrail coverage
- cover selective custom-role syncing for CSV-driven single-instance user sync
- expand API client boundary tests for auth, rate limits, workspace scoping, and invalid JSON

## Testing
- uv run pytest tests/test_users_csv_input.py tests/test_api_client.py tests/functional/test_cli_functional.py -q
- uv run pytest -q
- uv run --extra test ruff check tests/functional/test_cli_functional.py tests/test_users_csv_input.py tests/test_api_client.py