### PR TITLE
Prepare v0.0.65 release

### DIFF
--- a/.github/scripts/check_wheel_contents.py
+++ b/.github/scripts/check_wheel_contents.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Verify built wheels include the CLI module required by the console script."""
+
+from __future__ import annotations
+
+import configparser
+import sys
+import zipfile
+from pathlib import Path
+
+REQUIRED_FILES = ("langsmith_migrator/cli/main.py",)
+REQUIRED_CONSOLE_SCRIPTS = {
+    "langsmith-migrator": "langsmith_migrator.__main__:main",
+}
+
+
+def _validate_wheel(path: Path) -> list[str]:
+    errors: list[str] = []
+
+    with zipfile.ZipFile(path) as wheel:
+        names = set(wheel.namelist())
+
+        for required_file in REQUIRED_FILES:
+            if required_file not in names:
+                errors.append(f"missing required module `{required_file}`")
+
+        entry_points_path = next(
+            (name for name in names if name.endswith(".dist-info/entry_points.txt")),
+            None,
+        )
+        if entry_points_path is None:
+            errors.append("missing `entry_points.txt` in the wheel metadata")
+            return errors
+
+        entry_points = configparser.ConfigParser()
+        entry_points.read_string(wheel.read(entry_points_path).decode("utf-8"))
+
+        if not entry_points.has_section("console_scripts"):
+            errors.append("missing `[console_scripts]` section in `entry_points.txt`")
+            return errors
+
+        console_scripts = dict(entry_points.items("console_scripts"))
+        for script_name, target in REQUIRED_CONSOLE_SCRIPTS.items():
+            actual = console_scripts.get(script_name)
+            if actual != target:
+                errors.append(
+                    f"console script `{script_name}` points to `{actual}` instead of `{target}`"
+                )
+
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("Usage: check_wheel_contents.py <wheel> [<wheel> ...]", file=sys.stderr)
+        return 2
+
+    has_errors = False
+    for wheel_arg in argv[1:]:
+        wheel_path = Path(wheel_arg)
+        errors = _validate_wheel(wheel_path)
+        if errors:
+            has_errors = True
+            print(f"[FAIL] {wheel_path}")
+            for error in errors:
+                print(f"  - {error}")
+            continue
+
+        print(f"[PASS] {wheel_path}")
+
+    return 1 if has_errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Build package
         run: uv build
 
+      - name: Verify wheel contents
+        run: python3 .github/scripts/check_wheel_contents.py dist/*.whl
+
       - name: Extract release notes
         id: extract-release-notes
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,13 @@ jobs:
       run: bash .github/scripts/check_readme_release_sync.sh
 
     - name: Lint with ruff
-      run: uv run ruff check langsmith_migrator
+      run: uv run ruff check langsmith_migrator .github/scripts/check_wheel_contents.py
+
+    - name: Build wheel
+      run: uv build --wheel
+
+    - name: Verify wheel contents
+      run: python3 .github/scripts/check_wheel_contents.py dist/*.whl
 
     - name: Run tests
       run: uv run pytest --cov=langsmith_migrator --cov-report=xml --cov-report=term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -166,4 +166,4 @@ run_dataset_tests.py
 test_*.py
 !tests/**/test_*.py
 demo_*.py
-main.py
+/main.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.65] - 2026-04-21
+
+### Added
+- **Wheel artifact verification**: Test and release workflows now build the wheel and fail fast if the CLI module or console entry point metadata is missing from the published artifact.
+
+### Fixed
+- **CLI wheel packaging**: Narrowed the `.gitignore` `main.py` rule to the repository root so `langsmith_migrator/cli/main.py` is included in built wheels again, restoring `pip` and `uv` installs.
+
 ## [0.0.64] - 2026-04-10
 
 ### Added
@@ -281,7 +289,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration documentation
 - API reference for core classes
 
-[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.64...HEAD
+[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.65...HEAD
+[0.0.65]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.64...v0.0.65
 [0.0.64]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.63...v0.0.64
 [0.0.63]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.62...v0.0.63
 [0.0.62]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.61...v0.0.62

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python CLI for migrating users and roles, datasets, experiments, annotation qu
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.64-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.65-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -54,20 +54,20 @@ For trace data, use LangSmith's **Bulk Export** functionality: [LangSmith Bulk E
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.64-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.65-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.64-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.65-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.64-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.65-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.64-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.65-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)

--- a/langsmith_migrator/__init__.py
+++ b/langsmith_migrator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("langsmith-data-migration-tool")
 except PackageNotFoundError:
-    __version__ = "0.0.64"
+    __version__ = "0.0.65"

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -3,49 +3,33 @@
 import csv
 import functools
 import logging
+import time
 from pathlib import Path
 from typing import Iterable
+
 import click
-import time
 from dotenv import load_dotenv
 from rich.console import Console
-from rich.table import Table
 from rich.prompt import Confirm
 from rich.progress import Progress
-
-load_dotenv()
+from rich.table import Table
 
 from ..utils.config import Config
-
-
-def ssl_option(f):
-    """
-    Decorator kept for backwards compatibility.
-
-    Note: --no-ssl is now handled globally in the cli() group, so this decorator
-    is a no-op. It's kept to avoid breaking existing command decorations.
-    """
-    @functools.wraps(f)
-    def wrapper(*args, **kwargs):
-        # The global cli() already handles --no-ssl via the config object
-        return f(*args, **kwargs)
-    return wrapper
 from ..utils.state import MigrationStatus, ResolutionOutcome, StateManager, VerificationState
 from ..core.migrators import (
-    MigrationOrchestrator,
-    DatasetMigrator,
     AnnotationQueueMigrator,
+    ChartMigrator,
+    DatasetMigrator,
+    MigrationOrchestrator,
     PromptMigrator,
     RulesMigrator,
-    ChartMigrator,
     UserRoleMigrator,
 )
-from .tui_selector import select_items
 from .tui_project_mapper import build_project_mapping_tui
+from .tui_selector import select_items
 from .tui_workspace_mapper import WorkspaceProjectResult
 from ..utils.workspace import (
     discover_workspaces,
-    get_workspace_name,
     list_projects as _list_projects,
     list_workspaces as _list_workspaces,
 )
@@ -56,7 +40,25 @@ from ..utils.workspace_resolver import (
 )
 
 
+load_dotenv()
+
 console = Console()
+
+
+def ssl_option(f):
+    """
+    Decorator kept for backwards compatibility.
+
+    Note: --no-ssl is now handled globally in the cli() group, so this decorator
+    is a no-op. It's kept to avoid breaking existing command decorations.
+    """
+
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        # The global cli() already handles --no-ssl via the config object
+        return f(*args, **kwargs)
+
+    return wrapper
 
 
 class _SuppressRunCompressionNoise(logging.Filter):
@@ -2082,48 +2084,48 @@ def prompts(ctx, select_all, include_all_commits, source_workspace, dest_workspa
 def list_projects(ctx, source, dest):
     """List projects with their IDs to help create project mappings."""
     config = ctx.obj['config']
-    
+
     if not source and not dest:
         console.print("[yellow]Specify --source or --dest to list projects[/yellow]")
         return
-    
+
     if not ensure_config(config):
         return
-    
+
     orchestrator = MigrationOrchestrator(config, ctx.obj['state_manager'])
-    
+
     from rich.table import Table
-    
+
     if source:
         console.print("\n[bold]Source Projects:[/bold]")
         try:
             table = Table(show_header=True)
             table.add_column("Name", style="cyan", width=50)
             table.add_column("ID", style="dim", width=36)
-            
+
             for project in orchestrator.source_client.get_paginated("/sessions", page_size=100):
                 if isinstance(project, dict):
                     table.add_row(project.get('name', 'unnamed'), project.get('id', ''))
-            
+
             console.print(table)
         except Exception as e:
             console.print(f"[red]Failed to list source projects: {e}[/red]")
-    
+
     if dest:
         console.print("\n[bold]Destination Projects:[/bold]")
         try:
             table = Table(show_header=True)
             table.add_column("Name", style="cyan", width=50)
             table.add_column("ID", style="dim", width=36)
-            
+
             for project in orchestrator.dest_client.get_paginated("/sessions", page_size=100):
                 if isinstance(project, dict):
                     table.add_row(project.get('name', 'unnamed'), project.get('id', ''))
-            
+
             console.print(table)
         except Exception as e:
             console.print(f"[red]Failed to list destination projects: {e}[/red]")
-    
+
     orchestrator.cleanup()
 
 
@@ -2290,7 +2292,6 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
 
         # Analyze rules for project/dataset associations
         project_specific = [r for r in rules if r.get('session_id')]
-        dataset_specific = [r for r in rules if r.get('dataset_id')]
         project_only = [r for r in rules if r.get('session_id') and not r.get('dataset_id')]
 
         if project_specific and not strip_projects:
@@ -2414,10 +2415,10 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
 
         # Show helpful message about disabled rules
         if success_count > 0 and not create_enabled:
-            console.print(f"\n[cyan]Note:[/cyan] Rules were created as [yellow]disabled[/yellow] to bypass secrets validation.")
-            console.print(f"  To enable rules:")
-            console.print(f"  1. Configure required secrets (e.g., OPENAI_API_KEY) in destination workspace settings")
-            console.print(f"  2. Enable each rule in the LangSmith UI or use --create-enabled flag")
+            console.print("\n[cyan]Note:[/cyan] Rules were created as [yellow]disabled[/yellow] to bypass secrets validation.")
+            console.print("  To enable rules:")
+            console.print("  1. Configure required secrets (e.g., OPENAI_API_KEY) in destination workspace settings")
+            console.print("  2. Enable each rule in the LangSmith UI or use --create-enabled flag")
 
     if ws_result:
         orchestrator.clear_workspace_context()
@@ -2806,7 +2807,7 @@ def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_ex
                 strip = strip_projects
                 ensure_projects = False
                 create_enabled = rules_create_enabled
-                
+
                 if project_specific and not strip:
                     strip = _confirm_action(
                         config,
@@ -2888,10 +2889,10 @@ def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_ex
 
                 console.print(f"Rules: {success_count} migrated, {len(skipped_items)} skipped, {len(failed_items)} failed")
                 if success_count > 0 and create_disabled:
-                    console.print(f"\n[cyan]Note:[/cyan] Rules were created as [yellow]disabled[/yellow] to bypass secrets validation.")
-                    console.print(f"  To enable rules:")
-                    console.print(f"  1. Configure required secrets (e.g., OPENAI_API_KEY) in destination workspace settings")
-                    console.print(f"  2. Enable each rule in the LangSmith UI or rerun with --rules-create-enabled")
+                    console.print("\n[cyan]Note:[/cyan] Rules were created as [yellow]disabled[/yellow] to bypass secrets validation.")
+                    console.print("  To enable rules:")
+                    console.print("  1. Configure required secrets (e.g., OPENAI_API_KEY) in destination workspace settings")
+                    console.print("  2. Enable each rule in the LangSmith UI or rerun with --rules-create-enabled")
                 if (failed_items or skipped_items) and config.migration.verbose:
                     for name, err in skipped_items:
                         console.print(f"  [yellow]⊘[/yellow] {name}: {err}")
@@ -3108,7 +3109,7 @@ def charts(ctx, session, same_instance, map_projects, source_workspace, dest_wor
             if not target_session:
                 console.print("[red]✗[/red]")
                 console.print(f"[red]Session not found: {session}[/red]")
-                console.print(f"\n[yellow]Available sessions:[/yellow]")
+                console.print("\n[yellow]Available sessions:[/yellow]")
                 for s in sessions[:10]:
                     console.print(f"  - {s.get('name', 'unnamed')} ({s.get('id', 'no-id')})")
                 if len(sessions) > 10:
@@ -3391,7 +3392,7 @@ def resume(ctx):
         # Report results
         resumed = results.get("resumed", [])
         blocked = results.get("blocked", [])
-        console.print(f"\n[bold]Resume Results:[/bold]")
+        console.print("\n[bold]Resume Results:[/bold]")
         console.print(f"  [green]Resumed successfully: {len(resumed)}[/green]")
         console.print(f"  [yellow]Blocked/needs attention: {len(blocked)}[/yellow]")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.64"
+version = "0.0.65"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.64"
+version = "0.0.65"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- narrow the repo-root `main.py` ignore so `langsmith_migrator/cli/main.py` is packaged into wheels again
- add a wheel artifact verification script and run it in CI and the release workflow
- bump versioned release metadata and install snippets to `0.0.65`

## Verification
- `uv run pytest`
- `uv build --wheel --out-dir /tmp/langsmith-migrator-post-fix`
- `python3 .github/scripts/check_wheel_contents.py /tmp/langsmith-migrator-post-fix/langsmith_data_migration_tool-0.0.65-py3-none-any.whl`
- `python3 .github/scripts/check_wheel_contents.py /tmp/langsmith-migrator-pre-fix/langsmith_data_migration_tool-0.0.64-py3-none-any.whl`