### PR TITLE
Prepare v0.0.63 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.63] - 2026-04-10
+
+### Added
+- **Expanded CSV role-name support**: `users --members-csv` now recognizes `Organization Operator`, `Organization Viewer`, `Workspace User`, and `Workspace Viewer`, and ambiguous case-insensitive matches now call out the exact candidate roles.
+- **Grouped remediation guidance**: Resolution summaries, `resume`, and remediation bundles now collapse repeated blockers into grouped actionable next steps.
+
+### Fixed
+- **Single-instance workspace invites**: Workspace-only CSV rows now sync required custom workspace roles before org invites and attach initial workspace access directly to the org invite when the target instance supports it.
+- **Pending invite reconciliation**: Existing pending org invites are now reused only when they already include the requested workspace access, and otherwise are refreshed so phase 3 does not fail on missing workspace state.
+- **Workspace membership endpoint compatibility**: Workspace membership create, update, and delete operations now prefer workspace-scoped endpoints and fall back to legacy tenant endpoints when needed.
+- **CSV validation guidance**: Empty `langsmith_role` errors now explain whether the row expects an org-scoped or workspace-scoped role.
+
+### Changed
+- **README parity**: Updated release snippets, command coverage, users sync docs, workspace scoping, and remediation/resume documentation to match the current CLI surface.
+
 ## [0.0.62] - 2026-04-09
 
 ### Changed
@@ -255,7 +270,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration documentation
 - API reference for core classes
 
