### PR TITLE
Prepare v0.0.64 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.64] - 2026-04-10
+
+### Added
+- **Command-local headless users mode**: `users --non-interactive` now works as a subcommand-local alias for the global `--non-interactive` flag, making cron-style single-instance CSV sync runs easier to schedule.
+
+### Fixed
+- **Headless credential handling**: `users` now fails fast with a clear non-interactive configuration error instead of trying to prompt for API keys when running headless.
+
+### Changed
+- **README release parity**: Updated the release install snippets and `users` documentation to show the command-local headless mode and the new `0.0.64` wheel URLs.
+
 ## [0.0.63] - 2026-04-10
 
 ### Added
@@ -270,7 +281,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration documentation
 - API reference for core classes
 
-[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.63...HEAD
+[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.64...HEAD
+[0.0.64]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.63...v0.0.64
 [0.0.63]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.62...v0.0.63
 [0.0.62]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.61...v0.0.62
 [0.0.61]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.60...v0.0.61

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python CLI for migrating users and roles, datasets, experiments, annotation qu
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.63-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.64-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -54,20 +54,20 @@ For trace data, use LangSmith's **Bulk Export** functionality: [LangSmith Bulk E
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.63-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.64-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.63-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.64-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.63-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.64-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.63-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.64-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)
@@ -213,6 +213,7 @@ langsmith-migrator \
 
 In `--single-instance` mode, the command mirrors the provided instance configuration onto both internal clients, so you only need one working LangSmith connection. Workspace rows use the target workspace IDs directly; there is no workspace mapping step. All CSV rows are applied automatically after a single confirmation summary; there is no row-selection step in this mode. `--api-key`/`--url` imply `--single-instance`, `--csv` is a short alias for `--members-csv`, and `--sync` is a short alias for `--csv-source-of-truth`.
 `users --dry-run` is also supported as a command-local preview flag if you prefer to put dry-run after the subcommand instead of before it.
+For cron jobs and other headless runs, `users --non-interactive` is also supported as a command-local alias for the global `langsmith-migrator --non-interactive users ...` form. In headless mode, missing credentials fail fast instead of prompting.
 
 CSV schema:
 
@@ -325,6 +326,7 @@ The prompt default is `No` (rules are created disabled).
 
 ```bash
 --dry-run                  Preview this users sync without making POST/PATCH/DELETE changes
+--non-interactive          Disable prompts for this users run. Same as the global --non-interactive.
 --roles-only               Only migrate custom roles (skip member migration)
 --skip-workspace-members   Skip workspace member migration
 --single-instance, --instance

--- a/langsmith_migrator/__init__.py
+++ b/langsmith_migrator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("langsmith-data-migration-tool")
 except PackageNotFoundError:
-    __version__ = "0.0.63"
+    __version__ = "0.0.64"

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -1011,7 +1011,7 @@ def ensure_config(config: Config) -> bool:
         # Check if we're missing credentials specifically
         missing_creds = any("API key is required" in error for error in errors)
 
-        if missing_creds:
+        if missing_creds and not config.migration.non_interactive:
             # Prompt for missing credentials
             config.prompt_for_credentials(console)
 
@@ -1023,6 +1023,21 @@ def ensure_config(config: Config) -> bool:
                 for error in errors:
                     console.print(f"  • {error}")
                 return False
+
+        if config.migration.non_interactive:
+            guidance: list[str] = []
+            if missing_creds:
+                guidance.append(
+                    "Provide credentials via CLI flags or environment variables "
+                    "before running in --non-interactive mode."
+                )
+            error_lines = [f"  • {error}" for error in errors]
+            if guidance:
+                error_lines.extend(f"  • {line}" for line in guidance)
+            raise click.ClickException(
+                "Configuration is invalid in --non-interactive mode:\n"
+                + "\n".join(error_lines)
+            )
         else:
             # Non-credential errors
             for error in errors:
@@ -1469,6 +1484,12 @@ def queues(ctx, source_workspace, dest_workspace, map_workspaces):
     'instance_url',
     help='Base URL for the single-instance CSV sync target. Must be provided together with --api-key.',
 )
+@click.option(
+    '--non-interactive',
+    'users_non_interactive',
+    is_flag=True,
+    help='Disable prompts for this users run. Same behavior as the global --non-interactive.',
+)
 @workspace_options
 @click.pass_context
 def users(
@@ -1481,6 +1502,7 @@ def users(
     members_csv,
     instance_key,
     instance_url,
+    users_non_interactive,
     source_workspace,
     dest_workspace,
     map_workspaces,
@@ -1493,6 +1515,9 @@ def users(
 
     if users_dry_run:
         config.migration.dry_run = True
+    if users_non_interactive:
+        config.migration.non_interactive = True
+        config.migration.interactive = False
 
     if bool(instance_key) != bool(instance_url):
         raise click.ClickException(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.63"
+version = "0.0.64"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -1212,6 +1212,61 @@ def test_users_command_single_instance_sync_dry_run_keeps_safe_apply_behavior(
     )
 
 
+def test_users_command_local_non_interactive_runs_headless_single_instance_csv_apply(
+    cli_harness, monkeypatch, tmp_path
+):
+    """users --non-interactive should bypass confirmation prompts for cron-friendly runs."""
+    cli_harness.orchestrator_factory.dest_client.get_responses["/api/v1/workspaces"] = [
+        {"id": "ws-1", "display_name": "Workspace 1"},
+    ]
+    csv_path = tmp_path / "members.csv"
+    csv_path.write_text(
+        "email,langsmith_role,workspace_id\n"
+        "alice@example.com,Organization Admin,\n"
+        "bob@example.com,Workspace Admin,ws-1\n",
+        encoding="utf-8",
+    )
+
+    user_role_migrator = Mock()
+    user_role_migrator.build_role_mapping.return_value = {
+        "src-admin": "dst-admin",
+        "src-user": "dst-user",
+        "src-ws-admin": "dst-ws-admin",
+    }
+    user_role_migrator.list_source_roles.return_value = [
+        {"id": "src-admin", "name": "ORGANIZATION_ADMIN", "display_name": "Admin"},
+        {"id": "src-user", "name": "ORGANIZATION_USER", "display_name": "User"},
+        {"id": "src-ws-admin", "name": "WORKSPACE_ADMIN", "display_name": "Workspace Admin"},
+    ]
+    user_role_migrator.list_dest_org_members.return_value = []
+    user_role_migrator.migrate_org_members.return_value = (2, 0, 0)
+    user_role_migrator.migrate_workspace_members.return_value = (1, 0, 0)
+    monkeypatch.setattr(
+        cli_main, "UserRoleMigrator", lambda *args, **kwargs: user_role_migrator
+    )
+    cli_harness.controls.confirm_answers = [False]
+
+    result = cli_harness.invoke(
+        [
+            "users",
+            "--non-interactive",
+            "--api-key",
+            "sync-key",
+            "--url",
+            "https://sync.example",
+            "--csv",
+            str(csv_path),
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert cli_harness.controls.confirm_answers == [False]
+    orchestrator = cli_harness.orchestrator_factory.instances[0]
+    assert orchestrator.config.migration.non_interactive is True
+    user_role_migrator.migrate_org_members.assert_called_once()
+    user_role_migrator.migrate_workspace_members.assert_called_once()
+
+
 def test_users_command_rejects_org_scoped_role_on_workspace_row(
     cli_harness, monkeypatch, tmp_path
 ):
@@ -1417,6 +1472,38 @@ def test_users_help_describes_single_instance_csv_guardrails(cli_harness):
     assert "Must be provided together with --url." in normalized_output
     assert "Base URL for the single-instance CSV sync target." in normalized_output
     assert "provided together with --api-" in normalized_output
+    assert "Disable prompts for this users run." in normalized_output
+
+
+def test_users_command_non_interactive_missing_credentials_fails_without_prompt(
+    cli_harness, monkeypatch
+):
+    """Headless users runs should fail fast instead of prompting for credentials."""
+
+    monkeypatch.delenv("LANGSMITH_OLD_API_KEY", raising=False)
+    monkeypatch.delenv("LANGSMITH_NEW_API_KEY", raising=False)
+    monkeypatch.delenv("LANGSMITH_OLD_BASE_URL", raising=False)
+    monkeypatch.delenv("LANGSMITH_NEW_BASE_URL", raising=False)
+
+    prompted = False
+
+    def _unexpected_prompt(self, console=None):
+        nonlocal prompted
+        prompted = True
+        raise AssertionError("prompt_for_credentials should not be called")
+
+    monkeypatch.setattr(cli_main.Config, "prompt_for_credentials", _unexpected_prompt)
+
+    result = cli_harness.invoke(
+        ["users", "--non-interactive"],
+        add_base_args=False,
+    )
+
+    assert result.exit_code != 0
+    assert prompted is False
+    assert "Configuration is invalid in --non-interactive mode" in result.output
+    assert "Source API key is required" in result.output
+    assert "Destination API key is required" in result.output
 
 
 def test_datasets_command_migrates_selected_datasets_with_workspace_scope(cli_harness):

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.63"
+version = "0.0.64"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- add command-local `users --non-interactive` support for headless cron runs
- fail fast in headless mode instead of prompting for missing credentials
- bump release metadata and README install/docs to 0.0.64

## Testing
- uv run pytest tests/functional/test_cli_functional.py -k 'users_command' -q
- uv build