-[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.62...HEAD
+[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.63...HEAD
+[0.0.63]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.62...v0.0.63
 [0.0.62]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.61...v0.0.62
 [0.0.61]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.60...v0.0.61
 [0.0.60]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.59...v0.0.60

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # LangSmith Data Migration Tool
 
-A Python CLI for migrating datasets, experiments, annotation queues, project rules, prompts, and charts between LangSmith instances.
+A Python CLI for migrating users and roles, datasets, experiments, annotation queues, project rules, prompts, and charts between LangSmith instances, plus CSV-driven access sync for a single LangSmith deployment.
 
 ## Quick Start
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.62-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.63-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -22,13 +22,17 @@ langsmith-migrator datasets
 ## Features
 
 - **All-in-One Wizard**: Interactive migration of all resources (`migrate-all`)
+- **Users & Roles**: Migrate custom roles, org members, and workspace memberships between instances
+- **Single-Instance Access Sync**: Apply CSV-driven add/update or authoritative access sync to one LangSmith instance (`users --csv ... [--sync]`)
 - **Datasets**: Migrate datasets with examples and file attachments
-- **Experiments**: Migrate experiments with runs and feedback (`--include-experiments`)
+- **Experiments**: Include experiments, runs, and feedback during dataset migration (`datasets --include-experiments`) or through `migrate-all`
 - **Annotation Queues**: Transfer queue configurations
 - **Project Rules**: Copy automation rules with project mapping and optional project creation in interactive flows
 - **Prompts**: Migrate prompts (latest by default, full history with `--include-all-commits`)
 - **Charts**: Migrate monitoring charts with filter preservation
-- **Interactive CLI**: TUI-based selection with search/filter
+- **Workspace Scoping**: Run resource migrations per workspace pair with explicit IDs or interactive workspace mapping
+- **Remediation & Resume**: Persist migration state, write remediation bundles, print grouped actionable next steps, and retry pending/failed work with `resume`
+- **Interactive CLI**: TUI-based selection with search/filter, plus `--non-interactive` mode for automation
 
 ## Limitations
 
@@ -50,20 +54,20 @@ For trace data, use LangSmith's **Bulk Export** functionality: [LangSmith Bulk E
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.62-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.63-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.62-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.63-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.62-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.63-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.62-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.63-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)
@@ -138,9 +142,23 @@ langsmith-migrator charts --same-instance       # Reuse source project/session I
 # Utilities
 langsmith-migrator list-projects --source
 langsmith-migrator list_workspaces --source --dest
-langsmith-migrator resume  # Resume interrupted dataset migration
+langsmith-migrator resume  # Resume pending/failed items from a prior migration session
 langsmith-migrator clean
 ```
+
+### Command Overview
+
+- `test`: verify source and destination connectivity before running a migration
+- `migrate-all`: guided end-to-end wizard for users, datasets, prompts, queues, rules, and charts
+- `datasets`: migrate datasets; optionally include experiments, runs, and feedback
+- `queues`: migrate annotation queues
+- `prompts`: migrate prompts, optionally with full commit history
+- `rules`: migrate automation rules with project mapping controls
+- `charts`: migrate monitoring charts, either all sessions or one named session/project
+- `users`: migrate users/roles between instances, or run single-instance CSV access sync
+- `resume`: retry resumable items from a prior session and show grouped manual blockers
+- `list-projects` / `list_workspaces`: inspect project and workspace IDs for mapping
+- `clean`: remove saved migration sessions
 
 ### Users migration with CSV member input
 
@@ -208,7 +226,7 @@ Notes:
 - `email` and `langsmith_role` are required.
 - `workspace_id` is optional. Leave it empty for org-level role assignments.
 - `workspace_name` is optional and informational only.
-- `langsmith_role` should be a built-in LangSmith role name (for example `Organization Admin`, `Organization User`, `Workspace Admin`) or a custom role `display_name`.
+- `langsmith_role` should be a built-in LangSmith role name (for example `Organization Admin`, `Organization Operator`, `Organization User`, `Organization Viewer`, `Workspace Admin`, `Workspace User`, or `Workspace Viewer`) or a custom role `display_name`.
 - Users who only appear in workspace rows are invited to the org with the source `ORGANIZATION_USER` role before workspace membership is applied.
 - `Organization Admin` on a workspace row is treated as org-level admin access only. No explicit workspace membership is created because org admins already have workspace access.
 - Other org-scoped roles cannot be used on workspace rows. If you want org-level access, leave `workspace_id` empty.
@@ -238,25 +256,33 @@ Guardrails:
 --source-url TEXT       Source base URL
 --dest-url TEXT         Destination base URL
 --no-ssl                Disable SSL verification
---batch-size INTEGER    Batch size (default: 100)
---workers INTEGER       Concurrent workers (default: 4)
+--batch-size INTEGER    Batch size for operations (1-1000, default: 100)
+--workers INTEGER       Number of concurrent workers (1-10, default: 4)
 --dry-run               Run without making changes
 --skip-existing         Skip existing resources instead of updating them
+--non-interactive       Disable prompts and exit with code 2 when remediation is required
 --verbose, -v           Verbose output
 ```
 
 ### Dataset Options
 
 ```bash
---include-experiments   Include experiments, runs, and feedback (prompts if not specified)
---all                   Migrate all datasets without interactive selection
+--include-experiments   Include experiments with datasets
+--all                   Migrate all datasets
+```
+
+### Prompt Options
+
+```bash
+--all                   Migrate all prompts
+--include-all-commits   Include all commit history
 ```
 
 ### Rules Options
 
 ```bash
 --strip-projects        Strip project associations and create as global rules
---project-mapping TEXT  JSON string or file path mapping source project IDs to destination
+--project-mapping TEXT  JSON string or file path with project ID mapping (e.g., '{"old-id": "new-id"}')
 --map-projects          Launch interactive TUI to map source projects to destination projects
 --create-enabled        Create rules as enabled (default: disabled to bypass secrets validation)
 --all                   Migrate all rules without interactive selection
@@ -271,31 +297,60 @@ Guardrails:
 If `--rules-create-enabled` is omitted, `migrate-all` asks interactively whether to create rules enabled.
 The prompt default is `No` (rules are created disabled).
 
+### Migrate-All Options
+
+```bash
+--skip-users            Skip user and role migration
+--skip-datasets         Skip dataset migration
+--skip-experiments      Skip experiment migration
+--skip-prompts          Skip prompt migration
+--skip-queues           Skip annotation queue migration
+--skip-rules            Skip rules migration
+--skip-charts           Skip chart migration
+--include-all-commits   Include all prompt commit history
+--strip-projects        Strip project associations from rules
+--map-projects          Launch interactive TUI to map source projects to destination projects
+--rules-create-enabled  Create migrated rules as enabled instead of asking interactively
+```
+
 ### Chart Options
 
 ```bash
 --session TEXT          Migrate charts for a specific session/project (by name or ID)
 --map-projects          Launch interactive TUI to map source projects to destination projects
---same-instance         Reuse source project/session IDs on destination
+--same-instance         Source and destination are the same instance (use same session IDs)
 ```
 
 ### Users Options
 
 ```bash
 --dry-run                  Preview this users sync without making POST/PATCH/DELETE changes
---roles-only               Only sync custom roles (skip member migration)
---skip-workspace-members   Skip workspace member migration (phases 1-2 only)
+--roles-only               Only migrate custom roles (skip member migration)
+--skip-workspace-members   Skip workspace member migration
 --single-instance, --instance
                            Use one target LangSmith instance for CSV-driven access sync instead of source→destination migration
 --csv-source-of-truth, --sync
-                           Make the CSV authoritative for single-instance sync: remove org users, pending invites, and
-                           workspace memberships not present in the CSV. Without this flag, CSV mode only adds or updates
-                           access.
+                           Make the CSV authoritative for single-instance sync: any active org user or pending invite not
+                           present in the CSV will be removed, and workspace memberships not present in the CSV will also
+                           be removed. Without this flag, CSV mode only adds or updates access.
 --members-csv, --csv PATH  CSV file with member details (email, langsmith_role, workspace_id, workspace_name)
                            Replaces source member API lookups. In --single-instance mode, all CSV rows are applied
                            automatically.
 --api-key TEXT             API key for the single-instance CSV sync target. Must be provided together with --url.
 --url TEXT                 Base URL for the single-instance CSV sync target. Must be provided together with --api-key.
+--source-workspace TEXT    Source workspace ID (skip auto-detection)
+--dest-workspace TEXT      Destination workspace ID (skip auto-detection)
+--map-workspaces           Force workspace mapping TUI even for single-workspace instances
+```
+
+### Common Workspace Options
+
+These flags are available on `datasets`, `queues`, `prompts`, `rules`, `charts`, `migrate-all`, and `users`:
+
+```bash
+--source-workspace TEXT    Source workspace ID (skip auto-detection)
+--dest-workspace TEXT      Destination workspace ID (skip auto-detection)
+--map-workspaces           Force workspace mapping TUI even for single-workspace instances
 ```
 
 Migration proceeds in three phases:
@@ -355,9 +410,27 @@ langsmith-migrator datasets --source-workspace WS_ID --dest-workspace WS_ID
 
 When using `--map-workspaces`, each command iterates all mapped workspace pairs, running the full fetch/select/migrate flow per pair. For `rules` and `charts` with `--map-projects`, the project mapping TUI is shown per workspace pair so projects are correctly scoped.
 
-### Resume Scope
+### Resume and Remediation
 
-`resume` currently resumes interrupted dataset migration flows. Experiment-only resume is not yet supported.
+Every migration session persists state and writes a remediation bundle when there are blocked or manual-follow-up items.
+
+- Session state is stored under `~/.langsmith-migrator/state`.
+- Remediation bundles are written under `./.langsmith-migrator/remediation/<session_id>` by default.
+- The CLI prints a **Resolution Summary** with grouped **Actionable Next Steps** instead of one repeated line per failed item.
+- `--non-interactive` disables prompts and exits with status code `2` if manual remediation is still required.
+
+`langsmith-migrator resume` retries pending or failed items from a previous session. Today that includes:
+
+- datasets
+- experiments
+- prompts
+- annotation queues
+- rules
+- charts
+- org members
+- workspace members
+
+Use `langsmith-migrator clean` to remove saved sessions once you no longer need their state or remediation bundles.
 
 ## SSL Certificate Issues
 

--- a/examples/users_members_example.csv
+++ b/examples/users_members_example.csv
@@ -1,6 +1,6 @@
 email,langsmith_role,workspace_id,workspace_name
 amelia.nguyen@example.com,Organization Admin,,
 jordan.lee@example.com,Workspace Admin,ws_src_prod_us,Production US
-priya.patel@example.com,Data Scientist,ws_src_ml_platform,ML Platform
-mateo.garcia@example.com,Organization User,,
-sana.khan@example.com,Workspace Admin,ws_src_analytics,Analytics
+priya.patel@example.com,write-no-read,ws_src_ml_platform,ML Platform
+mateo.garcia@example.com,Workspace User,ws_src_analytics,Analytics
+sana.khan@example.com,Organization Viewer,,

--- a/langsmith_migrator/__init__.py
+++ b/langsmith_migrator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("langsmith-data-migration-tool")
 except PackageNotFoundError:
-    __version__ = "0.0.51"
+    __version__ = "0.0.63"

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -356,8 +356,22 @@ def _load_members_csv(path: str) -> list[dict]:
                         f"Members CSV row {index} has an empty email value"
                     )
                 if not langsmith_role:
+                    if workspace_id:
+                        raise click.ClickException(
+                            "Members CSV row "
+                            f"{index} for {email} in workspace {workspace_id} "
+                            "has an empty langsmith_role value. Set a "
+                            "workspace-scoped role such as 'Workspace Admin' "
+                            "or a custom workspace role. If this row is only "
+                            "meant to grant org access, leave workspace_id "
+                            "empty and use an org-scoped role such as "
+                            "'Organization User'."
+                        )
                     raise click.ClickException(
-                        f"Members CSV row {index} has an empty langsmith_role value"
+                        "Members CSV row "
+                        f"{index} for {email} has an empty langsmith_role "
+                        "value. Set a valid org-level LangSmith role, for "
+                        "example 'Organization User' or 'Organization Admin'."
                     )
 
                 rows.append(
@@ -381,11 +395,24 @@ def _load_members_csv(path: str) -> list[dict]:
 
 _BUILTIN_ROLE_ALIASES: dict[str, str] = {
     "organization admin": "ORGANIZATION_ADMIN",
+    "organization operator": "ORGANIZATION_OPERATOR",
     "organization user": "ORGANIZATION_USER",
+    "organization viewer": "ORGANIZATION_VIEWER",
     "workspace admin": "WORKSPACE_ADMIN",
+    "workspace user": "WORKSPACE_USER",
+    "workspace viewer": "WORKSPACE_VIEWER",
 }
-_ORG_SCOPED_BUILTIN_ROLE_NAMES = {"ORGANIZATION_ADMIN", "ORGANIZATION_USER"}
-_WORKSPACE_SCOPED_BUILTIN_ROLE_NAMES = {"WORKSPACE_ADMIN"}
+_ORG_SCOPED_BUILTIN_ROLE_NAMES = {
+    "ORGANIZATION_ADMIN",
+    "ORGANIZATION_OPERATOR",
+    "ORGANIZATION_USER",
+    "ORGANIZATION_VIEWER",
+}
+_WORKSPACE_SCOPED_BUILTIN_ROLE_NAMES = {
+    "WORKSPACE_ADMIN",
+    "WORKSPACE_USER",
+    "WORKSPACE_VIEWER",
+}
 
 
 def _resolve_csv_role_names(
@@ -401,39 +428,74 @@ def _resolve_csv_role_names(
     custom role display names.
     """
     role_lookup: dict[str, list[tuple[str, str]]] = {}
+    role_descriptions_by_label: dict[str, dict[str, str]] = {}
     builtin_by_name: dict[str, str] = {}
     preferred_builtin_by_label: dict[str, str] = {}
     org_user_role_id: str | None = None
+    available_role_labels: set[str] = set()
 
-    def register_role_label(label: str, role_id: str, role_name: str) -> None:
-        candidates = role_lookup.setdefault(label, [])
+    def register_role_label(
+        label: str, role_id: str, role_name: str, *, display_label: str = ""
+    ) -> None:
+        normalized_label = label.strip().lower()
+        candidates = role_lookup.setdefault(normalized_label, [])
         if not any(existing_role_id == role_id for existing_role_id, _ in candidates):
             candidates.append((role_id, role_name))
+        descriptions = role_descriptions_by_label.setdefault(normalized_label, {})
+        preferred_label = (display_label or label or role_name).strip()
+        if role_name != "CUSTOM" and preferred_label.lower() != role_name.lower():
+            descriptions[role_id] = f"{preferred_label} [{role_name}] ({role_id})"
+        else:
+            descriptions[role_id] = f"{preferred_label} ({role_id})"
 
     for role in source_roles:
         role_name = role.get("name", "")
         role_id = role["id"]
-        dn = (role.get("display_name") or "").strip().lower()
+        display_name = (role.get("display_name") or "").strip()
+        dn = display_name.lower()
 
         if role_name != "CUSTOM":
             builtin_by_name[role_name] = role_id
+            available_role_labels.add(role_name)
             if dn:
-                register_role_label(dn, role_id, role_name)
+                available_role_labels.add(display_name)
+                register_role_label(
+                    dn,
+                    role_id,
+                    role_name,
+                    display_label=display_name,
+                )
             builtin_label = role_name.lower()
-            register_role_label(builtin_label, role_id, role_name)
+            register_role_label(
+                builtin_label,
+                role_id,
+                role_name,
+                display_label=role_name,
+            )
             preferred_builtin_by_label[builtin_label] = role_id
             if role_name == "ORGANIZATION_USER":
                 org_user_role_id = role_id
         elif dn:
-            register_role_label(dn, role_id, role_name)
+            available_role_labels.add(display_name)
+            register_role_label(
+                dn,
+                role_id,
+                role_name,
+                display_label=display_name,
+            )
 
     for alias, builtin_name in _BUILTIN_ROLE_ALIASES.items():
         builtin_role_id = builtin_by_name.get(builtin_name)
         if builtin_role_id:
-            register_role_label(alias, builtin_role_id, builtin_name)
+            register_role_label(
+                alias,
+                builtin_role_id,
+                builtin_name,
+                display_label=builtin_name,
+            )
             preferred_builtin_by_label[alias] = builtin_role_id
 
-    ambiguous: set[str] = set()
+    ambiguous: dict[str, list[str]] = {}
     unresolved: set[str] = set()
     resolved_rows: list[dict] = []
     for row in csv_rows:
@@ -452,7 +514,10 @@ def _resolve_csv_role_names(
         else:
             unique_role_ids = {candidate_role_id for candidate_role_id, _ in candidates}
             if len(unique_role_ids) != 1:
-                ambiguous.add(row["langsmith_role"])
+                ambiguous[row["langsmith_role"]] = sorted(
+                    role_descriptions_by_label.get(label, {}).values(),
+                    key=str.lower,
+                )
                 continue
             role_id = next(iter(unique_role_ids))
         resolved_role_name = next(
@@ -472,16 +537,21 @@ def _resolve_csv_role_names(
         )
 
     if ambiguous or unresolved:
-        available = sorted(role_lookup.keys())
+        available = sorted(available_role_labels, key=str.lower)
         errors: list[str] = []
         if ambiguous:
-            errors.append("Ambiguous role name(s): " + ", ".join(sorted(ambiguous)))
+            ambiguity_details = "; ".join(
+                f"'{input_label}' matched multiple roles case-insensitively: "
+                + ", ".join(candidates)
+                for input_label, candidates in sorted(ambiguous.items(), key=lambda item: item[0].lower())
+            )
+            errors.append("Ambiguous role name(s): " + ambiguity_details)
         if unresolved:
             errors.append(
                 "Could not resolve role name(s): "
                 + ", ".join(sorted(unresolved))
             )
-        errors.append("Available roles: " + ", ".join(available))
+        errors.append("Available roles (case-insensitive): " + ", ".join(available))
         raise click.ClickException(". ".join(errors))
 
     return resolved_rows, org_user_role_id
@@ -542,7 +612,10 @@ def _normalize_csv_role_scopes(
 
 
 def _csv_rows_to_org_members(
-    csv_rows: list[dict], default_org_role_id: str | None = None
+    csv_rows: list[dict],
+    default_org_role_id: str | None = None,
+    *,
+    direct_workspace_invites: bool = False,
 ) -> list[dict]:
     """Build org member payloads from CSV rows.
 
@@ -550,11 +623,20 @@ def _csv_rows_to_org_members(
     ``role_id`` is used directly.  Users who only appear in workspace
     rows (non-empty ``workspace_id``) are assigned *default_org_role_id*
     (typically ORGANIZATION_USER) so they can be invited to the org.
+
+    When ``direct_workspace_invites`` is true, workspace-only users also
+    carry through ``workspace_ids`` and ``workspace_role_id`` when all of
+    their workspace rows share the same workspace role. This is used by
+    single-instance CSV sync so a new org invite can include initial
+    workspace access in the same API call.
     """
     org_rows = [r for r in csv_rows if not r.get("workspace_id")]
     ws_rows = [r for r in csv_rows if r.get("workspace_id")]
 
     members_by_email: dict[str, dict] = {}
+    ws_rows_by_email: dict[str, list[dict]] = {}
+    for row in ws_rows:
+        ws_rows_by_email.setdefault(row["email"], []).append(row)
 
     for row in org_rows:
         email = row["email"]
@@ -575,12 +657,29 @@ def _csv_rows_to_org_members(
     for row in ws_rows:
         email = row["email"]
         if email not in members_by_email and default_org_role_id:
-            members_by_email[email] = {
+            member = {
                 "id": email,
                 "email": email,
                 "role_id": default_org_role_id,
                 "full_name": "",
             }
+            if direct_workspace_invites:
+                workspace_rows = ws_rows_by_email.get(email, [])
+                workspace_role_ids = {
+                    (workspace_row.get("role_id") or "").strip()
+                    for workspace_row in workspace_rows
+                    if (workspace_row.get("role_id") or "").strip()
+                }
+                if len(workspace_role_ids) == 1:
+                    member["workspace_ids"] = sorted(
+                        {
+                            workspace_row["workspace_id"]
+                            for workspace_row in workspace_rows
+                            if workspace_row.get("workspace_id")
+                        }
+                    )
+                    member["workspace_role_id"] = next(iter(workspace_role_ids))
+            members_by_email[email] = member
 
     return list(members_by_email.values())
 
@@ -857,11 +956,24 @@ def _display_resolution_summary(orchestrator) -> None:
         console.print(f"  Remediation bundle: {bundle_display}")
     console.print("  Resume command: langsmith-migrator resume")
 
-    actionable_items = orchestrator.state.get_checkpoint_items()
-    if actionable_items:
+    actionable_groups = orchestrator.state.get_actionable_groups()
+    if actionable_groups:
         console.print("\n[bold]Actionable Next Steps[/bold]")
-        for item in actionable_items[:5]:
-            console.print(f"  • {item.name}: {item.next_action or item.outcome_code or 'needs attention'}")
+        for group in actionable_groups[:5]:
+            item_count = len(group["items"])
+            if item_count == 1:
+                console.print(
+                    f"  • {group['subjects'][0]}: {group['next_action']}"
+                )
+            else:
+                affected = orchestrator.state.format_actionable_subjects(
+                    group["subjects"],
+                    max_items=3,
+                )
+                console.print(
+                    f"  • {group['label']} ({item_count} items: {affected}): "
+                    f"{group['next_action']}"
+                )
 
 
 def _needs_operator_action(state) -> bool:
@@ -1328,8 +1440,9 @@ def queues(ctx, source_workspace, dest_workspace, map_workspaces):
     '--sync',
     is_flag=True,
     help=(
-        'Make the CSV authoritative for single-instance sync: remove org users, '
-        'pending invites, and workspace memberships not present in the CSV. '
+        'Make the CSV authoritative for single-instance sync: any active org '
+        'user or pending invite not present in the CSV will be removed, and '
+        'workspace memberships not present in the CSV will also be removed. '
         'Without this flag, CSV mode only adds or updates access.'
     ),
 )
@@ -1617,7 +1730,9 @@ def users(
 
     if csv_member_rows is not None:
         all_members = _csv_rows_to_org_members(
-            csv_member_rows, default_org_role_id=default_org_role_id
+            csv_member_rows,
+            default_org_role_id=default_org_role_id,
+            direct_workspace_invites=single_instance,
         )
     else:
         org_members = user_role_migrator.list_source_org_members()
@@ -1643,8 +1758,11 @@ def users(
             needed_role_ids = {
                 role_id
                 for member in selected_members
-                if (role_id := (member.get("role_id") or "").strip())
-                and role_id not in role_mapping
+                for role_id in (
+                    (member.get("role_id") or "").strip(),
+                    (member.get("workspace_role_id") or "").strip(),
+                )
+                if role_id and role_id not in role_mapping
             }
             if needed_role_ids:
                 console.print(
@@ -3193,19 +3311,34 @@ def resume(ctx):
 
         # Get resumable items
         resume_items = state.get_resume_items()
-        checkpoint_items = state.get_checkpoint_items()
+        actionable_groups = state.get_actionable_groups()
 
         console.print(f"\nResumable items: {len(resume_items)}")
-        console.print(f"Checkpoint/manual items: {len(checkpoint_items)}")
+        console.print(
+            f"Checkpoint/manual items: {sum(len(group['items']) for group in actionable_groups)}"
+        )
 
-        if checkpoint_items:
+        if actionable_groups:
             console.print("\n[bold]Items requiring manual attention:[/bold]")
-            for item in checkpoint_items[:10]:
-                console.print(f"  • {item.name}: {item.next_action or item.outcome_code or 'needs attention'}")
+            for group in actionable_groups[:10]:
+                item_count = len(group["items"])
+                if item_count == 1:
+                    console.print(
+                        f"  • {group['subjects'][0]}: {group['next_action']}"
+                    )
+                else:
+                    affected = state.format_actionable_subjects(
+                        group["subjects"],
+                        max_items=3,
+                    )
+                    console.print(
+                        f"  • {group['label']} ({item_count} items: {affected}): "
+                        f"{group['next_action']}"
+                    )
 
         if not resume_items:
             console.print("\n[yellow]No items to resume automatically.[/yellow]")
-            if checkpoint_items:
+            if actionable_groups:
                 console.print("[dim]Review the checkpoint items above and resolve them manually.[/dim]")
             return
 

--- a/langsmith_migrator/core/migrators/user_role.py
+++ b/langsmith_migrator/core/migrators/user_role.py
@@ -21,6 +21,8 @@ class UserRoleMigrator(BaseMigrator):
         super().__init__(source_client, dest_client, state, config)
         self._role_id_map: Dict[str, str] = {}
         self._dest_email_to_identity: Optional[Dict[str, Dict[str, Any]]] = None
+        self._pending_org_email_to_identity: Dict[str, Dict[str, Any]] = {}
+        self._pending_workspace_invites: set[tuple[str, str]] = set()
         self._last_org_member_removals = 0
         self._last_workspace_member_removals = 0
 
@@ -88,11 +90,14 @@ class UserRoleMigrator(BaseMigrator):
         """Fetch and cache the destination org-member email index."""
         if self._dest_email_to_identity is None or force:
             dest_members = self.list_dest_org_members()
-            self._dest_email_to_identity = {
+            active_by_email = {
                 (member.get("email") or "").lower(): member
                 for member in dest_members
                 if member.get("email")
             }
+            for email, member in self._pending_org_email_to_identity.items():
+                active_by_email.setdefault(email, member)
+            self._dest_email_to_identity = active_by_email
         return self._dest_email_to_identity
 
     # ------------------------------------------------------------------
@@ -309,7 +314,12 @@ class UserRoleMigrator(BaseMigrator):
         """
         dest_members = self.list_dest_org_members()
         pending_dest_members = (
-            self.list_dest_pending_org_members() if remove_pending else []
+            self.list_dest_pending_org_members()
+            if (
+                remove_pending
+                or any(member.get("workspace_ids") for member in selected_members)
+            )
+            else []
         )
 
         dest_by_email: Dict[str, Dict[str, Any]] = {}
@@ -350,6 +360,14 @@ class UserRoleMigrator(BaseMigrator):
 
             source_role_id = (member.get("role_id") or "").strip() or None
             mapped_role_id = self._role_id_map.get(source_role_id) if source_role_id else None
+            source_workspace_role_id = (
+                (member.get("workspace_role_id") or "").strip() or None
+            )
+            mapped_workspace_role_id = (
+                self._role_id_map.get(source_workspace_role_id)
+                if source_workspace_role_id
+                else None
+            )
 
             if source_role_id and not mapped_role_id:
                 self.log(
@@ -363,9 +381,31 @@ class UserRoleMigrator(BaseMigrator):
                 )
                 failed += 1
                 continue
+            if source_workspace_role_id and not mapped_workspace_role_id:
+                self.log(
+                    f"No workspace role mapping for {email} (role_id={source_workspace_role_id})",
+                    "warning",
+                )
+                self.mark_blocked(
+                    item_id,
+                    "unmapped_workspace_role",
+                    next_action="Run phase 1 (role sync) and retry.",
+                    evidence={
+                        "email": email,
+                        "source_workspace_role_id": source_workspace_role_id,
+                    },
+                )
+                failed += 1
+                continue
 
             dest_member = dest_by_email.get(email)
             pending_member = pending_by_email.get(email)
+            workspace_ids = [
+                workspace_id
+                for workspace_id in (member.get("workspace_ids") or [])
+                if workspace_id
+            ]
+            workspace_role_id = mapped_workspace_role_id
 
             if dest_member:
                 if self.config.migration.skip_existing:
@@ -389,7 +429,10 @@ class UserRoleMigrator(BaseMigrator):
                         )
                         self.mark_blocked(
                             item_id, "org_member_role_update_failed",
-                            next_action="Re-run `langsmith-migrator users`.",
+                            next_action=(
+                                "Review the org role update error in the remediation "
+                                "bundle, then re-run `langsmith-migrator users`."
+                            ),
                             evidence={"email": email, "error": str(e)},
                         )
                         failed += 1
@@ -399,10 +442,31 @@ class UserRoleMigrator(BaseMigrator):
                     skipped += 1
             elif pending_member:
                 dest_role_id = pending_member.get("role_id")
-                if mapped_role_id and dest_role_id != mapped_role_id:
+                needs_workspace_access = bool(workspace_ids and workspace_role_id)
+                pending_workspace_ids = {
+                    workspace_id
+                    for workspace_id in (pending_member.get("workspace_ids") or [])
+                    if workspace_id
+                }
+                pending_workspace_role_id = (
+                    (pending_member.get("workspace_role_id") or "").strip() or None
+                )
+                pending_covers_workspace_access = (
+                    needs_workspace_access
+                    and set(workspace_ids).issubset(pending_workspace_ids)
+                    and pending_workspace_role_id == workspace_role_id
+                )
+                needs_reinvite = bool(
+                    (mapped_role_id and dest_role_id != mapped_role_id)
+                    or (
+                        needs_workspace_access
+                        and not pending_covers_workspace_access
+                    )
+                )
+                if needs_reinvite:
                     if self.config.migration.skip_existing:
                         self.log(
-                            f"Org invite for '{email}' exists, skipping role update",
+                            f"Org invite for '{email}' exists, skipping update",
                             "warning",
                         )
                         self.mark_migrated(
@@ -417,7 +481,12 @@ class UserRoleMigrator(BaseMigrator):
                             pending_member["id"],
                             pending=True,
                         )
-                        self._invite_org_member(email, mapped_role_id)
+                        self._invite_org_member(
+                            email,
+                            mapped_role_id,
+                            workspace_ids=workspace_ids,
+                            workspace_role_id=workspace_role_id,
+                        )
                         self.mark_migrated(
                             item_id,
                             outcome_code="org_member_migrated",
@@ -431,15 +500,30 @@ class UserRoleMigrator(BaseMigrator):
                         self.mark_blocked(
                             item_id,
                             "org_member_pending_invite_replace_failed",
-                            next_action="Re-run `langsmith-migrator users`.",
+                            next_action=(
+                                "Cancel or replace the pending org invite on the "
+                                "target, then re-run `langsmith-migrator users`."
+                            ),
                             evidence={"email": email, "error": str(e)},
                         )
                         failed += 1
                 else:
-                    self.log(
-                        f"Invite for '{email}' already pending, skipping",
-                        "warning",
-                    )
+                    pending_identity = {**pending_member, "email": email}
+                    self._pending_org_email_to_identity[email] = pending_identity
+                    if self._dest_email_to_identity is not None:
+                        self._dest_email_to_identity[email] = pending_identity
+                    if needs_workspace_access:
+                        for workspace_id in workspace_ids:
+                            self._pending_workspace_invites.add((email, workspace_id))
+                        self.log(
+                            f"Invite for '{email}' already pending with the required workspace access",
+                            "info",
+                        )
+                    else:
+                        self.log(
+                            f"Invite for '{email}' already pending, skipping",
+                            "warning",
+                        )
                     self.mark_migrated(
                         item_id,
                         outcome_code="org_member_skipped_existing",
@@ -447,7 +531,12 @@ class UserRoleMigrator(BaseMigrator):
                     skipped += 1
             else:
                 try:
-                    self._invite_org_member(email, mapped_role_id)
+                    self._invite_org_member(
+                        email,
+                        mapped_role_id,
+                        workspace_ids=workspace_ids,
+                        workspace_role_id=workspace_role_id,
+                    )
                     self.mark_migrated(item_id, outcome_code="org_member_migrated")
                     migrated += 1
                 except ConflictError:
@@ -461,7 +550,10 @@ class UserRoleMigrator(BaseMigrator):
                     self.log(f"Failed to invite '{email}': {e}", "error")
                     self.mark_blocked(
                         item_id, "org_member_invite_failed",
-                        next_action="Re-run `langsmith-migrator users`.",
+                        next_action=(
+                            "Review the org invite error in the remediation "
+                            "bundle, then re-run `langsmith-migrator users`."
+                        ),
                         evidence={"email": email, "error": str(e)},
                     )
                     failed += 1
@@ -513,7 +605,10 @@ class UserRoleMigrator(BaseMigrator):
                     self.mark_blocked(
                         item_id,
                         "org_member_remove_failed",
-                        next_action="Re-run `langsmith-migrator users`.",
+                        next_action=(
+                            "Remove the extra org user or pending invite manually "
+                            "if needed, then re-run `langsmith-migrator users --sync`."
+                        ),
                         evidence={"email": email, "error": str(e)},
                     )
                     failed += 1
@@ -525,17 +620,39 @@ class UserRoleMigrator(BaseMigrator):
         self,
         email: str,
         role_id: Optional[str] = None,
+        *,
+        workspace_ids: Optional[List[str]] = None,
+        workspace_role_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Invite a new member to the destination org."""
         if self.config.migration.dry_run:
             self.log(f"[DRY RUN] Would invite {email}")
-            return {"id": f"dry-run-{email}"}
+            response = {"id": f"dry-run-{email}", "email": email}
+            self._pending_org_email_to_identity[email] = response
+            if self._dest_email_to_identity is not None:
+                self._dest_email_to_identity[email] = response
+            if workspace_ids and workspace_role_id:
+                for workspace_id in workspace_ids:
+                    self._pending_workspace_invites.add((email, workspace_id))
+            return response
 
         payload: Dict[str, Any] = {"email": email}
         if role_id:
             payload["role_id"] = role_id
+        if workspace_ids:
+            payload["workspace_ids"] = workspace_ids
+        if workspace_role_id:
+            payload["workspace_role_id"] = workspace_role_id
 
         response = self.dest.post("/orgs/current/members", payload)
+        if isinstance(response, dict) and response.get("id"):
+            invited_identity = {**response, "email": email}
+            self._pending_org_email_to_identity[email] = invited_identity
+            if self._dest_email_to_identity is not None:
+                self._dest_email_to_identity[email] = invited_identity
+        if workspace_ids and workspace_role_id:
+            for workspace_id in workspace_ids:
+                self._pending_workspace_invites.add((email, workspace_id))
         self.log(f"Invited {email}", "success")
         return response
 
@@ -562,7 +679,19 @@ class UserRoleMigrator(BaseMigrator):
             self.log(f"[DRY RUN] Would {action}: {identity_id}")
             return
 
-        self.dest.delete(f"/orgs/current/members/{identity_id}")
+        if pending:
+            pending_endpoint = f"/orgs/current/members/pending/{identity_id}"
+            legacy_endpoint = f"/orgs/current/members/{identity_id}"
+            try:
+                self.dest.delete(pending_endpoint)
+            except APIError as e:
+                status_code = getattr(e, "status_code", None)
+                message = str(e).lower()
+                if status_code not in {404, 405} and "not found" not in message and "not allowed" not in message:
+                    raise
+                self.dest.delete(legacy_endpoint)
+        else:
+            self.dest.delete(f"/orgs/current/members/{identity_id}")
         action = "Cancelled org invite" if pending else "Removed org member"
         self.log(f"{action}: {identity_id}", "success")
 
@@ -649,6 +778,7 @@ class UserRoleMigrator(BaseMigrator):
 
         ws_pair = self.workspace_pair()
         src_ws = ws_pair.get("source")
+        dst_ws = ws_pair.get("dest") or src_ws
         if not src_ws:
             raise APIError(
                 "Active source workspace is required for workspace member migration",
@@ -697,6 +827,17 @@ class UserRoleMigrator(BaseMigrator):
                 continue
 
             dest_member = dest_by_email.get(email)
+            if dst_ws and (email, dst_ws) in self._pending_workspace_invites:
+                self.log(
+                    f"Workspace access for '{email}' is already included in the pending org invite",
+                    "info",
+                )
+                self.mark_migrated(
+                    item_id,
+                    outcome_code="ws_member_included_in_org_invite",
+                )
+                skipped += 1
+                continue
 
             if dest_member:
                 if self.config.migration.skip_existing:
@@ -719,7 +860,11 @@ class UserRoleMigrator(BaseMigrator):
                         )
                         self.mark_blocked(
                             item_id, "ws_member_role_update_failed",
-                            next_action="Re-run `langsmith-migrator users`.",
+                            next_action=(
+                                "Review the workspace role update error in the "
+                                "remediation bundle, then re-run "
+                                "`langsmith-migrator users`."
+                            ),
                             evidence={"email": email, "error": str(e)},
                         )
                         failed += 1
@@ -743,7 +888,9 @@ class UserRoleMigrator(BaseMigrator):
 
                 try:
                     self._add_workspace_member(
-                        dest_org_member["id"], mapped_role_id
+                        dest_org_member,
+                        mapped_role_id,
+                        workspace_id=dst_ws,
                     )
                     self.mark_migrated(item_id, outcome_code="ws_member_migrated")
                     migrated += 1
@@ -760,7 +907,11 @@ class UserRoleMigrator(BaseMigrator):
                     )
                     self.mark_blocked(
                         item_id, "ws_member_add_failed",
-                        next_action="Re-run `langsmith-migrator users`.",
+                        next_action=(
+                            "Review the workspace membership create error in the "
+                            "remediation bundle, then re-run "
+                            "`langsmith-migrator users`."
+                        ),
                         evidence={"email": email, "error": str(e)},
                     )
                     failed += 1
@@ -799,7 +950,10 @@ class UserRoleMigrator(BaseMigrator):
                     self.mark_blocked(
                         item_id,
                         "ws_member_remove_failed",
-                        next_action="Re-run `langsmith-migrator users`.",
+                        next_action=(
+                            "Remove the extra workspace membership manually if "
+                            "needed, then re-run `langsmith-migrator users --sync`."
+                        ),
                         evidence={"email": email, "error": str(e)},
                     )
                     failed += 1
@@ -808,14 +962,47 @@ class UserRoleMigrator(BaseMigrator):
         return migrated, skipped, failed
 
     def _add_workspace_member(
-        self, org_identity_id: str, role_id: Optional[str] = None
+        self,
+        org_member: Dict[str, Any],
+        role_id: Optional[str] = None,
+        *,
+        workspace_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Add an org member to the current workspace."""
+        org_identity_id = org_member.get("id", "")
+        user_id = (
+            org_member.get("user_id")
+            or (org_member.get("user") or {}).get("id")
+        )
+
         if self.config.migration.dry_run:
             self.log(f"[DRY RUN] Would add workspace member: {org_identity_id}")
             return {"id": f"dry-run-{org_identity_id}"}
 
-        payload: Dict[str, Any] = {"org_identity_id": org_identity_id}
+        if user_id and workspace_id:
+            payload: Dict[str, Any] = {
+                "user_id": user_id,
+                "workspace_ids": [workspace_id],
+            }
+            if role_id:
+                payload["workspace_role_id"] = role_id
+            try:
+                response = self.dest.post("/workspaces/current/members", payload)
+                self.log(f"Added workspace member: {org_identity_id}", "success")
+                return response
+            except APIError as e:
+                status_code = getattr(e, "status_code", None)
+                message = str(e).lower()
+                if (
+                    status_code not in {404, 405, 422}
+                    and "not found" not in message
+                    and "not allowed" not in message
+                    and "user_id" not in message
+                    and "validation" not in message
+                ):
+                    raise
+
+        payload = {"org_identity_id": org_identity_id}
         if role_id:
             payload["role_id"] = role_id
 
@@ -833,9 +1020,22 @@ class UserRoleMigrator(BaseMigrator):
             )
             return
 
-        self.dest.patch(
-            f"/tenants/current/members/{identity_id}", {"role_id": role_id}
-        )
+        try:
+            self.dest.patch(
+                f"/workspaces/current/members/{identity_id}", {"role_id": role_id}
+            )
+        except APIError as e:
+            status_code = getattr(e, "status_code", None)
+            message = str(e).lower()
+            if (
+                status_code not in {404, 405}
+                and "not found" not in message
+                and "not allowed" not in message
+            ):
+                raise
+            self.dest.patch(
+                f"/tenants/current/members/{identity_id}", {"role_id": role_id}
+            )
         self.log(f"Updated workspace member role: {identity_id}", "success")
 
     def _remove_workspace_member(self, identity_id: str) -> None:
@@ -844,7 +1044,18 @@ class UserRoleMigrator(BaseMigrator):
             self.log(f"[DRY RUN] Would remove workspace member: {identity_id}")
             return
 
-        self.dest.delete(f"/tenants/current/members/{identity_id}")
+        try:
+            self.dest.delete(f"/workspaces/current/members/{identity_id}")
+        except APIError as e:
+            status_code = getattr(e, "status_code", None)
+            message = str(e).lower()
+            if (
+                status_code not in {404, 405}
+                and "not found" not in message
+                and "not allowed" not in message
+            ):
+                raise
+            self.dest.delete(f"/tenants/current/members/{identity_id}")
         self.log(f"Removed workspace member: {identity_id}", "success")
 
     # ------------------------------------------------------------------

--- a/langsmith_migrator/utils/state.py
+++ b/langsmith_migrator/utils/state.py
@@ -63,6 +63,52 @@ REPAIR_POLICIES = {
 }
 
 
+_ACTIONABLE_GROUP_LABELS = {
+    "unmapped_role": "Roles are missing from the mapping",
+    "unmapped_workspace_role": "Workspace roles are missing from the mapping",
+    "org_member_role_update_failed": "Org role updates failed",
+    "org_member_pending_invite_replace_failed": "Pending org invites could not be refreshed",
+    "org_member_invite_failed": "Org invites failed",
+    "org_member_remove_failed": "Extra org users or pending invites could not be removed",
+    "ws_member_role_update_failed": "Workspace role updates failed",
+    "ws_member_not_in_org": "Workspace users are missing org access",
+    "ws_member_add_failed": "Workspace memberships failed to add",
+    "ws_member_remove_failed": "Extra workspace memberships could not be removed",
+}
+
+
+_ACTIONABLE_NEXT_ACTION_OVERRIDES = {
+    "org_member_role_update_failed": (
+        "Review the org role update error in the remediation bundle, "
+        "then re-run `langsmith-migrator users`."
+    ),
+    "org_member_pending_invite_replace_failed": (
+        "Cancel or replace the pending org invite on the target, "
+        "then re-run `langsmith-migrator users`."
+    ),
+    "org_member_invite_failed": (
+        "Review the org invite error in the remediation bundle, "
+        "then re-run `langsmith-migrator users`."
+    ),
+    "org_member_remove_failed": (
+        "Remove the extra org user or pending invite manually if needed, "
+        "then re-run `langsmith-migrator users --sync`."
+    ),
+    "ws_member_role_update_failed": (
+        "Review the workspace role update error in the remediation bundle, "
+        "then re-run `langsmith-migrator users`."
+    ),
+    "ws_member_add_failed": (
+        "Review the workspace membership create error in the remediation bundle, "
+        "then re-run `langsmith-migrator users`."
+    ),
+    "ws_member_remove_failed": (
+        "Remove the extra workspace membership manually if needed, "
+        "then re-run `langsmith-migrator users --sync`."
+    ),
+}
+
+
 def _now() -> float:
     return time.time()
 
@@ -485,6 +531,97 @@ class MigrationState:
                 items.append(item)
         return items
 
+    @staticmethod
+    def _humanize_outcome_code(code: str) -> str:
+        text = code.replace("_", " ").strip()
+        if not text:
+            return "Items need attention"
+        return text[:1].upper() + text[1:]
+
+    def _actionable_subject(self, item: MigrationItem) -> str:
+        return str(
+            item.evidence.get("email")
+            or item.name
+            or item.source_id
+            or item.id
+        )
+
+    def _actionable_label(self, item: MigrationItem) -> str:
+        code = item.outcome_code or item.error or ""
+        if code in _ACTIONABLE_GROUP_LABELS:
+            return _ACTIONABLE_GROUP_LABELS[code]
+        if code:
+            return self._humanize_outcome_code(code)
+        return self._humanize_outcome_code(item.type)
+
+    def _actionable_next_action(self, item: MigrationItem) -> str:
+        code = item.outcome_code or item.error or ""
+        if code in _ACTIONABLE_NEXT_ACTION_OVERRIDES:
+            return _ACTIONABLE_NEXT_ACTION_OVERRIDES[code]
+        if item.next_action:
+            return item.next_action
+        return (
+            "Review the remediation bundle for the specific error and retry "
+            "once the issue is resolved."
+        )
+
+    @staticmethod
+    def format_actionable_subjects(
+        subjects: List[str],
+        *,
+        max_items: Optional[int] = None,
+    ) -> str:
+        unique_subjects: List[str] = []
+        seen: set[str] = set()
+        for subject in subjects:
+            if subject and subject not in seen:
+                unique_subjects.append(subject)
+                seen.add(subject)
+
+        if max_items is not None and len(unique_subjects) > max_items:
+            preview = ", ".join(unique_subjects[:max_items])
+            return f"{preview}, +{len(unique_subjects) - max_items} more"
+        return ", ".join(unique_subjects)
+
+    def get_actionable_groups(self) -> List[Dict[str, Any]]:
+        """Group blocked/exported items into higher-signal remediation steps."""
+        grouped: Dict[tuple[str, str, str, str], Dict[str, Any]] = {}
+
+        for item in sorted(
+            self.get_checkpoint_items(),
+            key=lambda current: (
+                current.outcome_code or "",
+                current.type,
+                self._actionable_subject(current).lower(),
+            ),
+        ):
+            label = self._actionable_label(item)
+            next_action = self._actionable_next_action(item)
+            key = (
+                item.outcome_code or "",
+                item.type,
+                label,
+                next_action,
+            )
+            group = grouped.setdefault(
+                key,
+                {
+                    "label": label,
+                    "next_action": next_action,
+                    "subjects": [],
+                    "items": [],
+                    "artifacts": [],
+                },
+            )
+            subject = self._actionable_subject(item)
+            if subject not in group["subjects"]:
+                group["subjects"].append(subject)
+            group["items"].append(item)
+            if item.export_path and item.export_path not in group["artifacts"]:
+                group["artifacts"].append(item.export_path)
+
+        return list(grouped.values())
+
     def record_capability(
         self,
         scope: str,
@@ -702,7 +839,7 @@ class MigrationState:
         )
 
         stats = self.get_statistics()
-        checkpoint_items = self.get_checkpoint_items()
+        actionable_groups = self.get_actionable_groups()
         resume_command = "langsmith-migrator resume"
         lines = [
             f"# Remediation Summary: {self.session_id}",
@@ -720,15 +857,33 @@ class MigrationState:
             "",
         ]
 
-        if checkpoint_items:
+        if actionable_groups:
             lines.append("## Actionable Items")
             lines.append("")
-            for item in checkpoint_items:
-                lines.append(f"- `{item.id}` ({item.type}): {item.outcome_code or 'needs_attention'}")
-                if item.next_action:
-                    lines.append(f"  Next: {item.next_action}")
-                if item.export_path:
-                    lines.append(f"  Artifact: `{item.export_path}`")
+            for group in actionable_groups:
+                item_count = len(group["items"])
+                if item_count == 1:
+                    lines.append(
+                        f"- {group['subjects'][0]}: {group['label']}"
+                    )
+                else:
+                    lines.append(
+                        f"- {group['label']} ({item_count} items)"
+                    )
+                    lines.append(
+                        "  Affected: "
+                        + self.format_actionable_subjects(
+                            group["subjects"],
+                            max_items=10,
+                        )
+                    )
+                lines.append(f"  Next: {group['next_action']}")
+                for artifact_path in group["artifacts"][:3]:
+                    lines.append(f"  Artifact: `{artifact_path}`")
+                if len(group["artifacts"]) > 3:
+                    lines.append(
+                        f"  Artifacts: {len(group['artifacts'])} files in the remediation bundle"
+                    )
             lines.append("")
 
         if self.remediation_queue:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.62"
+version = "0.0.63"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -7,7 +7,13 @@ from unittest.mock import Mock, call
 
 from langsmith_migrator.cli import main as cli_main
 from langsmith_migrator.cli.tui_workspace_mapper import WorkspaceProjectResult
-from langsmith_migrator.utils.state import MigrationItem, MigrationState, MigrationStatus
+from langsmith_migrator.utils.state import (
+    MigrationItem,
+    MigrationState,
+    MigrationStatus,
+    ResolutionOutcome,
+    VerificationState,
+)
 
 
 def build_state(
@@ -69,6 +75,54 @@ def test_name_mapping_to_id_mapping_ignores_unknown_project_names():
     )
 
     assert result == {"src-a": "dst-a"}
+
+
+def test_display_resolution_summary_groups_duplicate_user_failures(monkeypatch, tmp_path):
+    """Resolution summaries should collapse repeated user-role blockers into a grouped next step."""
+
+    state = build_state("migration_grouped_summary")
+    state.remediation_bundle_path = str(
+        (tmp_path / "remediation" / state.session_id).resolve()
+    )
+    for email in ("alice@example.com", "bob@example.com"):
+        item = state.ensure_item(
+            f"ws_member_ws-1_{email}",
+            "ws_member",
+            email,
+            email,
+        )
+        state.mark_terminal(
+            item.id,
+            ResolutionOutcome.BLOCKED_WITH_CHECKPOINT,
+            "ws_member_add_failed",
+            verification_state=VerificationState.BLOCKED,
+            next_action="Re-run `langsmith-migrator users`.",
+            evidence={"email": email},
+        )
+
+    class StubOrchestrator:
+        def __init__(self, state):
+            self.state = state
+
+    class SimpleConsole:
+        def __init__(self):
+            self.text = ""
+
+        def print(self, *args, end="\n", **kwargs):
+            self.text += "".join(str(arg) for arg in args) + end
+
+    console = SimpleConsole()
+    monkeypatch.setattr(cli_main, "console", console)
+
+    cli_main._display_resolution_summary(StubOrchestrator(state))
+
+    normalized_output = " ".join(console.text.split())
+    assert "Actionable Next Steps" in normalized_output
+    assert (
+        "Workspace memberships failed to add (2 items: alice@example.com, "
+        "bob@example.com): Review the workspace membership create error in the "
+        "remediation bundle, then re-run `langsmith-migrator users`."
+    ) in normalized_output
 
 
 def test_resolve_workspaces_with_explicit_pair_sets_context(monkeypatch):
@@ -531,6 +585,8 @@ def test_users_command_single_instance_source_of_truth_uses_identity_workspace_p
                 "email": "bob@example.com",
                 "role_id": "src-user",
                 "full_name": "",
+                "workspace_ids": ["ws-1"],
+                "workspace_role_id": "src-ws-admin",
             },
         ],
         remove_missing=True,
@@ -742,6 +798,8 @@ def test_users_command_single_instance_csv_apply_auto_applies_all_rows(
                 "email": "bob@example.com",
                 "role_id": "src-user",
                 "full_name": "",
+                "workspace_ids": ["ws-1"],
+                "workspace_role_id": "src-ws-admin",
             },
         ],
         remove_missing=False,
@@ -838,6 +896,74 @@ def test_users_command_single_instance_syncs_custom_roles_only_when_csv_rows_nee
             }
         ],
         remove_missing=False,
+    )
+
+
+def test_users_command_single_instance_syncs_workspace_only_custom_roles_before_org_invites(
+    cli_harness, monkeypatch, tmp_path
+):
+    """Workspace-only users should sync custom workspace roles before direct org invites."""
+    cli_harness.orchestrator_factory.dest_client.get_responses["/api/v1/workspaces"] = [
+        {"id": "ws-1", "display_name": "Workspace 1"},
+    ]
+    csv_path = tmp_path / "members.csv"
+    csv_path.write_text(
+        "email,langsmith_role,workspace_id\n"
+        "alice@example.com,write-no-read,ws-1\n",
+        encoding="utf-8",
+    )
+
+    user_role_migrator = Mock()
+    user_role_migrator.build_role_mapping.side_effect = [
+        {
+            "src-admin": "dst-admin",
+            "src-user": "dst-user",
+            "src-ws-admin": "dst-ws-admin",
+        },
+        {"src-ws-custom": "dst-ws-custom"},
+    ]
+    user_role_migrator.list_source_roles.return_value = [
+        {"id": "src-admin", "name": "ORGANIZATION_ADMIN", "display_name": "Admin"},
+        {"id": "src-user", "name": "ORGANIZATION_USER", "display_name": "User"},
+        {"id": "src-ws-admin", "name": "WORKSPACE_ADMIN", "display_name": "Workspace Admin"},
+        {"id": "src-ws-custom", "name": "CUSTOM", "display_name": "write-no-read"},
+    ]
+    user_role_migrator.list_dest_org_members.return_value = []
+    user_role_migrator.migrate_org_members.return_value = (1, 0, 0)
+    user_role_migrator.migrate_workspace_members.return_value = (0, 1, 0)
+    monkeypatch.setattr(cli_main, "UserRoleMigrator", lambda *args, **kwargs: user_role_migrator)
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(
+        [
+            "users",
+            "--api-key",
+            "sync-key",
+            "--url",
+            "https://sync.example",
+            "--csv",
+            str(csv_path),
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert user_role_migrator.build_role_mapping.call_args_list == [
+        call(custom_role_ids=set()),
+        call(custom_role_ids={"src-ws-custom"}),
+    ]
+    user_role_migrator.migrate_org_members.assert_called_once_with(
+        [
+            {
+                "id": "alice@example.com",
+                "email": "alice@example.com",
+                "role_id": "src-user",
+                "full_name": "",
+                "workspace_ids": ["ws-1"],
+                "workspace_role_id": "src-ws-custom",
+            }
+        ],
+        remove_missing=False,
+        remove_pending=False,
     )
 
 
@@ -1066,6 +1192,8 @@ def test_users_command_single_instance_sync_dry_run_keeps_safe_apply_behavior(
                 "email": "bob@example.com",
                 "role_id": "src-user",
                 "full_name": "",
+                "workspace_ids": ["ws-1"],
+                "workspace_role_id": "src-ws-admin",
             },
         ],
         remove_missing=True,
@@ -1281,6 +1409,8 @@ def test_users_help_describes_single_instance_csv_guardrails(cli_harness):
     assert "Preview this users sync without making POST/PATCH/DELETE changes." in normalized_output
     assert "Use one target LangSmith instance" in normalized_output
     assert "access sync instead of" in normalized_output
+    assert "any active org user or pending invite not present in the CSV will be removed" in normalized_output
+    assert "workspace memberships not present in the CSV will also be removed" in normalized_output
     assert "Without this flag, CSV mode only adds or updates access." in normalized_output
     assert "all CSV rows are applied automatically" in normalized_output
     assert "Organization Admin on a workspace row is treated as org-level access only." in normalized_output

--- a/tests/test_state_resolution.py
+++ b/tests/test_state_resolution.py
@@ -95,3 +95,45 @@ def test_loading_v1_state_upgrades_to_schema_v2(tmp_path):
     assert loaded is not None
     assert loaded.schema_version == 2
     assert loaded.verification_summary["total"] == 1
+
+
+def test_remediation_summary_groups_duplicate_actionable_items(tmp_path):
+    """Remediation summaries should collapse repeated user-role failures into one actionable step."""
+
+    state = MigrationState(
+        session_id="migration_grouped_actions",
+        started_at=time.time(),
+        updated_at=time.time(),
+        source_url="https://source.example",
+        destination_url="https://dest.example",
+        remediation_bundle_path=str(
+            (tmp_path / "remediation" / "migration_grouped_actions").resolve()
+        ),
+    )
+
+    for email in ("alice@example.com", "bob@example.com"):
+        item = state.ensure_item(
+            f"ws_member_ws-1_{email}",
+            "ws_member",
+            email,
+            email,
+        )
+        state.mark_terminal(
+            item.id,
+            ResolutionOutcome.BLOCKED_WITH_CHECKPOINT,
+            "ws_member_add_failed",
+            verification_state=VerificationState.BLOCKED,
+            next_action="Re-run `langsmith-migrator users`.",
+            evidence={"email": email},
+        )
+
+    bundle_dir = state.write_remediation_bundle()
+
+    assert bundle_dir is not None
+    summary = (bundle_dir / "summary.md").read_text(encoding="utf-8")
+    assert "Workspace memberships failed to add (2 items)" in summary
+    assert "Affected: alice@example.com, bob@example.com" in summary
+    assert (
+        "Next: Review the workspace membership create error in the remediation "
+        "bundle, then re-run `langsmith-migrator users`."
+    ) in summary

--- a/tests/test_user_role_migrator.py
+++ b/tests/test_user_role_migrator.py
@@ -1,7 +1,7 @@
 """Unit tests for UserRoleMigrator."""
 
 import pytest
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 from langsmith_migrator.core.migrators import UserRoleMigrator
 from langsmith_migrator.utils.retry import APIError, ConflictError
 
@@ -215,6 +215,51 @@ class TestUserRoleMigrator:
             {"email": "alice@example.com", "role_id": "dst-role"},
         )
 
+    def test_migrate_org_members_invite_new_with_workspace_access(self, migrator):
+        """Single-instance workspace-only users can be invited to the org and workspace together."""
+        migrator._role_id_map = {
+            "src-org-role": "dst-org-role",
+            "src-ws-role": "dst-ws-role",
+        }
+        migrator.dest.get_paginated.side_effect = [iter([]), iter([])]
+        migrator.dest.post.return_value = {"id": "new-identity-1"}
+
+        members = [
+            {
+                "id": "src-m1",
+                "email": "alice@example.com",
+                "role_id": "src-org-role",
+                "workspace_ids": ["ws-1"],
+                "workspace_role_id": "src-ws-role",
+            },
+        ]
+
+        m, s, f = migrator.migrate_org_members(members)
+
+        assert (m, s, f) == (1, 0, 0)
+        migrator.dest.post.assert_called_once_with(
+            "/orgs/current/members",
+            {
+                "email": "alice@example.com",
+                "role_id": "dst-org-role",
+                "workspace_ids": ["ws-1"],
+                "workspace_role_id": "dst-ws-role",
+            },
+        )
+        assert migrator._pending_workspace_invites == {("alice@example.com", "ws-1")}
+        assert migrator._pending_org_email_to_identity["alice@example.com"]["id"] == "new-identity-1"
+
+    def test_ensure_dest_email_index_preserves_newly_invited_pending_identities(self, migrator):
+        """A refresh keeps newly invited identities available for the workspace phase."""
+        migrator._pending_org_email_to_identity = {
+            "alice@example.com": {"id": "pending-1", "email": "alice@example.com"}
+        }
+        migrator.dest.get_paginated.return_value = iter([])
+
+        refreshed = migrator.ensure_dest_email_index(force=True)
+
+        assert refreshed["alice@example.com"]["id"] == "pending-1"
+
     def test_migrate_org_members_update_role(self, migrator):
         """Existing members with different roles get updated."""
         migrator._role_id_map = {"src-role": "dst-role-new"}
@@ -305,11 +350,132 @@ class TestUserRoleMigrator:
         )
 
         assert (m, s, f) == (1, 0, 0)
-        migrator.dest.delete.assert_called_once_with("/orgs/current/members/pending-1")
+        migrator.dest.delete.assert_called_once_with(
+            "/orgs/current/members/pending/pending-1"
+        )
         migrator.dest.post.assert_called_once_with(
             "/orgs/current/members",
             {"email": "alice@example.com", "role_id": "dst-role-new"},
         )
+
+    def test_migrate_org_members_reinvites_pending_falls_back_to_legacy_delete_path(
+        self, migrator
+    ):
+        """Pending invite replacement should tolerate instances that only support the legacy delete path."""
+        migrator._role_id_map = {"src-role": "dst-role-new"}
+        migrator.dest.get_paginated.side_effect = [
+            iter([]),
+            iter([
+                {"id": "pending-1", "email": "alice@example.com", "role_id": "dst-role-old"},
+            ]),
+        ]
+        migrator.dest.delete.side_effect = [
+            APIError("Not found", status_code=404, request_info={}),
+            {},
+        ]
+        migrator.dest.post.return_value = {"id": "new-identity-1"}
+
+        members = [
+            {"id": "src-m1", "email": "alice@example.com", "role_id": "src-role"},
+        ]
+
+        m, s, f = migrator.migrate_org_members(
+            members,
+            remove_pending=True,
+        )
+
+        assert (m, s, f) == (1, 0, 0)
+        assert migrator.dest.delete.call_args_list == [
+            call("/orgs/current/members/pending/pending-1"),
+            call("/orgs/current/members/pending-1"),
+        ]
+        migrator.dest.post.assert_called_once_with(
+            "/orgs/current/members",
+            {"email": "alice@example.com", "role_id": "dst-role-new"},
+        )
+
+    def test_migrate_org_members_reinvites_pending_when_workspace_access_is_needed(
+        self, migrator
+    ):
+        """Existing pending invites should be replaced when workspace access still needs to be attached."""
+        migrator._role_id_map = {
+            "src-role": "dst-role",
+            "src-ws-role": "dst-ws-role",
+        }
+        migrator.dest.get_paginated.side_effect = [
+            iter([]),
+            iter([
+                {"id": "pending-1", "email": "alice@example.com", "role_id": "dst-role"},
+            ]),
+        ]
+        migrator.dest.post.return_value = {"id": "new-identity-1"}
+
+        members = [
+            {
+                "id": "src-m1",
+                "email": "alice@example.com",
+                "role_id": "src-role",
+                "workspace_ids": ["ws-1"],
+                "workspace_role_id": "src-ws-role",
+            },
+        ]
+
+        m, s, f = migrator.migrate_org_members(members)
+
+        assert (m, s, f) == (1, 0, 0)
+        migrator.dest.delete.assert_called_once_with(
+            "/orgs/current/members/pending/pending-1"
+        )
+        migrator.dest.post.assert_called_once_with(
+            "/orgs/current/members",
+            {
+                "email": "alice@example.com",
+                "role_id": "dst-role",
+                "workspace_ids": ["ws-1"],
+                "workspace_role_id": "dst-ws-role",
+            },
+        )
+        assert migrator._pending_workspace_invites == {("alice@example.com", "ws-1")}
+        assert migrator._pending_org_email_to_identity["alice@example.com"]["id"] == "new-identity-1"
+
+    def test_migrate_org_members_keeps_pending_invite_when_role_and_workspace_access_match(
+        self, migrator
+    ):
+        """Existing pending invites are reused when they already include the requested workspace access."""
+        migrator._role_id_map = {
+            "src-role": "dst-role",
+            "src-ws-role": "dst-ws-role",
+        }
+        migrator.dest.get_paginated.side_effect = [
+            iter([]),
+            iter([
+                {
+                    "id": "pending-1",
+                    "email": "alice@example.com",
+                    "role_id": "dst-role",
+                    "workspace_ids": ["ws-1"],
+                    "workspace_role_id": "dst-ws-role",
+                },
+            ]),
+        ]
+
+        members = [
+            {
+                "id": "src-m1",
+                "email": "alice@example.com",
+                "role_id": "src-role",
+                "workspace_ids": ["ws-1"],
+                "workspace_role_id": "src-ws-role",
+            },
+        ]
+
+        m, s, f = migrator.migrate_org_members(members)
+
+        assert (m, s, f) == (0, 1, 0)
+        assert migrator._pending_org_email_to_identity["alice@example.com"]["id"] == "pending-1"
+        assert migrator._pending_workspace_invites == {("alice@example.com", "ws-1")}
+        migrator.dest.delete.assert_not_called()
+        migrator.dest.post.assert_not_called()
 
     def test_migrate_org_members_remove_missing_active_and_pending(self, migrator):
         """Authoritative mode removes extra active members and pending invites."""
@@ -337,7 +503,9 @@ class TestUserRoleMigrator:
         assert (m, s, f) == (2, 1, 0)
         assert migrator._last_org_member_removals == 2
         migrator.dest.delete.assert_any_call("/orgs/current/members/dst-remove")
-        migrator.dest.delete.assert_any_call("/orgs/current/members/pending-remove")
+        migrator.dest.delete.assert_any_call(
+            "/orgs/current/members/pending/pending-remove"
+        )
 
     # ── Phase 3: Workspace member migration ──
 
@@ -345,7 +513,7 @@ class TestUserRoleMigrator:
         """Users not in workspace are added."""
         migrator._role_id_map = {"src-ws-role": "dst-ws-role"}
         migrator._dest_email_to_identity = {
-            "alice@example.com": {"id": "dst-org-identity-1"},
+            "alice@example.com": {"id": "dst-org-identity-1", "user_id": "dst-user-1"},
         }
         migrator.source.get_paginated.return_value = iter([
             {"id": "src-ws-m1", "email": "alice@example.com", "role_id": "src-ws-role"},
@@ -357,8 +525,12 @@ class TestUserRoleMigrator:
 
         assert m == 1
         migrator.dest.post.assert_called_once_with(
-            "/tenants/current/members",
-            {"org_identity_id": "dst-org-identity-1", "role_id": "dst-ws-role"},
+            "/workspaces/current/members",
+            {
+                "user_id": "dst-user-1",
+                "workspace_ids": ["ws-default-dst"],
+                "workspace_role_id": "dst-ws-role",
+            },
         )
 
     def test_migrate_workspace_members_update_role(self, migrator):
@@ -375,9 +547,66 @@ class TestUserRoleMigrator:
 
         assert m == 1
         migrator.dest.patch.assert_called_once_with(
-            "/tenants/current/members/dst-ws-m1",
+            "/workspaces/current/members/dst-ws-m1",
             {"role_id": "dst-ws-role-new"},
         )
+
+    def test_migrate_workspace_members_add_falls_back_to_legacy_tenant_endpoint(self, migrator):
+        """Workspace member creation should tolerate instances that only support the legacy tenant write path."""
+        migrator._role_id_map = {"src-ws-role": "dst-ws-role"}
+        migrator._dest_email_to_identity = {
+            "alice@example.com": {"id": "dst-org-identity-1", "user_id": "dst-user-1"},
+        }
+        migrator.source.get_paginated.return_value = iter([
+            {"id": "src-ws-m1", "email": "alice@example.com", "role_id": "src-ws-role"},
+        ])
+        migrator.dest.get_paginated.return_value = iter([])
+        migrator.dest.post.side_effect = [
+            APIError("Not found", status_code=404, request_info={}),
+            {"id": "dst-ws-identity-1"},
+        ]
+
+        m, s, f = migrator.migrate_workspace_members()
+
+        assert (m, s, f) == (1, 0, 0)
+        assert migrator.dest.post.call_args_list == [
+            call(
+                "/workspaces/current/members",
+                {
+                    "user_id": "dst-user-1",
+                    "workspace_ids": ["ws-default-dst"],
+                    "workspace_role_id": "dst-ws-role",
+                },
+            ),
+            call(
+                "/tenants/current/members",
+                {"org_identity_id": "dst-org-identity-1", "role_id": "dst-ws-role"},
+            ),
+        ]
+
+    def test_migrate_workspace_members_update_role_falls_back_to_legacy_tenant_endpoint(
+        self, migrator
+    ):
+        """Workspace role updates should tolerate instances that only support the legacy tenant write path."""
+        migrator._role_id_map = {"src-ws-role": "dst-ws-role-new"}
+        migrator.source.get_paginated.return_value = iter([
+            {"id": "src-ws-m1", "email": "alice@example.com", "role_id": "src-ws-role"},
+        ])
+        migrator.dest.get_paginated.return_value = iter([
+            {"id": "dst-ws-m1", "email": "alice@example.com", "role_id": "dst-ws-role-old"},
+        ])
+        migrator.dest.patch.side_effect = [
+            APIError("Not found", status_code=404, request_info={}),
+            {},
+        ]
+
+        m, s, f = migrator.migrate_workspace_members()
+
+        assert (m, s, f) == (1, 0, 0)
+        assert migrator.dest.patch.call_args_list == [
+            call("/workspaces/current/members/dst-ws-m1", {"role_id": "dst-ws-role-new"}),
+            call("/tenants/current/members/dst-ws-m1", {"role_id": "dst-ws-role-new"}),
+        ]
 
     def test_migrate_workspace_members_not_in_org(self, migrator):
         """User not an org member on dest is recorded as failed."""
@@ -392,6 +621,21 @@ class TestUserRoleMigrator:
 
         assert f == 1
         assert m == 0
+
+    def test_migrate_workspace_members_skips_when_included_in_pending_org_invite(self, migrator):
+        """Workspace phase should not re-add membership already included in a pending org invite."""
+        migrator._role_id_map = {"src-ws-role": "dst-ws-role"}
+        migrator._dest_email_to_identity = {}
+        migrator._pending_workspace_invites = {("alice@example.com", "ws-default-dst")}
+        migrator.source.get_paginated.return_value = iter([
+            {"id": "src-ws-m1", "email": "alice@example.com", "role_id": "src-ws-role"},
+        ])
+        migrator.dest.get_paginated.return_value = iter([])
+
+        m, s, f = migrator.migrate_workspace_members()
+
+        assert (m, s, f) == (0, 1, 0)
+        migrator.dest.post.assert_not_called()
 
     def test_migrate_workspace_members_remove_missing(self, migrator):
         """Authoritative workspace sync removes extra memberships."""
@@ -416,7 +660,7 @@ class TestUserRoleMigrator:
         assert (m, s, f) == (1, 1, 0)
         assert migrator._last_workspace_member_removals == 1
         migrator.dest.delete.assert_called_once_with(
-            "/tenants/current/members/dst-ws-remove"
+            "/workspaces/current/members/dst-ws-remove"
         )
 
     def test_migrate_workspace_members_remove_missing_with_empty_selection(self, migrator):
@@ -435,8 +679,33 @@ class TestUserRoleMigrator:
         assert (m, s, f) == (1, 0, 0)
         assert migrator._last_workspace_member_removals == 1
         migrator.dest.delete.assert_called_once_with(
-            "/tenants/current/members/dst-ws-remove"
+            "/workspaces/current/members/dst-ws-remove"
         )
+
+    def test_migrate_workspace_members_remove_missing_falls_back_to_legacy_tenant_endpoint(
+        self, migrator
+    ):
+        """Workspace member removals should tolerate instances that only support the legacy tenant delete path."""
+        migrator._role_id_map = {}
+        migrator._dest_email_to_identity = {}
+        migrator.dest.get_paginated.return_value = iter([
+            {"id": "dst-ws-remove", "email": "remove@example.com", "role_id": "dst-ws-role"},
+        ])
+        migrator.dest.delete.side_effect = [
+            APIError("Not found", status_code=404, request_info={}),
+            {},
+        ]
+
+        m, s, f = migrator.migrate_workspace_members(
+            selected_members=[],
+            remove_missing=True,
+        )
+
+        assert (m, s, f) == (1, 0, 0)
+        assert migrator.dest.delete.call_args_list == [
+            call("/workspaces/current/members/dst-ws-remove"),
+            call("/tenants/current/members/dst-ws-remove"),
+        ]
 
     # ── Dry run ──
 
@@ -622,7 +891,7 @@ class TestUserRoleMigrator:
         migrator.source.session.headers["X-Tenant-Id"] = "ws-src-1"
         migrator._role_id_map = {"src-ws-role": "dst-ws-role"}
         migrator._dest_email_to_identity = {
-            "alice@example.com": {"id": "dst-org-identity-1"},
+            "alice@example.com": {"id": "dst-org-identity-1", "user_id": "dst-user-1"},
         }
         migrator.dest.get_paginated.return_value = iter([])
         migrator.dest.post.return_value = {"id": "dst-ws-identity-1"}
@@ -644,8 +913,12 @@ class TestUserRoleMigrator:
 
         assert (m, s, f) == (1, 0, 0)
         migrator.dest.post.assert_called_once_with(
-            "/tenants/current/members",
-            {"org_identity_id": "dst-org-identity-1", "role_id": "dst-ws-role"},
+            "/workspaces/current/members",
+            {
+                "user_id": "dst-user-1",
+                "workspace_ids": ["ws-default-dst"],
+                "workspace_role_id": "dst-ws-role",
+            },
         )
 
     def test_migrate_workspace_members_from_csv_rows_requires_workspace_context(self, migrator):

--- a/tests/test_users_csv_input.py
+++ b/tests/test_users_csv_input.py
@@ -29,15 +29,40 @@ def test_load_members_csv_requires_columns(tmp_path: Path):
         _load_members_csv(str(csv_path))
 
 
-def test_load_members_csv_rejects_empty_langsmith_role(tmp_path: Path):
+def test_load_members_csv_rejects_empty_langsmith_role_with_workspace_guidance(tmp_path: Path):
     csv_path = tmp_path / "members.csv"
     csv_path.write_text(
         "email,langsmith_role,workspace_id\nalice@example.com,,ws-1\n",
         encoding="utf-8",
     )
 
-    with pytest.raises(click.ClickException, match="empty langsmith_role"):
+    with pytest.raises(click.ClickException) as exc_info:
         _load_members_csv(str(csv_path))
+
+    message = str(exc_info.value)
+    assert "row 2 for alice@example.com in workspace ws-1" in message
+    assert "empty langsmith_role" in message
+    assert "Workspace Admin" in message
+    assert "leave workspace_id empty" in message
+
+
+def test_load_members_csv_rejects_empty_langsmith_role_on_org_row_with_org_guidance(
+    tmp_path: Path,
+):
+    csv_path = tmp_path / "members.csv"
+    csv_path.write_text(
+        "email,langsmith_role,workspace_id\nalice@example.com,,\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(click.ClickException) as exc_info:
+        _load_members_csv(str(csv_path))
+
+    message = str(exc_info.value)
+    assert "row 2 for alice@example.com" in message
+    assert "empty langsmith_role" in message
+    assert "Organization User" in message
+    assert "Organization Admin" in message
 
 
 def test_load_members_csv_rejects_empty_file(tmp_path: Path):
@@ -109,8 +134,12 @@ def test_load_members_csv_strips_whitespace(tmp_path: Path):
 
 SOURCE_ROLES = [
     {"id": "src-admin", "name": "ORGANIZATION_ADMIN", "display_name": "Admin", "permissions": []},
+    {"id": "src-operator", "name": "ORGANIZATION_OPERATOR", "display_name": "Operator", "permissions": []},
     {"id": "src-user", "name": "ORGANIZATION_USER", "display_name": "User", "permissions": []},
+    {"id": "src-viewer", "name": "ORGANIZATION_VIEWER", "display_name": "Viewer", "permissions": []},
     {"id": "src-ws-admin", "name": "WORKSPACE_ADMIN", "display_name": "Workspace Admin", "permissions": []},
+    {"id": "src-ws-user", "name": "WORKSPACE_USER", "display_name": "Collaborator", "permissions": []},
+    {"id": "src-ws-viewer", "name": "WORKSPACE_VIEWER", "display_name": "Workspace Read-only", "permissions": []},
     {"id": "src-custom-1", "name": "CUSTOM", "display_name": "Data Scientist", "permissions": []},
     {"id": "src-custom-2", "name": "CUSTOM", "display_name": "maintainer-dl-general", "permissions": []},
 ]
@@ -129,6 +158,20 @@ def test_resolve_csv_role_names_builtin_roles():
     assert org_user_id == "src-user"
 
 
+def test_resolve_csv_role_names_extended_builtin_aliases():
+    rows = [
+        {"email": "a@example.com", "langsmith_role": "Organization Viewer", "workspace_id": ""},
+        {"email": "b@example.com", "langsmith_role": "Workspace User", "workspace_id": "ws-1"},
+        {"email": "c@example.com", "langsmith_role": "WORKSPACE_VIEWER", "workspace_id": "ws-1"},
+    ]
+
+    resolved, _ = _resolve_csv_role_names(rows, SOURCE_ROLES)
+
+    assert resolved[0]["role_id"] == "src-viewer"
+    assert resolved[1]["role_id"] == "src-ws-user"
+    assert resolved[2]["role_id"] == "src-ws-viewer"
+
+
 def test_resolve_csv_role_names_custom_roles():
     rows = [
         {"email": "a@example.com", "langsmith_role": "Data Scientist", "workspace_id": "ws-1"},
@@ -143,7 +186,7 @@ def test_resolve_csv_role_names_case_insensitive():
     rows = [
         {"email": "a@example.com", "langsmith_role": "organization admin", "workspace_id": ""},
         {"email": "b@example.com", "langsmith_role": "ORGANIZATION_ADMIN", "workspace_id": ""},
-        {"email": "c@example.com", "langsmith_role": "data scientist", "workspace_id": "ws-1"},
+        {"email": "c@example.com", "langsmith_role": "DATA SCIENTIST", "workspace_id": "ws-1"},
     ]
 
     resolved, _ = _resolve_csv_role_names(rows, SOURCE_ROLES)
@@ -201,6 +244,25 @@ def test_resolve_csv_role_names_ambiguous_display_name_rejected_regardless_of_or
 
     with pytest.raises(click.ClickException, match="Ambiguous role name"):
         _resolve_csv_role_names(rows, source_roles)
+
+
+def test_resolve_csv_role_names_case_insensitive_conflict_calls_out_candidates():
+    rows = [
+        {"email": "a@example.com", "langsmith_role": "DATA SCIENTIST", "workspace_id": "ws-1"},
+    ]
+    source_roles = [
+        {"id": "src-custom-1", "name": "CUSTOM", "display_name": "Data Scientist", "permissions": []},
+        {"id": "src-custom-2", "name": "CUSTOM", "display_name": "DATA SCIENTIST", "permissions": []},
+    ]
+
+    with pytest.raises(click.ClickException) as exc_info:
+        _resolve_csv_role_names(rows, source_roles)
+
+    message = str(exc_info.value)
+    assert "matched multiple roles case-insensitively" in message
+    assert "Data Scientist (src-custom-1)" in message
+    assert "DATA SCIENTIST (src-custom-2)" in message
+    assert "Available roles (case-insensitive)" in message
 
 
 def test_resolve_csv_role_names_builtin_identifier_preferred_over_custom_collision():
@@ -269,9 +331,9 @@ def test_normalize_csv_role_scopes_rejects_workspace_role_on_org_row():
     rows = [
         {
             "email": "alice@example.com",
-            "langsmith_role": "Workspace Admin",
-            "role_id": "src-ws-admin",
-            "role_name": "WORKSPACE_ADMIN",
+            "langsmith_role": "Workspace User",
+            "role_id": "src-ws-user",
+            "role_name": "WORKSPACE_USER",
             "workspace_id": "",
         }
     ]
@@ -284,9 +346,9 @@ def test_normalize_csv_role_scopes_rejects_org_user_on_workspace_row():
     rows = [
         {
             "email": "alice@example.com",
-            "langsmith_role": "Organization User",
-            "role_id": "src-user",
-            "role_name": "ORGANIZATION_USER",
+            "langsmith_role": "Organization Viewer",
+            "role_id": "src-viewer",
+            "role_name": "ORGANIZATION_VIEWER",
             "workspace_id": "ws-1",
         }
     ]
@@ -321,6 +383,52 @@ def test_csv_rows_to_org_members_workspace_only_gets_default():
 
     assert len(members) == 1
     assert members[0]["role_id"] == "role-user"
+
+
+def test_csv_rows_to_org_members_single_instance_workspace_only_carries_workspace_invite():
+    rows = [
+        {"email": "alice@example.com", "role_id": "role-ws-admin", "workspace_id": "ws-2"},
+        {"email": "alice@example.com", "role_id": "role-ws-admin", "workspace_id": "ws-1"},
+    ]
+
+    members = _csv_rows_to_org_members(
+        rows,
+        default_org_role_id="role-user",
+        direct_workspace_invites=True,
+    )
+
+    assert members == [
+        {
+            "id": "alice@example.com",
+            "email": "alice@example.com",
+            "role_id": "role-user",
+            "full_name": "",
+            "workspace_ids": ["ws-1", "ws-2"],
+            "workspace_role_id": "role-ws-admin",
+        }
+    ]
+
+
+def test_csv_rows_to_org_members_single_instance_mixed_workspace_roles_omit_direct_invite():
+    rows = [
+        {"email": "alice@example.com", "role_id": "role-ws-admin", "workspace_id": "ws-1"},
+        {"email": "alice@example.com", "role_id": "role-ws-viewer", "workspace_id": "ws-2"},
+    ]
+
+    members = _csv_rows_to_org_members(
+        rows,
+        default_org_role_id="role-user",
+        direct_workspace_invites=True,
+    )
+
+    assert members == [
+        {
+            "id": "alice@example.com",
+            "email": "alice@example.com",
+            "role_id": "role-user",
+            "full_name": "",
+        }
+    ]
 
 
 def test_csv_rows_to_org_members_conflicting_org_roles_rejected():

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.62"
+version = "0.0.63"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- harden single-instance users CSV sync for workspace-role, pending-invite, and workspace-endpoint compatibility cases
- group repeated remediation blockers into higher-signal actionable next steps and improve CSV validation guidance
- update release metadata, README parity, and examples for v0.0.63

## Testing
- uv run pytest tests/test_users_csv_input.py tests/test_user_role_migrator.py tests/test_state_resolution.py tests/functional/test_cli_functional.py
- uv build