### PR TITLE
Release v0.0.66: harden single-instance users sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.66] - 2026-04-29
+
+### Added
+- **CSV workspace role unionization**: Multiple CSV rows for the same user and workspace can now be combined into one effective workspace assignment. Built-in workspace roles collapse to the highest-privilege built-in role, while custom ABAC roles are materialized through managed union roles so all required source policy attachments are preserved.
+- **Automation-ready users sync remediation**: Authoritative single-instance sync now reports Organization Admin PAT blockers consistently when active members or pending invites cannot be managed by the destination key.
+- **Expanded users CSV examples**: Added scenario CSVs for multi-workspace roles, source-of-truth removals, and pending invites with mixed workspace role rows.
+
+### Fixed
+- **ABAC role preservation with Workspace Admin**: Workspace Admin rows no longer bypass custom ABAC role unionization when the same user also has custom roles for the same workspace.
+- **Pending invite permission handling**: 401/403 `not allowed` failures while cancelling pending invites now surface the Org Admin PAT remediation instead of falling through to an unsupported-cancel result.
+- **Authoritative pending invite reconciliation**: Pending invites with extra workspace grants are refreshed during CSV source-of-truth sync instead of being treated as valid supersets.
+- **Policy materialization safety**: Synthetic union roles are not mapped unless all required custom ABAC policy clone and attach operations succeed.
+
 ## [0.0.65] - 2026-04-21
 
 ### Added
@@ -289,7 +302,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration documentation
 - API reference for core classes
 
-[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.65...HEAD
+[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.66...HEAD
+[0.0.66]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.65...v0.0.66
 [0.0.65]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.64...v0.0.65
 [0.0.64]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.63...v0.0.64
 [0.0.63]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.62...v0.0.63

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python CLI for migrating users and roles, datasets, experiments, annotation qu
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.65-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.66-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -23,7 +23,7 @@ langsmith-migrator datasets
 
 - **All-in-One Wizard**: Interactive migration of all resources (`migrate-all`)
 - **Users & Roles**: Migrate custom roles, org members, and workspace memberships between instances
-- **Single-Instance Access Sync**: Apply CSV-driven add/update or authoritative access sync to one LangSmith instance (`users --csv ... [--sync]`)
+- **Single-Instance Access Sync**: Apply CSV-driven add/update or authoritative access sync to one LangSmith instance (`users --csv ... [--sync]`), including multi-row workspace role unionization for custom ABAC roles
 - **Datasets**: Migrate datasets with examples and file attachments
 - **Experiments**: Include experiments, runs, and feedback during dataset migration (`datasets --include-experiments`) or through `migrate-all`
 - **Annotation Queues**: Transfer queue configurations
@@ -54,20 +54,20 @@ For trace data, use LangSmith's **Bulk Export** functionality: [LangSmith Bulk E
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.65-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.66-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.65-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.66-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.65-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.66-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.65-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.66-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)
@@ -223,12 +223,23 @@ alice@example.com,Organization Admin,,
 alice@example.com,Workspace Admin,ws_src_prod_us,Production US
 ```
 
+Example CSVs:
+- `examples/users_members_example.csv`: minimal org and workspace member rows.
+- `examples/users_members_multi_workspace_roles_example.csv`: users with multiple workspace assignments, including different workspace roles.
+- `examples/users_members_sync_remove_workspace_b_example.csv`: desired-state CSV for `--csv-source-of-truth` when a user should keep Workspace A and lose Workspace B.
+- `examples/users_members_sync_remove_user_example.csv`: desired-state CSV for `--csv-source-of-truth` after a removed user has been omitted entirely.
+- `examples/users_members_pending_mixed_workspace_roles_example.csv`: pending-invite examples for same-role multi-workspace invites and mixed workspace-role rows.
+
+These examples are templates. Do not run them with `--csv-source-of-truth` against a populated target unless the file has been expanded into the full desired org and workspace access state for that target; authoritative sync removes org users, pending invites, and workspace memberships that are not listed.
+
 Notes:
 - `email` and `langsmith_role` are required.
 - `workspace_id` is optional. Leave it empty for org-level role assignments.
-- `workspace_name` is optional and informational only.
+- `workspace_name` is optional. When provided in single-instance CSV sync, it is validated against the target workspace display name, name, or tenant handle; `workspace_id` remains authoritative for applying access.
 - `langsmith_role` should be a built-in LangSmith role name (for example `Organization Admin`, `Organization Operator`, `Organization User`, `Organization Viewer`, `Workspace Admin`, `Workspace User`, or `Workspace Viewer`) or a custom role `display_name`.
+- Multiple rows for the same user and workspace are combined. Built-in workspace roles collapse to the highest-privilege built-in role; custom ABAC roles are unioned with each other and with any built-in workspace role so their policy attachments are preserved.
 - Users who only appear in workspace rows are invited to the org with the source `ORGANIZATION_USER` role before workspace membership is applied.
+- Workspace-only users with multiple workspace roles cannot have all workspace access attached to the initial org invite. The command calls this out before apply, attempts phase 3 workspace membership application, and may require a rerun after the invite is accepted on target versions that block workspace membership for pending org invites.
 - `Organization Admin` on a workspace row is treated as org-level admin access only. No explicit workspace membership is created because org admins already have workspace access.
 - Other org-scoped roles cannot be used on workspace rows. If you want org-level access, leave `workspace_id` empty.
 - Workspace-scoped roles such as `Workspace Admin` cannot be used on org-level rows.
@@ -248,6 +259,11 @@ Guardrails:
 - If the CSV contains workspace rows and `--skip-workspace-members` is set, the command fails instead of silently ignoring those rows.
 - If the CSV contains workspace-only users, the target instance must have an `ORGANIZATION_USER` role available or the command fails before applying member changes.
 - If the CSV references unknown `workspace_id` values, the command fails before any membership changes are applied.
+
+Operational notes:
+- Authoritative sync can remove active org members, cancel pending invites, and remove workspace memberships. Use an Organization Admin PAT for unattended runs that need removal semantics.
+- If the destination API key cannot manage org members or pending invites, 401/403 responses are reported as Organization Admin PAT blockers with grouped remediation and resume metadata.
+- Pending invites whose org role or workspace access does not match the CSV are refreshed when the target supports invite cancellation; if the target lacks a cancellation endpoint, the command reports an explicit manual follow-up instead of silently accepting stale access.
 
 ### CLI Options
 

--- a/examples/users_members_example.csv
+++ b/examples/users_members_example.csv
@@ -1,6 +1,6 @@
 email,langsmith_role,workspace_id,workspace_name
 amelia.nguyen@example.com,Organization Admin,,
-jordan.lee@example.com,Workspace Admin,<workspace_uuid>,Production US
-priya.patel@example.com,write-no-read,<workspace_uuid>,ML Platform
-mateo.garcia@example.com,Workspace User,<workspace_uuid>,Analytics
+jordan.lee@example.com,Workspace Admin,5025604d-c4ad-46ac-9f60-3840156ec9dc,Workspace 1
+priya.patel@example.com,write-no-read,5025604d-c4ad-46ac-9f60-3840156ec9dc,Workspace 1
+mateo.garcia@example.com,Workspace User,5025604d-c4ad-46ac-9f60-3840156ec9dc,Workspace 1
 sana.khan@example.com,Organization Viewer,,

--- a/examples/users_members_multi_workspace_roles_example.csv
+++ b/examples/users_members_multi_workspace_roles_example.csv
@@ -1,0 +1,7 @@
+email,langsmith_role,workspace_id,workspace_name
+saad@langchain.dev,Organization Admin,,
+alex.morgan@example.com,Organization User,,
+alex.morgan@example.com,Workspace Admin,812285f1-77c1-40fd-ad94-d9194c1d3a4b,Workspace A
+alex.morgan@example.com,Workspace Viewer,3e463447-7e35-4dbf-863a-fc3a19ee2c53,Workspace B
+sam.rivera@example.com,Workspace User,812285f1-77c1-40fd-ad94-d9194c1d3a4b,Workspace A
+sam.rivera@example.com,Workspace User,bd980bbb-4a80-4642-be6c-2039cbc740ac,Workspace C

--- a/examples/users_members_pending_mixed_workspace_roles_example.csv
+++ b/examples/users_members_pending_mixed_workspace_roles_example.csv
@@ -1,0 +1,6 @@
+email,langsmith_role,workspace_id,workspace_name
+saad@langchain.dev,Organization Admin,,
+pending.same-role@example.com,Workspace Admin,<workspace_a_uuid>,Workspace A
+pending.same-role@example.com,Workspace Admin,<workspace_b_uuid>,Workspace B
+pending.mixed-role@example.com,Workspace Admin,<workspace_a_uuid>,Workspace A
+pending.mixed-role@example.com,Workspace Viewer,<workspace_b_uuid>,Workspace B

--- a/examples/users_members_sync_remove_user_example.csv
+++ b/examples/users_members_sync_remove_user_example.csv
@@ -1,0 +1,3 @@
+email,langsmith_role,workspace_id,workspace_name
+saad@langchain.dev,Organization Admin,,
+remaining.user@example.com,Workspace Admin,<workspace_a_uuid>,Workspace A

--- a/examples/users_members_sync_remove_workspace_b_example.csv
+++ b/examples/users_members_sync_remove_workspace_b_example.csv
@@ -1,0 +1,3 @@
+email,langsmith_role,workspace_id,workspace_name
+saad@langchain.dev,Organization Admin,,
+user@example.com,Workspace Admin,<workspace_a_uuid>,Workspace A

--- a/langsmith_migrator/__init__.py
+++ b/langsmith_migrator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("langsmith-data-migration-tool")
 except PackageNotFoundError:
-    __version__ = "0.0.65"
+    __version__ = "0.0.66"

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -4,6 +4,7 @@ import csv
 import functools
 import logging
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
@@ -24,6 +25,10 @@ from ..core.migrators import (
     PromptMigrator,
     RulesMigrator,
     UserRoleMigrator,
+)
+from ..core.migrators.user_role import (
+    is_workspace_role_union_id,
+    select_effective_workspace_role_id,
 )
 from .tui_project_mapper import build_project_mapping_tui
 from .tui_selector import select_items
@@ -352,6 +357,7 @@ def _load_members_csv(path: str) -> list[dict]:
                 email = (row.get("email") or "").strip().lower()
                 langsmith_role = (row.get("langsmith_role") or "").strip()
                 workspace_id = (row.get("workspace_id") or "").strip()
+                workspace_name = (row.get("workspace_name") or "").strip()
 
                 if not email:
                     raise click.ClickException(
@@ -376,13 +382,14 @@ def _load_members_csv(path: str) -> list[dict]:
                         "example 'Organization User' or 'Organization Admin'."
                     )
 
-                rows.append(
-                    {
-                        "email": email,
-                        "langsmith_role": langsmith_role,
-                        "workspace_id": workspace_id,
-                    }
-                )
+                csv_row = {
+                    "email": email,
+                    "langsmith_role": langsmith_role,
+                    "workspace_id": workspace_id,
+                }
+                if workspace_name:
+                    csv_row["workspace_name"] = workspace_name
+                rows.append(csv_row)
     except click.ClickException:
         raise
     except csv.Error as e:
@@ -528,15 +535,11 @@ def _resolve_csv_role_names(
             if candidate_role_id == role_id
         )
 
-        resolved_rows.append(
-            {
-                "email": row["email"],
-                "langsmith_role": row["langsmith_role"],
-                "role_id": role_id,
-                "role_name": resolved_role_name,
-                "workspace_id": row.get("workspace_id", ""),
-            }
-        )
+        resolved_row = dict(row)
+        resolved_row["role_id"] = role_id
+        resolved_row["role_name"] = resolved_role_name
+        resolved_row["workspace_id"] = row.get("workspace_id", "")
+        resolved_rows.append(resolved_row)
 
     if ambiguous or unresolved:
         available = sorted(available_role_labels, key=str.lower)
@@ -613,6 +616,32 @@ def _normalize_csv_role_scopes(
     return normalized_rows, org_admin_workspace_rows
 
 
+def _effective_workspace_role_ids_for_rows(
+    email: str,
+    workspace_rows: list[dict],
+) -> set[str]:
+    """Return effective per-workspace role IDs for one user's workspace rows."""
+    rows_by_workspace: dict[str, list[dict]] = {}
+    for row in workspace_rows:
+        workspace_id = (row.get("workspace_id") or "").strip()
+        if workspace_id:
+            rows_by_workspace.setdefault(workspace_id, []).append(row)
+
+    effective_role_ids: set[str] = set()
+    for workspace_id, rows in rows_by_workspace.items():
+        try:
+            effective_role_id = select_effective_workspace_role_id(
+                rows,
+                email=email,
+                workspace_id=workspace_id,
+            )
+        except ValueError as e:
+            raise click.ClickException(str(e)) from e
+        if effective_role_id:
+            effective_role_ids.add(effective_role_id)
+    return effective_role_ids
+
+
 def _csv_rows_to_org_members(
     csv_rows: list[dict],
     default_org_role_id: str | None = None,
@@ -667,11 +696,10 @@ def _csv_rows_to_org_members(
             }
             if direct_workspace_invites:
                 workspace_rows = ws_rows_by_email.get(email, [])
-                workspace_role_ids = {
-                    (workspace_row.get("role_id") or "").strip()
-                    for workspace_row in workspace_rows
-                    if (workspace_row.get("role_id") or "").strip()
-                }
+                workspace_role_ids = _effective_workspace_role_ids_for_rows(
+                    email,
+                    workspace_rows,
+                )
                 if len(workspace_role_ids) == 1:
                     member["workspace_ids"] = sorted(
                         {
@@ -683,29 +711,56 @@ def _csv_rows_to_org_members(
                     member["workspace_role_id"] = next(iter(workspace_role_ids))
             members_by_email[email] = member
 
+    if direct_workspace_invites:
+        for email, workspace_rows in ws_rows_by_email.items():
+            member = members_by_email.get(email)
+            if not member:
+                continue
+            workspace_role_ids = _effective_workspace_role_ids_for_rows(
+                email,
+                workspace_rows,
+            )
+            if len(workspace_role_ids) != 1:
+                continue
+            member.setdefault(
+                "workspace_ids",
+                sorted(
+                    {
+                        workspace_row["workspace_id"]
+                        for workspace_row in workspace_rows
+                        if workspace_row.get("workspace_id")
+                    }
+                ),
+            )
+            member.setdefault("workspace_role_id", next(iter(workspace_role_ids)))
+
     return list(members_by_email.values())
 
 
 def _csv_rows_for_workspace(csv_rows: list[dict], source_workspace_id: str) -> list[dict]:
     """Build workspace member payloads for a specific source workspace."""
     rows_for_workspace = [row for row in csv_rows if row["workspace_id"] == source_workspace_id]
-    members_by_email: dict[str, dict] = {}
+    rows_by_email: dict[str, list[dict]] = {}
     for row in rows_for_workspace:
         email = row["email"]
-        existing = members_by_email.get(email)
-        if existing and existing["role_id"] != row["role_id"]:
-            raise click.ClickException(
-                "Members CSV has conflicting role_id values for "
-                f"{email} in workspace {source_workspace_id}: "
-                f"'{existing['role_id']}' vs '{row['role_id']}'"
+        rows_by_email.setdefault(email, []).append(row)
+
+    members_by_email: dict[str, dict] = {}
+    for email, rows in rows_by_email.items():
+        try:
+            role_id = select_effective_workspace_role_id(
+                rows,
+                email=email,
+                workspace_id=source_workspace_id,
             )
-        if not existing:
-            members_by_email[email] = {
-                "id": f"{source_workspace_id}:{email}",
-                "email": email,
-                "role_id": row["role_id"],
-                "full_name": "",
-            }
+        except ValueError as e:
+            raise click.ClickException(str(e)) from e
+        members_by_email[email] = {
+            "id": f"{source_workspace_id}:{email}",
+            "email": email,
+            "role_id": role_id,
+            "full_name": "",
+        }
     return list(members_by_email.values())
 
 
@@ -775,6 +830,136 @@ def _resolve_single_instance_workspace_ids(
     return sorted(workspace_ids)
 
 
+@dataclass(frozen=True)
+class SingleInstanceUsersPlan:
+    """Resolved single-instance users CSV plan."""
+
+    workspace_ids: list[str]
+    org_members: list[dict]
+    workspace_members_by_id: dict[str, list[dict]]
+    operator_notes: list[str]
+
+
+def _workspace_display_names(workspace: dict) -> list[str]:
+    """Return all stable names an operator might put in the CSV."""
+    names: list[str] = []
+    for key in ("display_name", "name", "tenant_handle"):
+        name = str(workspace.get(key) or "").strip()
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def _normalize_workspace_name_for_compare(name: str) -> str:
+    """Normalize display labels for CSV-vs-target workspace name checks."""
+    return " ".join(name.split()).casefold()
+
+
+def _validate_csv_workspace_names(
+    csv_rows: list[dict],
+    available_workspaces_by_id: dict[str, dict],
+) -> None:
+    """Validate optional workspace_name hints against known target workspaces."""
+    mismatches: list[str] = []
+    for row in csv_rows:
+        workspace_id = (row.get("workspace_id") or "").strip()
+        csv_name = (row.get("workspace_name") or "").strip()
+        if not workspace_id or not csv_name:
+            continue
+
+        workspace = available_workspaces_by_id.get(workspace_id) or {}
+        target_names = _workspace_display_names(workspace)
+        if not target_names:
+            continue
+
+        normalized_csv_name = _normalize_workspace_name_for_compare(csv_name)
+        normalized_target_names = {
+            _normalize_workspace_name_for_compare(name)
+            for name in target_names
+        }
+        if normalized_csv_name not in normalized_target_names:
+            mismatches.append(
+                f"{workspace_id}: CSV workspace_name '{csv_name}' does not match "
+                f"target workspace name '{target_names[0]}'"
+            )
+
+    if mismatches:
+        raise click.ClickException(
+            "Members CSV workspace_name mismatch: " + "; ".join(mismatches)
+        )
+
+
+def _single_instance_operator_notes(
+    csv_rows: list[dict],
+    org_members: list[dict],
+) -> list[str]:
+    """Return operator-facing notes for lossy pending-invite shapes."""
+    direct_invite_by_email = {
+        member["email"]
+        for member in org_members
+        if member.get("workspace_ids") and member.get("workspace_role_id")
+    }
+    workspace_rows_by_email: dict[str, list[dict]] = {}
+    for row in csv_rows:
+        if (row.get("workspace_id") or "").strip():
+            workspace_rows_by_email.setdefault(row["email"], []).append(row)
+
+    notes: list[str] = []
+    for email, workspace_rows in sorted(workspace_rows_by_email.items()):
+        if email in direct_invite_by_email:
+            continue
+        workspace_role_ids = {
+            (row.get("role_id") or "").strip()
+            for row in workspace_rows
+            if (row.get("role_id") or "").strip()
+        }
+        if len(workspace_role_ids) > 1:
+            notes.append(
+                f"{email} has multiple workspace roles; the initial org invite "
+                "cannot attach all workspace access in one pending invite. "
+                "Workspace membership will be applied in phase 3 when the target "
+                "accepts it; otherwise re-run after the invite is accepted."
+            )
+    return notes
+
+
+def _build_single_instance_users_plan(
+    csv_rows: list[dict],
+    *,
+    available_workspaces: list[dict],
+    default_org_role_id: str | None,
+    source_of_truth: bool,
+) -> SingleInstanceUsersPlan:
+    """Build all derived single-instance users sync inputs in one place."""
+    available_workspaces_by_id = {
+        workspace["id"]: workspace
+        for workspace in available_workspaces
+        if workspace.get("id")
+    }
+    workspace_ids = _resolve_single_instance_workspace_ids(
+        csv_rows,
+        set(available_workspaces_by_id),
+        source_of_truth=source_of_truth,
+    )
+    _validate_csv_workspace_names(csv_rows, available_workspaces_by_id)
+    org_members = _csv_rows_to_org_members(
+        csv_rows,
+        default_org_role_id=default_org_role_id,
+        direct_workspace_invites=True,
+    )
+    workspace_members_by_id = {
+        workspace_id: _csv_rows_for_workspace(csv_rows, workspace_id)
+        for workspace_id in workspace_ids
+    }
+
+    return SingleInstanceUsersPlan(
+        workspace_ids=workspace_ids,
+        org_members=org_members,
+        workspace_members_by_id=workspace_members_by_id,
+        operator_notes=_single_instance_operator_notes(csv_rows, org_members),
+    )
+
+
 def _print_single_instance_users_summary(
     config: Config,
     *,
@@ -782,6 +967,7 @@ def _print_single_instance_users_summary(
     workspace_ids: list[str],
     csv_source_of_truth: bool,
     skip_workspace_members: bool,
+    operator_notes: list[str] | None = None,
 ) -> None:
     """Print a concise, high-signal summary for single-instance CSV sync runs."""
     org_rows = sum(1 for row in csv_rows if not row.get("workspace_id"))
@@ -808,8 +994,14 @@ def _print_single_instance_users_summary(
         console.print(
             f"  Workspace access: direct target workspace IDs from CSV ({len(workspace_ids)} workspace(s) in scope)"
         )
+        console.print(
+            "  Missing CSV rows: preserved "
+            "(workspace memberships missing from the CSV will be preserved)"
+        )
     else:
         console.print("  Workspace access: no workspace rows in the CSV")
+    for note in operator_notes or []:
+        console.print(f"  [yellow]Note:[/yellow] {note}")
 
 
 def _workspace_scope_key(orchestrator) -> str:
@@ -821,9 +1013,9 @@ def _workspace_scope_key(orchestrator) -> str:
 
 
 def _probe_lookup_capability(client, endpoint: str) -> tuple[bool, str]:
-    """Probe a paginated lookup endpoint without mutating state."""
+    """Probe a lookup endpoint without mutating state or exhausting pagination."""
     try:
-        list(client.get_paginated(endpoint, page_size=1))
+        client.get(endpoint, params={"limit": 1})
         return True, "ok"
     except Exception as e:  # noqa: BLE001
         return False, str(e)
@@ -834,6 +1026,7 @@ def _run_preflight(orchestrator, config: Config, resources: Iterable[str]) -> No
     state = _ensure_migration_session(orchestrator, config)
     scope_key = _workspace_scope_key(orchestrator)
     resource_list = sorted(set(resources))
+    resource_set = set(resource_list)
     workspace_pair = _active_workspace_pair(orchestrator)
 
     state.record_inventory(
@@ -868,10 +1061,13 @@ def _run_preflight(orchestrator, config: Config, resources: Iterable[str]) -> No
         probe="workspace_discovery",
     )
 
-    for label, endpoint in (
-        ("project_lookup", "/sessions"),
-        ("dataset_lookup", "/datasets"),
-    ):
+    lookup_probes = []
+    if {"experiments", "runs", "feedback", "rules", "charts"} & resource_set:
+        lookup_probes.append(("project_lookup", "/sessions"))
+    if {"datasets", "experiments", "rules"} & resource_set:
+        lookup_probes.append(("dataset_lookup", "/datasets"))
+
+    for label, endpoint in lookup_probes:
         source_supported, source_detail = _probe_lookup_capability(orchestrator.source_client, endpoint)
         dest_supported, dest_detail = _probe_lookup_capability(orchestrator.dest_client, endpoint)
         state.record_capability(
@@ -889,6 +1085,13 @@ def _run_preflight(orchestrator, config: Config, resources: Iterable[str]) -> No
             probe=f"GET {endpoint}",
         )
 
+    if "users" in resource_list:
+        UserRoleMigrator(
+            orchestrator.source_client,
+            orchestrator.dest_client,
+            state,
+            config,
+        ).probe_capabilities()
     if "prompts" in resource_list or "rules" in resource_list:
         PromptMigrator(
             orchestrator.source_client,
@@ -1590,14 +1793,10 @@ def users(
         orchestrator.cleanup()
         return
 
-    available_workspace_ids: set[str] = set()
+    available_workspaces: list[dict] = []
     ws_result = None
     if single_instance:
-        available_workspace_ids = {
-            ws.get("id", "")
-            for ws in _list_workspaces(orchestrator.dest_client)
-            if ws.get("id")
-        }
+        available_workspaces = _list_workspaces(orchestrator.dest_client)
         ws_pairs = [(None, None)]
     else:
         # Resolve workspace context (needed for phase 3)
@@ -1630,6 +1829,16 @@ def users(
     )
 
     _run_preflight(orchestrator, config, ["users"])
+    if csv_source_of_truth:
+        try:
+            user_role_migrator.require_destination_org_admin_for_authoritative_sync()
+        except Exception as e:  # noqa: BLE001
+            console.print(
+                "  [red]Failed to verify destination org-member management "
+                f"permissions: {e}[/red]"
+            )
+            orchestrator.cleanup()
+            ctx.exit(1)
 
     # ── Phase 1: Role synchronisation ──
     console.print("\n[bold]Phase 1: Synchronising roles...[/bold]")
@@ -1684,6 +1893,7 @@ def users(
     default_org_role_id: str | None = None
     ws_only_emails: set[str] = set()
     org_admin_workspace_row_count = 0
+    single_instance_plan: SingleInstanceUsersPlan | None = None
 
     if csv_member_rows is not None:
         source_roles = user_role_migrator.list_source_roles()
@@ -1713,12 +1923,16 @@ def users(
                 )
 
         if single_instance:
-            workspace_ids = _resolve_single_instance_workspace_ids(
+            single_instance_plan = _build_single_instance_users_plan(
                 csv_member_rows,
-                available_workspace_ids,
+                available_workspaces=available_workspaces,
+                default_org_role_id=default_org_role_id,
                 source_of_truth=csv_source_of_truth,
             )
-            ws_pairs = [(workspace_id, workspace_id) for workspace_id in workspace_ids]
+            ws_pairs = [
+                (workspace_id, workspace_id)
+                for workspace_id in single_instance_plan.workspace_ids
+            ]
 
         if org_admin_workspace_row_count:
             console.print(
@@ -1734,6 +1948,9 @@ def users(
             workspace_ids=[dst_ws for _, dst_ws in ws_pairs if dst_ws],
             csv_source_of_truth=csv_source_of_truth,
             skip_workspace_members=skip_workspace_members,
+            operator_notes=single_instance_plan.operator_notes
+            if single_instance_plan is not None
+            else [],
         )
         confirm_prompt = (
             "Proceed with authoritative single-instance CSV sync? This will "
@@ -1755,7 +1972,9 @@ def users(
     # ── Phase 2: Org member migration ──
     console.print("\n[bold]Phase 2: Migrating organisation members...[/bold]")
 
-    if csv_member_rows is not None:
+    if single_instance_plan is not None:
+        all_members = single_instance_plan.org_members
+    elif csv_member_rows is not None:
         all_members = _csv_rows_to_org_members(
             csv_member_rows,
             default_org_role_id=default_org_role_id,
@@ -1791,19 +2010,39 @@ def users(
                 )
                 if role_id and role_id not in role_mapping
             }
-            if needed_role_ids:
+            needed_union_role_ids = {
+                role_id
+                for role_id in needed_role_ids
+                if is_workspace_role_union_id(role_id)
+            }
+            needed_regular_role_ids = needed_role_ids - needed_union_role_ids
+            if needed_regular_role_ids:
                 console.print(
-                    f"  Syncing {len(needed_role_ids)} additional role(s) needed by selected members..."
+                    f"  Syncing {len(needed_regular_role_ids)} additional role(s) needed by selected members..."
                 )
                 try:
                     role_mapping.update(
                         user_role_migrator.build_role_mapping(
-                            custom_role_ids=needed_role_ids,
+                            custom_role_ids=needed_regular_role_ids,
                         )
                     )
                 except Exception as e:
                     console.print(
                         f"  [yellow]Warning: failed to sync some roles: {e}[/yellow]"
+                    )
+            if needed_union_role_ids:
+                console.print(
+                    f"  Creating {len(needed_union_role_ids)} managed workspace role union(s)..."
+                )
+                try:
+                    role_mapping.update(
+                        user_role_migrator.materialize_workspace_role_unions(
+                            needed_union_role_ids,
+                        )
+                    )
+                except Exception as e:
+                    console.print(
+                        f"  [yellow]Warning: failed to create workspace role union(s): {e}[/yellow]"
                     )
 
             migrated, skipped, failed = user_role_migrator.migrate_org_members(
@@ -1844,7 +2083,9 @@ def users(
                 orchestrator.set_workspace_context(src_ws, dst_ws)
                 console.print(f"\n  [cyan]Workspace: {src_ws} -> {dst_ws}[/cyan]")
 
-                if csv_member_rows is not None:
+                if single_instance_plan is not None:
+                    ws_members = single_instance_plan.workspace_members_by_id.get(src_ws, [])
+                elif csv_member_rows is not None:
                     ws_members = _csv_rows_for_workspace(csv_member_rows, src_ws)
                 else:
                     ws_members = user_role_migrator.list_source_workspace_members()
@@ -1873,21 +2114,45 @@ def users(
                     if (role_id := (member.get("role_id") or "").strip())
                     and role_id not in role_mapping
                 }
-                if needed_workspace_role_ids:
+                needed_workspace_union_role_ids = {
+                    role_id
+                    for role_id in needed_workspace_role_ids
+                    if is_workspace_role_union_id(role_id)
+                }
+                needed_regular_workspace_role_ids = (
+                    needed_workspace_role_ids - needed_workspace_union_role_ids
+                )
+                if needed_regular_workspace_role_ids:
                     console.print(
                         "    "
-                        f"Syncing {len(needed_workspace_role_ids)} additional role(s) needed by selected workspace members..."
+                        f"Syncing {len(needed_regular_workspace_role_ids)} additional role(s) needed by selected workspace members..."
                     )
                     try:
                         role_mapping.update(
                             user_role_migrator.build_role_mapping(
-                                custom_role_ids=needed_workspace_role_ids,
+                                custom_role_ids=needed_regular_workspace_role_ids,
                             )
                         )
                     except Exception as e:
                         console.print(
                             "    [yellow]Warning: failed to sync some workspace "
                             f"roles: {e}[/yellow]"
+                        )
+                if needed_workspace_union_role_ids:
+                    console.print(
+                        "    "
+                        f"Creating {len(needed_workspace_union_role_ids)} managed workspace role union(s)..."
+                    )
+                    try:
+                        role_mapping.update(
+                            user_role_migrator.materialize_workspace_role_unions(
+                                needed_workspace_union_role_ids,
+                            )
+                        )
+                    except Exception as e:
+                        console.print(
+                            "    [yellow]Warning: failed to create workspace role "
+                            f"union(s): {e}[/yellow]"
                         )
 
                 try:

--- a/langsmith_migrator/core/migrators/user_role.py
+++ b/langsmith_migrator/core/migrators/user_role.py
@@ -1,9 +1,161 @@
 """User and role migration logic."""
 
+import hashlib
+import json
 from typing import Any, Dict, List, Optional, Tuple
 
 from .base import BaseMigrator
 from ...utils.retry import APIError, AuthenticationError, ConflictError
+
+
+WORKSPACE_ROLE_UNION_PREFIX = "union::workspace::"
+WORKSPACE_ROLE_UNION_DISPLAY_PREFIX = "LangSmith Migrator Union"
+WORKSPACE_ROLE_PRECEDENCE = {
+    "WORKSPACE_VIEWER": 10,
+    "WORKSPACE_USER": 20,
+    "WORKSPACE_EDITOR": 20,
+    "WORKSPACE_ADMIN": 30,
+}
+ORG_MEMBER_MANAGEMENT_CAPABILITY = "org_member_management"
+ORG_ADMIN_PAT_REQUIRED_CODE = "dest_org_admin_pat_required"
+ORG_ADMIN_PAT_NEXT_ACTION = (
+    "Retry with an Organization Admin PAT for the destination organization, "
+    "or perform the org member or pending invite change manually and re-run "
+    "`langsmith-migrator users`."
+)
+
+
+def make_workspace_role_union_id(role_ids: set[str]) -> str:
+    """Return a stable synthetic role ID for a set of source workspace role IDs."""
+    normalized = sorted({role_id.strip() for role_id in role_ids if role_id.strip()})
+    return WORKSPACE_ROLE_UNION_PREFIX + ",".join(normalized)
+
+
+def is_workspace_role_union_id(role_id: str | None) -> bool:
+    """Return whether *role_id* is a synthetic workspace role union ID."""
+    return bool(role_id and role_id.startswith(WORKSPACE_ROLE_UNION_PREFIX))
+
+
+def parse_workspace_role_union_id(role_id: str) -> set[str]:
+    """Return source role IDs embedded in a synthetic workspace role union ID."""
+    if not is_workspace_role_union_id(role_id):
+        return set()
+    encoded = role_id[len(WORKSPACE_ROLE_UNION_PREFIX):]
+    return {part for part in encoded.split(",") if part}
+
+
+def is_org_member_management_permission_error(error: BaseException) -> bool:
+    """Return whether an API error looks like missing org-member management access."""
+    status_code = getattr(error, "status_code", None)
+    return isinstance(error, AuthenticationError) or status_code in {401, 403}
+
+
+def is_member_absent_error(error: BaseException) -> bool:
+    """Return whether a member mutation error means the member is already absent."""
+    status_code = getattr(error, "status_code", None)
+    message = str(error).lower()
+    return status_code == 404 or "not found" in message
+
+
+def org_admin_pat_required_message(operation: str, error: BaseException) -> str:
+    """Build a consistent org-admin PAT requirement message."""
+    return (
+        f"{operation} requires an Organization Admin PAT on the destination "
+        "organization. The current destination API key does not appear to be "
+        f"allowed to manage organization members or pending invites. Original "
+        f"error: {error}"
+    )
+
+
+def org_admin_pat_required_evidence(
+    operation: str,
+    error: BaseException,
+) -> Dict[str, Any]:
+    """Build evidence payload for org-member permission failures."""
+    return {
+        "operation": operation,
+        "status_code": getattr(error, "status_code", None),
+        "error": str(error),
+        "requires_org_admin_pat": True,
+    }
+
+
+def select_effective_workspace_role_id(
+    rows: List[Dict[str, Any]],
+    *,
+    email: str,
+    workspace_id: str,
+) -> str:
+    """Collapse one user's CSV rows for a workspace to one effective role ID."""
+    role_rows = [
+        row
+        for row in rows
+        if (row.get("role_id") or "").strip()
+    ]
+    role_ids = {
+        (row.get("role_id") or "").strip()
+        for row in role_rows
+        if (row.get("role_id") or "").strip()
+    }
+    if not role_ids:
+        return ""
+    if len(role_ids) == 1:
+        return next(iter(role_ids))
+
+    custom_role_ids = {
+        (row.get("role_id") or "").strip()
+        for row in role_rows
+        if (row.get("role_name") or "").strip().upper() == "CUSTOM"
+    }
+    builtin_rows = [
+        row
+        for row in role_rows
+        if (row.get("role_name") or "").strip().upper() in WORKSPACE_ROLE_PRECEDENCE
+    ]
+    unknown_role_labels = sorted(
+        {
+            row.get("role_name") or row.get("langsmith_role") or row.get("role_id") or "<unknown>"
+            for row in role_rows
+            if (
+                (row.get("role_name") or "").strip().upper() not in WORKSPACE_ROLE_PRECEDENCE
+                and (row.get("role_name") or "").strip().upper() != "CUSTOM"
+            )
+        },
+        key=str.lower,
+    )
+    if unknown_role_labels:
+        raise ValueError(
+            "Members CSV has unsupported workspace role type(s) for "
+            f"{email} in workspace {workspace_id}: "
+            + ", ".join(unknown_role_labels)
+        )
+
+    if custom_role_ids:
+        union_role_ids = set(custom_role_ids)
+        union_role_ids.update(
+            (row.get("role_id") or "").strip()
+            for row in builtin_rows
+            if (row.get("role_id") or "").strip()
+        )
+        if len(union_role_ids) == 1:
+            return next(iter(union_role_ids))
+        return make_workspace_role_union_id(union_role_ids)
+
+    admin_role_ids = {
+        (row.get("role_id") or "").strip()
+        for row in role_rows
+        if (row.get("role_name") or "").strip().upper() == "WORKSPACE_ADMIN"
+    }
+    if admin_role_ids:
+        return sorted(admin_role_ids)[0]
+
+    best_row = max(
+        builtin_rows,
+        key=lambda row: WORKSPACE_ROLE_PRECEDENCE[
+            (row.get("role_name") or "").strip().upper()
+        ],
+    )
+    return (best_row.get("role_id") or "").strip()
 
 
 class UserRoleMigrator(BaseMigrator):
@@ -23,6 +175,8 @@ class UserRoleMigrator(BaseMigrator):
         self._dest_email_to_identity: Optional[Dict[str, Dict[str, Any]]] = None
         self._pending_org_email_to_identity: Dict[str, Dict[str, Any]] = {}
         self._pending_workspace_invites: set[tuple[str, str]] = set()
+        self._pending_org_blockers: Dict[str, Dict[str, Any]] = {}
+        self._pending_org_invite_wait_reported: set[str] = set()
         self._last_org_member_removals = 0
         self._last_workspace_member_removals = 0
 
@@ -69,6 +223,65 @@ class UserRoleMigrator(BaseMigrator):
             if isinstance(member, dict):
                 members.append(member)
         return members
+
+    def require_destination_org_admin_for_authoritative_sync(self) -> None:
+        """Fail fast when authoritative sync cannot read org-member state.
+
+        ``--csv-source-of-truth`` can remove active members and cancel pending
+        invites, so a non-admin PAT cannot safely provide the requested
+        semantics. There is no safe read-only delete probe; this verifies the
+        read side up front and write failures still report the same PAT hint.
+        """
+        probes = [
+            (
+                "Listing active organization members for authoritative users sync",
+                "/orgs/current/members/active",
+            ),
+            (
+                "Listing pending organization invites for authoritative users sync",
+                "/orgs/current/members/pending",
+            ),
+        ]
+        for operation, endpoint in probes:
+            try:
+                self.dest.get(endpoint, params={"limit": 1})
+            except (AuthenticationError, APIError) as e:
+                if is_org_member_management_permission_error(e):
+                    message = org_admin_pat_required_message(operation, e)
+                    evidence = {
+                        "endpoint": endpoint,
+                        **org_admin_pat_required_evidence(operation, e),
+                    }
+                    self.record_capability(
+                        "dest",
+                        ORG_MEMBER_MANAGEMENT_CAPABILITY,
+                        supported=False,
+                        detail=message,
+                        evidence=evidence,
+                        probe=f"GET {endpoint}?limit=1",
+                    )
+                    self.record_issue(
+                        "capability",
+                        ORG_ADMIN_PAT_REQUIRED_CODE,
+                        message,
+                        next_action=ORG_ADMIN_PAT_NEXT_ACTION,
+                        evidence=evidence,
+                    )
+                    raise APIError(
+                        message,
+                        status_code=getattr(e, "status_code", None),
+                        request_info=getattr(e, "request_info", None),
+                    ) from e
+                raise
+
+        self.record_capability(
+            "dest",
+            ORG_MEMBER_MANAGEMENT_CAPABILITY,
+            supported=True,
+            detail="Active and pending org-member list probes succeeded",
+            evidence={"endpoints": [endpoint for _, endpoint in probes]},
+            probe="GET /orgs/current/members/{active,pending}?limit=1",
+        )
 
     def list_source_workspace_members(self) -> List[Dict[str, Any]]:
         """Fetch active workspace members from source (requires X-Tenant-Id)."""
@@ -152,6 +365,119 @@ class UserRoleMigrator(BaseMigrator):
         return [
             role for role in self.list_source_roles() if role.get("name") == "CUSTOM"
         ]
+
+    def list_source_access_policies(self) -> List[Dict[str, Any]]:
+        """Fetch ABAC access policies from the source organisation when supported."""
+        return self._list_access_policies(self.source)
+
+    def list_dest_access_policies(self) -> List[Dict[str, Any]]:
+        """Fetch ABAC access policies from the destination organisation when supported."""
+        return self._list_access_policies(self.dest)
+
+    def materialize_workspace_role_unions(
+        self,
+        union_role_ids: set[str],
+    ) -> Dict[str, str]:
+        """Create/reuse managed destination roles for synthetic workspace role unions."""
+        requested_union_ids = {
+            role_id
+            for role_id in union_role_ids
+            if is_workspace_role_union_id(role_id)
+        }
+        if not requested_union_ids:
+            return {}
+
+        source_roles = self.list_source_roles()
+        dest_roles = self.list_dest_roles()
+        source_role_by_id = {
+            role["id"]: role
+            for role in source_roles
+            if role.get("id")
+        }
+        dest_by_display = {
+            role.get("display_name", ""): role
+            for role in dest_roles
+            if role.get("name") == "CUSTOM"
+        }
+        source_policies = self.list_source_access_policies()
+        dest_policies = self.list_dest_access_policies()
+
+        mapping: Dict[str, str] = {}
+        for union_role_id in sorted(requested_union_ids):
+            source_role_ids = parse_workspace_role_union_id(union_role_id)
+            source_union_roles = [
+                source_role_by_id[role_id]
+                for role_id in sorted(source_role_ids)
+                if role_id in source_role_by_id
+            ]
+            missing_role_ids = source_role_ids - {
+                role["id"] for role in source_union_roles
+            }
+            if missing_role_ids:
+                raise APIError(
+                    "Cannot create workspace role union because source role "
+                    f"metadata is missing for: {', '.join(sorted(missing_role_ids))}",
+                    request_info={},
+                )
+
+            union_role = self._build_workspace_union_role(
+                union_role_id,
+                source_union_roles,
+            )
+            display_name = union_role["display_name"]
+            existing = dest_by_display.get(display_name)
+            if existing:
+                dest_role_id = existing["id"]
+                self.log(f"Reused managed workspace role union {display_name}")
+                if self.config.migration.skip_existing:
+                    self.log(f"Workspace role union '{display_name}' exists, skipping")
+                    mapping[union_role_id] = dest_role_id
+                    continue
+
+                if set(existing.get("permissions", [])) != set(union_role["permissions"]):
+                    if not self._update_custom_role(dest_role_id, union_role):
+                        self.log(
+                            f"Workspace role union '{display_name}' mapped but "
+                            "permissions may be stale",
+                            "warning",
+                        )
+                else:
+                    self.log(f"Workspace role union '{display_name}' already up to date")
+            else:
+                dest_role_id = self._create_custom_role(union_role)
+                if not dest_role_id:
+                    raise APIError(
+                        f"Failed to create workspace role union '{display_name}'",
+                        request_info={},
+                    )
+                self.log(
+                    f"Created managed workspace role union {display_name}",
+                    "success",
+                )
+                dest_by_display[display_name] = {
+                    **union_role,
+                    "id": dest_role_id,
+                    "name": "CUSTOM",
+                }
+
+            self._attach_union_access_policies(
+                source_role_ids,
+                dest_role_id,
+                source_policies,
+                dest_policies,
+                union_role_hash=self._workspace_union_hash(source_role_ids),
+            )
+            mapping[union_role_id] = dest_role_id
+            self.log(
+                f"Resolved workspace role union {union_role_id} -> {dest_role_id}"
+            )
+
+        self._role_id_map.update(mapping)
+        if self.state:
+            for src_id, dst_id in mapping.items():
+                self.state.set_mapped_id("roles", src_id, dst_id)
+            self.persist_state()
+        return mapping
 
     def _match_builtin_roles(
         self,
@@ -297,9 +623,418 @@ class UserRoleMigrator(BaseMigrator):
             )
             return False
 
+    def _platform_url(self, client, endpoint: str) -> str:
+        """Return an absolute platform API URL for clients based at /api/v1."""
+        base_url = getattr(client, "base_url", "").rstrip("/")
+        for suffix in ("/api/v1", "/api/v2"):
+            if base_url.endswith(suffix):
+                base_url = base_url[: -len(suffix)]
+                break
+        return f"{base_url}{endpoint}"
+
+    def _list_access_policies(self, client) -> List[Dict[str, Any]]:
+        """List ABAC access policies, returning [] when the endpoint is unsupported."""
+        endpoint = self._platform_url(
+            client,
+            "/v1/platform/orgs/current/access-policies",
+        )
+        try:
+            response = client.get(endpoint)
+        except APIError as e:
+            if getattr(e, "status_code", None) == 404:
+                self.log("ABAC access policy API is not available", "info")
+                return []
+            raise
+        if isinstance(response, dict):
+            policies = response.get("access_policies", [])
+            return policies if isinstance(policies, list) else []
+        if isinstance(response, list):
+            return response
+        return []
+
+    def _workspace_union_hash(self, source_role_ids: set[str]) -> str:
+        """Return a short stable hash for a synthetic workspace role union."""
+        encoded = json.dumps(sorted(source_role_ids), separators=(",", ":"))
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()[:12]
+
+    def _build_workspace_union_role(
+        self,
+        union_role_id: str,
+        source_roles: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Build the managed custom role payload for a workspace role union."""
+        source_role_ids = parse_workspace_role_union_id(union_role_id)
+        union_hash = self._workspace_union_hash(source_role_ids)
+        has_custom_role = any(role.get("name") == "CUSTOM" for role in source_roles)
+        builtin_roles_without_permissions = [
+            role
+            for role in source_roles
+            if (
+                has_custom_role
+                and role.get("name") in WORKSPACE_ROLE_PRECEDENCE
+                and not role.get("permissions")
+            )
+        ]
+        if builtin_roles_without_permissions:
+            labels = [
+                role.get("display_name") or role.get("name") or role["id"]
+                for role in builtin_roles_without_permissions
+            ]
+            raise APIError(
+                "Cannot create workspace role union because built-in role "
+                "permissions were not exposed by the roles API for: "
+                + ", ".join(sorted(labels)),
+                request_info={},
+            )
+        source_labels = [
+            f"{role.get('display_name') or role.get('name') or role['id']} ({role['id']})"
+            for role in source_roles
+        ]
+        permissions = sorted(
+            {
+                permission
+                for role in source_roles
+                for permission in (role.get("permissions") or [])
+                if permission
+            }
+        )
+        return {
+            "id": union_role_id,
+            "name": "CUSTOM",
+            "display_name": f"{WORKSPACE_ROLE_UNION_DISPLAY_PREFIX} {union_hash}",
+            "description": (
+                "Managed by langsmith-migrator. Union of source workspace roles: "
+                + "; ".join(source_labels)
+            ),
+            "permissions": permissions,
+        }
+
+    def _access_policy_signature(self, policy: Dict[str, Any]) -> str:
+        """Return a stable signature for policy equivalence across instances."""
+        payload = {
+            "name": policy.get("name") or "",
+            "description": policy.get("description") or "",
+            "effect": policy.get("effect") or "",
+            "condition_groups": policy.get("condition_groups") or [],
+        }
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+    def _access_policy_payload(
+        self,
+        policy: Dict[str, Any],
+        *,
+        role_ids: List[str],
+        fallback_name: str | None = None,
+    ) -> Dict[str, Any]:
+        """Build the create payload for an ABAC access policy clone."""
+        return {
+            "name": fallback_name or policy.get("name") or "Migrated access policy",
+            "description": policy.get("description") or "",
+            "effect": policy.get("effect") or "",
+            "condition_groups": policy.get("condition_groups") or [],
+            "role_ids": role_ids,
+        }
+
+    def _managed_union_policy_name(
+        self,
+        policy: Dict[str, Any],
+        *,
+        union_role_hash: str,
+    ) -> str:
+        """Return the deterministic managed fallback name for a cloned policy."""
+        return (
+            f"{WORKSPACE_ROLE_UNION_DISPLAY_PREFIX} {union_role_hash}: "
+            f"{policy.get('name') or policy.get('id') or 'policy'}"
+        )
+
+    def _attach_union_access_policies(
+        self,
+        source_role_ids: set[str],
+        dest_role_id: str,
+        source_policies: List[Dict[str, Any]],
+        dest_policies: List[Dict[str, Any]],
+        *,
+        union_role_hash: str,
+    ) -> None:
+        """Clone or attach ABAC policies that apply to any source role in a union."""
+        relevant_policies = [
+            policy
+            for policy in source_policies
+            if source_role_ids.intersection(set(policy.get("role_ids") or []))
+        ]
+        if not relevant_policies:
+            return
+
+        dest_by_id = {
+            policy.get("id"): policy
+            for policy in dest_policies
+            if policy.get("id")
+        }
+        dest_by_signature = {
+            self._access_policy_signature(policy): policy
+            for policy in dest_policies
+        }
+        dest_by_name = {
+            policy.get("name"): policy
+            for policy in dest_policies
+            if policy.get("name")
+        }
+
+        for source_policy in relevant_policies:
+            dest_policy = dest_by_id.get(source_policy.get("id"))
+            if not dest_policy:
+                dest_policy = dest_by_signature.get(
+                    self._access_policy_signature(source_policy)
+                )
+            if not dest_policy:
+                dest_policy = dest_by_name.get(
+                    self._managed_union_policy_name(
+                        source_policy,
+                        union_role_hash=union_role_hash,
+                    )
+                )
+
+            if not dest_policy:
+                dest_policy = self._create_access_policy_clone(
+                    source_policy,
+                    dest_role_id,
+                    union_role_hash=union_role_hash,
+                )
+                if not dest_policy:
+                    raise APIError(
+                        "Failed to create destination access policy for "
+                        f"workspace role union {union_role_hash}",
+                        request_info={},
+                    )
+                dest_policies.append(dest_policy)
+                dest_by_id[dest_policy["id"]] = dest_policy
+                dest_by_signature[
+                    self._access_policy_signature(dest_policy)
+                ] = dest_policy
+                dest_by_name[dest_policy["name"]] = dest_policy
+                continue
+
+            attached_role_ids = {
+                role_id for role_id in (dest_policy.get("role_ids") or []) if role_id
+            }
+            if dest_role_id in attached_role_ids:
+                continue
+            self._attach_access_policy_to_role(dest_policy["id"], dest_role_id)
+            dest_policy["role_ids"] = sorted(attached_role_ids | {dest_role_id})
+
+    def _create_access_policy_clone(
+        self,
+        source_policy: Dict[str, Any],
+        dest_role_id: str,
+        *,
+        union_role_hash: str,
+    ) -> Dict[str, Any]:
+        """Create a destination ABAC access policy equivalent to a source policy."""
+        endpoint = self._platform_url(
+            self.dest,
+            "/v1/platform/orgs/current/access-policies",
+        )
+        payload = self._access_policy_payload(
+            source_policy,
+            role_ids=[dest_role_id],
+        )
+        try:
+            response = self.dest.post(endpoint, payload)
+        except ConflictError:
+            managed_name = self._managed_union_policy_name(
+                source_policy,
+                union_role_hash=union_role_hash,
+            )
+            payload = self._access_policy_payload(
+                source_policy,
+                role_ids=[dest_role_id],
+                fallback_name=managed_name,
+            )
+            try:
+                response = self.dest.post(endpoint, payload)
+            except ConflictError as e:
+                self.log(
+                    f"Access policy '{managed_name}' already exists but could not "
+                    "be matched for attachment",
+                    "error",
+                )
+                self.record_issue(
+                    "capability",
+                    "access_policy_create_conflict",
+                    (
+                        f"Access policy '{managed_name}' already exists but could "
+                        "not be matched for attachment"
+                    ),
+                    evidence={"policy": source_policy, "error": str(e)},
+                )
+                raise
+        except APIError as e:
+            self.log(
+                f"Failed to create access policy '{source_policy.get('name')}': {e}",
+                "error",
+            )
+            self.record_issue(
+                "capability",
+                "access_policy_create_failed",
+                f"Failed to create access policy '{source_policy.get('name')}': {e}",
+                evidence={"policy": source_policy, "error": str(e)},
+            )
+            raise
+
+        policy_id = response.get("id") if isinstance(response, dict) else None
+        if not policy_id:
+            self.record_issue(
+                "data_integrity",
+                "access_policy_create_missing_id",
+                "Access policy create response did not include an id",
+                evidence={"policy": source_policy, "response": response},
+            )
+            raise APIError(
+                "Access policy create response did not include an id",
+                request_info={"response": response},
+            )
+        self.log(f"Created access policy: {payload['name']}", "success")
+        return {
+            **payload,
+            "id": policy_id,
+        }
+
+    def _attach_access_policy_to_role(
+        self,
+        access_policy_id: str,
+        dest_role_id: str,
+    ) -> None:
+        """Attach an existing destination ABAC access policy to a destination role."""
+        endpoint = self._platform_url(
+            self.dest,
+            f"/v1/platform/orgs/current/access-policies/roles/{dest_role_id}/access-policies",
+        )
+        try:
+            self.dest.post(
+                endpoint,
+                {"access_policy_ids": [access_policy_id]},
+            )
+            self.log(
+                f"Attached access policy {access_policy_id} to role {dest_role_id}",
+                "success",
+            )
+        except APIError as e:
+            self.log(
+                f"Failed to attach access policy {access_policy_id}: {e}",
+                "error",
+            )
+            self.record_issue(
+                "capability",
+                "access_policy_attach_failed",
+                f"Failed to attach access policy {access_policy_id}: {e}",
+                evidence={
+                    "access_policy_id": access_policy_id,
+                    "dest_role_id": dest_role_id,
+                    "error": str(e),
+                },
+            )
+            raise
+
     # ------------------------------------------------------------------
     # Phase 2: organisation member migration
     # ------------------------------------------------------------------
+
+    def _org_member_failure_context(
+        self,
+        *,
+        email: str,
+        error: BaseException,
+        operation: str,
+        fallback_next_action: str,
+    ) -> tuple[str, Dict[str, Any]]:
+        """Return remediation text/evidence for org-member mutation failures."""
+        evidence: Dict[str, Any] = {"email": email, "error": str(error)}
+        if is_org_member_management_permission_error(error):
+            evidence.update(org_admin_pat_required_evidence(operation, error))
+            return ORG_ADMIN_PAT_NEXT_ACTION, evidence
+        return fallback_next_action, evidence
+
+    def _pending_invite_evidence(
+        self,
+        *,
+        email: str,
+        pending_member: Dict[str, Any],
+        desired_org_role_id: Optional[str],
+        desired_workspace_ids: List[str],
+        desired_workspace_role_id: Optional[str],
+        desired_workspace_access_representable: bool = True,
+        error: Optional[BaseException] = None,
+    ) -> Dict[str, Any]:
+        """Return structured evidence for pending invite reconciliation."""
+        evidence: Dict[str, Any] = {
+            "email": email,
+            "existing_pending_invite_id": pending_member.get("id"),
+            "existing_org_role_id": pending_member.get("role_id"),
+            "existing_workspace_ids": sorted(
+                workspace_id
+                for workspace_id in (pending_member.get("workspace_ids") or [])
+                if workspace_id
+            ),
+            "existing_workspace_role_id": (
+                (pending_member.get("workspace_role_id") or "").strip() or None
+            ),
+            "desired_org_role_id": desired_org_role_id,
+            "desired_workspace_ids": sorted(
+                workspace_id for workspace_id in desired_workspace_ids if workspace_id
+            ),
+            "desired_workspace_role_id": desired_workspace_role_id,
+            "desired_workspace_access_representable": (
+                desired_workspace_access_representable
+            ),
+        }
+        if error is not None:
+            evidence.update(
+                {
+                    "error": str(error),
+                    "status_code": getattr(error, "status_code", None),
+                    "request_info": getattr(error, "request_info", None),
+                }
+            )
+        return evidence
+
+    def _mark_pending_org_blocked(
+        self,
+        *,
+        email: str,
+        item_id: str,
+        code: str,
+        next_action: str,
+        evidence: Dict[str, Any],
+    ) -> None:
+        """Mark an org pending-invite blocker and expose it to workspace phase."""
+        self._pending_org_blockers[email] = {
+            "item_id": item_id,
+            "code": code,
+            "next_action": next_action,
+            "evidence": evidence,
+        }
+        self.mark_blocked(
+            item_id,
+            code,
+            next_action=next_action,
+            evidence=evidence,
+        )
+
+    def _log_pending_invite_workspace_payload(
+        self,
+        *,
+        email: str,
+        workspace_ids: List[str],
+        workspace_role_id: Optional[str],
+    ) -> None:
+        """Log the workspace access that can be embedded in an org invite."""
+        if not workspace_ids or not workspace_role_id:
+            return
+        self.log(
+            "Pending invite for "
+            f"{email} will include workspace access: {len(workspace_ids)} "
+            f"workspaces with role {workspace_role_id}"
+        )
 
     def migrate_org_members(
         self,
@@ -427,13 +1162,19 @@ class UserRoleMigrator(BaseMigrator):
                             f"Failed to update role for '{email}': {e}",
                             "error",
                         )
-                        self.mark_blocked(
-                            item_id, "org_member_role_update_failed",
-                            next_action=(
+                        next_action, evidence = self._org_member_failure_context(
+                            email=email,
+                            error=e,
+                            operation="Updating an organization member role",
+                            fallback_next_action=(
                                 "Review the org role update error in the remediation "
                                 "bundle, then re-run `langsmith-migrator users`."
                             ),
-                            evidence={"email": email, "error": str(e)},
+                        )
+                        self.mark_blocked(
+                            item_id, "org_member_role_update_failed",
+                            next_action=next_action,
+                            evidence=evidence,
                         )
                         failed += 1
                 else:
@@ -443,6 +1184,11 @@ class UserRoleMigrator(BaseMigrator):
             elif pending_member:
                 dest_role_id = pending_member.get("role_id")
                 needs_workspace_access = bool(workspace_ids and workspace_role_id)
+                desired_workspace_ids = {
+                    workspace_id
+                    for workspace_id in workspace_ids
+                    if workspace_id
+                }
                 pending_workspace_ids = {
                     workspace_id
                     for workspace_id in (pending_member.get("workspace_ids") or [])
@@ -453,15 +1199,20 @@ class UserRoleMigrator(BaseMigrator):
                 )
                 pending_covers_workspace_access = (
                     needs_workspace_access
-                    and set(workspace_ids).issubset(pending_workspace_ids)
+                    and desired_workspace_ids.issubset(pending_workspace_ids)
                     and pending_workspace_role_id == workspace_role_id
+                )
+                pending_workspace_access_matches = (
+                    (
+                        pending_workspace_ids == desired_workspace_ids
+                        and pending_workspace_role_id == workspace_role_id
+                    )
+                    if remove_missing
+                    else (not needs_workspace_access or pending_covers_workspace_access)
                 )
                 needs_reinvite = bool(
                     (mapped_role_id and dest_role_id != mapped_role_id)
-                    or (
-                        needs_workspace_access
-                        and not pending_covers_workspace_access
-                    )
+                    or not pending_workspace_access_matches
                 )
                 if needs_reinvite:
                     if self.config.migration.skip_existing:
@@ -477,10 +1228,77 @@ class UserRoleMigrator(BaseMigrator):
                         continue
 
                     try:
-                        self._remove_org_member(
+                        reasons: list[str] = []
+                        if mapped_role_id and dest_role_id != mapped_role_id:
+                            reasons.append("org role differs")
+                        if not pending_workspace_access_matches:
+                            reasons.append("workspace access differs")
+                        self.log(
+                            f"Replacing pending invite for {email}: "
+                            + ", ".join(reasons)
+                        )
+                        pending_removed = self._remove_org_member(
                             pending_member["id"],
                             pending=True,
+                            tolerate_missing=True,
                         )
+                    except (AuthenticationError, APIError) as e:
+                        self.log(
+                            f"Failed to cancel pending invite for '{email}': {e}",
+                            "error",
+                        )
+                        next_action, evidence = self._org_member_failure_context(
+                            email=email,
+                            error=e,
+                            operation="Replacing a pending organization invite",
+                            fallback_next_action=(
+                                "Cancel or replace the pending org invite on the "
+                                "target, then re-run `langsmith-migrator users`."
+                            ),
+                        )
+                        evidence.update(
+                            self._pending_invite_evidence(
+                                email=email,
+                                pending_member=pending_member,
+                                desired_org_role_id=mapped_role_id,
+                                desired_workspace_ids=workspace_ids,
+                                desired_workspace_role_id=workspace_role_id,
+                                error=e,
+                            )
+                        )
+                        self._mark_pending_org_blocked(
+                            email=email,
+                            item_id=item_id,
+                            code="org_member_pending_invite_replace_failed",
+                            next_action=next_action,
+                            evidence=evidence,
+                        )
+                        failed += 1
+                        continue
+
+                    if not pending_removed:
+                        next_action = (
+                            "Cancel or replace the pending org invite on the "
+                            "target, then re-run `langsmith-migrator users`."
+                        )
+                        evidence = self._pending_invite_evidence(
+                            email=email,
+                            pending_member=pending_member,
+                            desired_org_role_id=mapped_role_id,
+                            desired_workspace_ids=workspace_ids,
+                            desired_workspace_role_id=workspace_role_id,
+                        )
+                        self._mark_pending_org_blocked(
+                            email=email,
+                            item_id=item_id,
+                            code="org_member_pending_invite_cancel_unsupported",
+                            next_action=next_action,
+                            evidence=evidence,
+                        )
+                        failed += 1
+                        continue
+
+                    try:
                         self._invite_org_member(
                             email,
                             mapped_role_id,
@@ -492,19 +1310,61 @@ class UserRoleMigrator(BaseMigrator):
                             outcome_code="org_member_migrated",
                         )
                         migrated += 1
+                    except ConflictError as e:
+                        self.log(
+                            f"Replacement invite for '{email}' conflicted: {e}",
+                            "error",
+                        )
+                        next_action = (
+                            "Cancel or replace the pending org invite on the "
+                            "target, then re-run `langsmith-migrator users`."
+                        )
+                        evidence = self._pending_invite_evidence(
+                            email=email,
+                            pending_member=pending_member,
+                            desired_org_role_id=mapped_role_id,
+                            desired_workspace_ids=workspace_ids,
+                            desired_workspace_role_id=workspace_role_id,
+                            error=e,
+                        )
+                        self._mark_pending_org_blocked(
+                            email=email,
+                            item_id=item_id,
+                            code="org_member_pending_invite_replace_conflict",
+                            next_action=next_action,
+                            evidence=evidence,
+                        )
+                        failed += 1
                     except (AuthenticationError, APIError) as e:
                         self.log(
                             f"Failed to replace pending invite for '{email}': {e}",
                             "error",
                         )
-                        self.mark_blocked(
-                            item_id,
-                            "org_member_pending_invite_replace_failed",
-                            next_action=(
+                        next_action, evidence = self._org_member_failure_context(
+                            email=email,
+                            error=e,
+                            operation="Replacing a pending organization invite",
+                            fallback_next_action=(
                                 "Cancel or replace the pending org invite on the "
                                 "target, then re-run `langsmith-migrator users`."
                             ),
-                            evidence={"email": email, "error": str(e)},
+                        )
+                        evidence.update(
+                            self._pending_invite_evidence(
+                                email=email,
+                                pending_member=pending_member,
+                                desired_org_role_id=mapped_role_id,
+                                desired_workspace_ids=workspace_ids,
+                                desired_workspace_role_id=workspace_role_id,
+                                error=e,
+                            )
+                        )
+                        self._mark_pending_org_blocked(
+                            email=email,
+                            item_id=item_id,
+                            code="org_member_pending_invite_replace_failed",
+                            next_action=next_action,
+                            evidence=evidence,
                         )
                         failed += 1
                 else:
@@ -516,12 +1376,12 @@ class UserRoleMigrator(BaseMigrator):
                         for workspace_id in workspace_ids:
                             self._pending_workspace_invites.add((email, workspace_id))
                         self.log(
-                            f"Invite for '{email}' already pending with the required workspace access",
+                            f"Keeping pending invite for {email}: existing invite satisfies desired access",
                             "info",
                         )
                     else:
                         self.log(
-                            f"Invite for '{email}' already pending, skipping",
+                            f"Keeping pending invite for {email}: existing invite satisfies desired access",
                             "warning",
                         )
                     self.mark_migrated(
@@ -548,13 +1408,19 @@ class UserRoleMigrator(BaseMigrator):
                     skipped += 1
                 except (AuthenticationError, APIError) as e:
                     self.log(f"Failed to invite '{email}': {e}", "error")
-                    self.mark_blocked(
-                        item_id, "org_member_invite_failed",
-                        next_action=(
+                    next_action, evidence = self._org_member_failure_context(
+                        email=email,
+                        error=e,
+                        operation="Inviting an organization member",
+                        fallback_next_action=(
                             "Review the org invite error in the remediation "
                             "bundle, then re-run `langsmith-migrator users`."
                         ),
-                        evidence={"email": email, "error": str(e)},
+                    )
+                    self.mark_blocked(
+                        item_id, "org_member_invite_failed",
+                        next_action=next_action,
+                        evidence=evidence,
                     )
                     failed += 1
 
@@ -590,6 +1456,7 @@ class UserRoleMigrator(BaseMigrator):
                     self._remove_org_member(
                         member["id"],
                         pending=member.get("id") in pending_extra_ids,
+                        tolerate_missing=True,
                     )
                     self.mark_migrated(
                         item_id,
@@ -602,14 +1469,20 @@ class UserRoleMigrator(BaseMigrator):
                         f"Failed to remove org member '{email}': {e}",
                         "error",
                     )
-                    self.mark_blocked(
-                        item_id,
-                        "org_member_remove_failed",
-                        next_action=(
+                    next_action, evidence = self._org_member_failure_context(
+                        email=email,
+                        error=e,
+                        operation="Removing an organization member or pending invite",
+                        fallback_next_action=(
                             "Remove the extra org user or pending invite manually "
                             "if needed, then re-run `langsmith-migrator users --sync`."
                         ),
-                        evidence={"email": email, "error": str(e)},
+                    )
+                    self.mark_blocked(
+                        item_id,
+                        "org_member_remove_failed",
+                        next_action=next_action,
+                        evidence=evidence,
                     )
                     failed += 1
 
@@ -625,6 +1498,11 @@ class UserRoleMigrator(BaseMigrator):
         workspace_role_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Invite a new member to the destination org."""
+        self._log_pending_invite_workspace_payload(
+            email=email,
+            workspace_ids=workspace_ids or [],
+            workspace_role_id=workspace_role_id,
+        )
         if self.config.migration.dry_run:
             self.log(f"[DRY RUN] Would invite {email}")
             response = {"id": f"dry-run-{email}", "email": email}
@@ -672,12 +1550,13 @@ class UserRoleMigrator(BaseMigrator):
         identity_id: str,
         *,
         pending: bool = False,
-    ) -> None:
+        tolerate_missing: bool = False,
+    ) -> bool:
         """Remove an active org member or cancel a pending invite."""
         if self.config.migration.dry_run:
             action = "cancel org invite" if pending else "remove org member"
             self.log(f"[DRY RUN] Would {action}: {identity_id}")
-            return
+            return True
 
         if pending:
             pending_endpoint = f"/orgs/current/members/pending/{identity_id}"
@@ -685,15 +1564,57 @@ class UserRoleMigrator(BaseMigrator):
             try:
                 self.dest.delete(pending_endpoint)
             except APIError as e:
+                if is_org_member_management_permission_error(e):
+                    raise
                 status_code = getattr(e, "status_code", None)
                 message = str(e).lower()
-                if status_code not in {404, 405} and "not found" not in message and "not allowed" not in message:
+                if (
+                    status_code not in {404, 405}
+                    and "not found" not in message
+                    and "not allowed" not in message
+                ):
                     raise
-                self.dest.delete(legacy_endpoint)
+                try:
+                    self.dest.delete(legacy_endpoint)
+                except APIError as legacy_error:
+                    if is_org_member_management_permission_error(legacy_error):
+                        raise
+                    legacy_status_code = getattr(legacy_error, "status_code", None)
+                    legacy_message = str(legacy_error).lower()
+                    if is_member_absent_error(legacy_error):
+                        if not tolerate_missing:
+                            raise
+                        self.log(
+                            f"Pending org invite already absent: {identity_id}",
+                            "warning",
+                        )
+                        return True
+                    legacy_unsupported = (
+                        legacy_status_code == 405 or "not allowed" in legacy_message
+                    )
+                    if not (tolerate_missing and legacy_unsupported):
+                        raise
+                    self.log(
+                        "Pending org invite is not cancellable via known endpoints: "
+                        f"{identity_id}",
+                        "warning",
+                    )
+                    return False
         else:
-            self.dest.delete(f"/orgs/current/members/{identity_id}")
+            endpoint = f"/orgs/current/members/{identity_id}"
+            try:
+                self.dest.delete(endpoint)
+            except APIError as e:
+                if not (tolerate_missing and is_member_absent_error(e)):
+                    raise
+                self.log(
+                    f"Org member already absent during source-of-truth cleanup: {identity_id}",
+                    "warning",
+                )
+                return False
         action = "Cancelled org invite" if pending else "Removed org member"
         self.log(f"{action}: {identity_id}", "success")
+        return True
 
     # ------------------------------------------------------------------
     # Phase 3: workspace member migration
@@ -714,32 +1635,36 @@ class UserRoleMigrator(BaseMigrator):
                 request_info={},
             )
 
-        selected_by_email: Dict[str, Dict[str, Any]] = {}
+        rows_by_email: Dict[str, List[Dict[str, Any]]] = {}
         for row in csv_rows:
             if row.get("workspace_id") != source_workspace_id:
                 continue
 
             email = (row.get("email") or "").strip().lower()
-            role_id = (row.get("role_id") or "").strip()
             if not email:
                 continue
+            rows_by_email.setdefault(email, []).append(row)
 
-            existing = selected_by_email.get(email)
-            if existing and existing["role_id"] != role_id:
-                raise APIError(
-                    (
-                        "Conflicting workspace role_id values in CSV rows for "
-                        f"{email} in workspace {source_workspace_id}"
-                    ),
-                    request_info={},
+        selected_by_email: Dict[str, Dict[str, Any]] = {}
+        for email, rows in rows_by_email.items():
+            try:
+                role_id = select_effective_workspace_role_id(
+                    rows,
+                    email=email,
+                    workspace_id=source_workspace_id,
                 )
-            if not existing:
-                selected_by_email[email] = {
-                    "id": row.get("id") or f"{source_workspace_id}:{email}",
-                    "email": email,
-                    "role_id": role_id,
-                    "full_name": row.get("full_name", ""),
-                }
+            except ValueError as e:
+                raise APIError(
+                    str(e),
+                    request_info={},
+                ) from e
+            first_row = rows[0]
+            selected_by_email[email] = {
+                "id": first_row.get("id") or f"{source_workspace_id}:{email}",
+                "email": email,
+                "role_id": role_id,
+                "full_name": first_row.get("full_name", ""),
+            }
 
         return self.migrate_workspace_members(
             selected_members=list(selected_by_email.values())
@@ -806,6 +1731,25 @@ class UserRoleMigrator(BaseMigrator):
                 member.get("id", email),
                 metadata={"member": member, "workspace_pair": ws_pair},
             )
+
+            pending_org_blocker = self._pending_org_blockers.get(email)
+            if pending_org_blocker:
+                self.log(
+                    "Skipping workspace membership for "
+                    f"'{email}' because org pending invite reconciliation is blocked",
+                    "warning",
+                )
+                self.mark_migrated(
+                    item_id,
+                    outcome_code="ws_member_skipped_pending_org_blocker",
+                    evidence={
+                        "email": email,
+                        "org_item_id": pending_org_blocker.get("item_id"),
+                        "org_blocker": pending_org_blocker.get("code"),
+                    },
+                )
+                skipped += 1
+                continue
 
             source_role_id = (member.get("role_id") or "").strip() or None
             mapped_role_id = (
@@ -881,6 +1825,43 @@ class UserRoleMigrator(BaseMigrator):
                     self.mark_blocked(
                         item_id, "ws_member_not_in_org",
                         next_action="Migrate the user as an org member first, then retry.",
+                        evidence={"email": email},
+                    )
+                    failed += 1
+                    continue
+                pending_org_member = self._pending_org_email_to_identity.get(email)
+                pending_user_id = (
+                    pending_org_member
+                    and (
+                        pending_org_member.get("user_id")
+                        or (pending_org_member.get("user") or {}).get("id")
+                    )
+                )
+                if pending_org_member and not pending_user_id:
+                    if email in self._pending_org_invite_wait_reported:
+                        self.log(
+                            f"Workspace membership for '{email}' is already waiting on pending org invite acceptance",
+                            "info",
+                        )
+                        self.mark_migrated(
+                            item_id,
+                            outcome_code="ws_member_skipped_pending_org_invite_waiting",
+                            evidence={"email": email},
+                        )
+                        skipped += 1
+                        continue
+                    self._pending_org_invite_wait_reported.add(email)
+                    self.log(
+                        f"Cannot add '{email}' to workspace until the pending org invite is accepted",
+                        "warning",
+                    )
+                    self.mark_blocked(
+                        item_id,
+                        "ws_member_pending_org_invite",
+                        next_action=(
+                            "Wait for the pending org invite to be accepted, "
+                            "then re-run `langsmith-migrator users`."
+                        ),
                         evidence={"email": email},
                     )
                     failed += 1

--- a/langsmith_migrator/utils/state.py
+++ b/langsmith_migrator/utils/state.py
@@ -67,11 +67,14 @@ _ACTIONABLE_GROUP_LABELS = {
     "unmapped_role": "Roles are missing from the mapping",
     "unmapped_workspace_role": "Workspace roles are missing from the mapping",
     "org_member_role_update_failed": "Org role updates failed",
+    "org_member_pending_invite_cancel_unsupported": "Pending org invites could not be cancelled",
+    "org_member_pending_invite_replace_conflict": "Pending org invites could not be replaced",
     "org_member_pending_invite_replace_failed": "Pending org invites could not be refreshed",
     "org_member_invite_failed": "Org invites failed",
     "org_member_remove_failed": "Extra org users or pending invites could not be removed",
     "ws_member_role_update_failed": "Workspace role updates failed",
     "ws_member_not_in_org": "Workspace users are missing org access",
+    "ws_member_pending_org_invite": "Workspace users are waiting on pending org invites",
     "ws_member_add_failed": "Workspace memberships failed to add",
     "ws_member_remove_failed": "Extra workspace memberships could not be removed",
 }
@@ -83,6 +86,14 @@ _ACTIONABLE_NEXT_ACTION_OVERRIDES = {
         "then re-run `langsmith-migrator users`."
     ),
     "org_member_pending_invite_replace_failed": (
+        "Cancel or replace the pending org invite on the target, "
+        "then re-run `langsmith-migrator users`."
+    ),
+    "org_member_pending_invite_cancel_unsupported": (
+        "Cancel or replace the pending org invite on the target, "
+        "then re-run `langsmith-migrator users`."
+    ),
+    "org_member_pending_invite_replace_conflict": (
         "Cancel or replace the pending org invite on the target, "
         "then re-run `langsmith-migrator users`."
     ),
@@ -100,6 +111,10 @@ _ACTIONABLE_NEXT_ACTION_OVERRIDES = {
     ),
     "ws_member_add_failed": (
         "Review the workspace membership create error in the remediation bundle, "
+        "then re-run `langsmith-migrator users`."
+    ),
+    "ws_member_pending_org_invite": (
+        "Wait for the pending org invite to be accepted, "
         "then re-run `langsmith-migrator users`."
     ),
     "ws_member_remove_failed": (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.65"
+version = "0.0.66"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -87,7 +87,7 @@ class FakeClient:
         self.set_workspace_calls: list[str | None] = []
         self.closed = False
 
-    def get(self, endpoint: str) -> Any:
+    def get(self, endpoint: str, params: dict[str, Any] | None = None) -> Any:
         self.get_calls.append(endpoint)
         response = self.get_responses.get(endpoint, [])
         if isinstance(response, Exception):
@@ -358,7 +358,9 @@ def cli_harness(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliHarness:
     monkeypatch.setattr(cli_main, "MigrationOrchestrator", orchestrator_factory)
 
     def patch_migrator(name: str, instance: Mock) -> None:
-        factory = lambda *args, **kwargs: instance
+        def factory(*args: Any, **kwargs: Any) -> Mock:
+            return instance
+
         monkeypatch.setattr(cli_main, name, factory)
         monkeypatch.setattr(migrators_module, name, factory)
 

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, call
 
 from langsmith_migrator.cli import main as cli_main
 from langsmith_migrator.cli.tui_workspace_mapper import WorkspaceProjectResult
+from langsmith_migrator.utils.retry import APIError
 from langsmith_migrator.utils.state import (
     MigrationItem,
     MigrationState,
@@ -390,6 +391,34 @@ def test_users_command_without_csv_keeps_api_member_paths(cli_harness, monkeypat
     user_role_migrator.list_source_workspace_members.assert_called_once()
 
 
+def test_users_command_preflight_stays_user_scoped(cli_harness, monkeypatch):
+    """users preflight should avoid project/dataset lookup probes."""
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={},
+        workspaces_to_create=[],
+    )
+
+    user_role_migrator = Mock()
+    user_role_migrator.build_role_mapping.return_value = {"src-role": "dst-role"}
+    user_role_migrator._dest_email_to_identity = {}
+    user_role_migrator.list_source_org_members.return_value = []
+    user_role_migrator.list_source_pending_org_members.return_value = []
+    user_role_migrator.list_source_workspace_members.return_value = []
+    monkeypatch.setattr(cli_main, "UserRoleMigrator", lambda *args, **kwargs: user_role_migrator)
+
+    result = cli_harness.invoke(["users"])
+
+    assert result.exit_code == 0
+    user_role_migrator.probe_capabilities.assert_called_once()
+    for client in (
+        cli_harness.orchestrator_factory.source_client,
+        cli_harness.orchestrator_factory.dest_client,
+    ):
+        assert ("/sessions", 1) not in client.get_paginated_calls
+        assert ("/datasets", 1) not in client.get_paginated_calls
+
+
 def test_users_command_defers_custom_role_sync_until_members_are_selected(
     cli_harness, monkeypatch
 ):
@@ -613,6 +642,80 @@ def test_users_command_single_instance_source_of_truth_uses_identity_workspace_p
     )
 
 
+def test_users_command_single_instance_source_of_truth_removes_omitted_workspace_access(
+    cli_harness, monkeypatch, tmp_path
+):
+    """Authoritative CSV sync should reconcile workspaces omitted for a retained user."""
+    cli_harness.orchestrator_factory.dest_client.get_responses["/api/v1/workspaces"] = [
+        {"id": "ws-a", "display_name": "Workspace A"},
+        {"id": "ws-b", "display_name": "Workspace B"},
+    ]
+    csv_path = tmp_path / "members.csv"
+    csv_path.write_text(
+        "email,langsmith_role,workspace_id,workspace_name\n"
+        "user@example.com,Workspace Admin,ws-a,Workspace A\n",
+        encoding="utf-8",
+    )
+
+    user_role_migrator = Mock()
+    user_role_migrator.build_role_mapping.return_value = {
+        "src-user": "dst-user",
+        "src-ws-admin": "dst-ws-admin",
+    }
+    user_role_migrator.list_source_roles.return_value = [
+        {"id": "src-user", "name": "ORGANIZATION_USER", "display_name": "User"},
+        {"id": "src-ws-admin", "name": "WORKSPACE_ADMIN", "display_name": "Workspace Admin"},
+    ]
+    user_role_migrator.migrate_org_members.return_value = (1, 0, 0)
+    user_role_migrator.migrate_workspace_members.side_effect = [(1, 0, 0), (0, 0, 0)]
+    monkeypatch.setattr(cli_main, "UserRoleMigrator", lambda *args, **kwargs: user_role_migrator)
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(
+        [
+            "users",
+            "--api-key",
+            "sync-key",
+            "--url",
+            "https://sync.example",
+            "--csv",
+            str(csv_path),
+            "--sync",
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert "Workspace access: authoritative across 2 target workspace(s)" in cli_harness.console.text
+    user_role_migrator.migrate_org_members.assert_called_once_with(
+        [
+            {
+                "id": "user@example.com",
+                "email": "user@example.com",
+                "role_id": "src-user",
+                "full_name": "",
+                "workspace_ids": ["ws-a"],
+                "workspace_role_id": "src-ws-admin",
+            }
+        ],
+        remove_missing=True,
+        remove_pending=True,
+    )
+    assert user_role_migrator.migrate_workspace_members.call_args_list == [
+        call(
+            selected_members=[
+                {
+                    "id": "ws-a:user@example.com",
+                    "email": "user@example.com",
+                    "role_id": "src-ws-admin",
+                    "full_name": "",
+                }
+            ],
+            remove_missing=True,
+        ),
+        call(selected_members=[], remove_missing=True),
+    ]
+
+
 def test_users_command_single_instance_rejects_workspace_flags(cli_harness, tmp_path):
     """Single-instance sync should not accept source/dest workspace mapping flags."""
     csv_path = tmp_path / "members.csv"
@@ -730,6 +833,41 @@ def test_users_command_rejects_sync_with_skip_existing(cli_harness, tmp_path):
     assert "--csv-source-of-truth cannot be combined with --skip-existing" in result.output
 
 
+def test_users_command_source_of_truth_requires_org_admin_pat(
+    cli_harness, monkeypatch, tmp_path
+):
+    """Authoritative users sync should fail fast when the target PAT cannot manage org members."""
+    csv_path = tmp_path / "members.csv"
+    csv_path.write_text(
+        "email,langsmith_role,workspace_id\nalice@example.com,Organization Admin,\n",
+        encoding="utf-8",
+    )
+
+    user_role_migrator = Mock()
+    user_role_migrator.require_destination_org_admin_for_authoritative_sync.side_effect = APIError(
+        "Destination API key does not appear to have Organization Admin PAT permissions"
+    )
+    monkeypatch.setattr(cli_main, "UserRoleMigrator", lambda *args, **kwargs: user_role_migrator)
+
+    result = cli_harness.invoke(
+        [
+            "users",
+            "--api-key",
+            "sync-key",
+            "--url",
+            "https://sync.example",
+            "--csv",
+            str(csv_path),
+            "--sync",
+        ]
+    )
+
+    assert result.exit_code == 1
+    assert "Organization Admin PAT" in cli_harness.console.text
+    user_role_migrator.require_destination_org_admin_for_authoritative_sync.assert_called_once()
+    user_role_migrator.build_role_mapping.assert_not_called()
+
+
 def test_users_command_single_instance_csv_apply_auto_applies_all_rows(
     cli_harness, monkeypatch, tmp_path
 ):
@@ -785,6 +923,7 @@ def test_users_command_single_instance_csv_apply_auto_applies_all_rows(
     assert "Single-Instance User Sync" in cli_harness.console.text
     assert "Row selection: disabled" in cli_harness.console.text
     assert "Removals: disabled (add/update only)" in cli_harness.console.text
+    assert "workspace memberships missing from the CSV will be preserved" in cli_harness.console.text
     user_role_migrator.migrate_org_members.assert_called_once_with(
         [
             {
@@ -840,8 +979,10 @@ def test_users_command_single_instance_syncs_custom_roles_only_when_csv_rows_nee
             "src-user": "dst-user",
             "src-ws-admin": "dst-ws-admin",
         },
-        {"src-org-custom": "dst-org-custom"},
-        {"src-ws-custom": "dst-ws-custom"},
+        {
+            "src-org-custom": "dst-org-custom",
+            "src-ws-custom": "dst-ws-custom",
+        },
     ]
     user_role_migrator.list_source_roles.return_value = [
         {"id": "src-admin", "name": "ORGANIZATION_ADMIN", "display_name": "Admin"},
@@ -871,8 +1012,7 @@ def test_users_command_single_instance_syncs_custom_roles_only_when_csv_rows_nee
     assert result.exit_code == 0
     assert user_role_migrator.build_role_mapping.call_args_list == [
         call(custom_role_ids=set()),
-        call(custom_role_ids={"src-org-custom"}),
-        call(custom_role_ids={"src-ws-custom"}),
+        call(custom_role_ids={"src-org-custom", "src-ws-custom"}),
     ]
     user_role_migrator.migrate_org_members.assert_called_once_with(
         [
@@ -881,6 +1021,8 @@ def test_users_command_single_instance_syncs_custom_roles_only_when_csv_rows_nee
                 "email": "alice@example.com",
                 "role_id": "src-org-custom",
                 "full_name": "",
+                "workspace_ids": ["ws-1"],
+                "workspace_role_id": "src-ws-custom",
             }
         ],
         remove_missing=False,
@@ -960,6 +1102,66 @@ def test_users_command_single_instance_syncs_workspace_only_custom_roles_before_
                 "full_name": "",
                 "workspace_ids": ["ws-1"],
                 "workspace_role_id": "src-ws-custom",
+            }
+        ],
+        remove_missing=False,
+        remove_pending=False,
+    )
+
+
+def test_users_command_single_instance_warns_for_mixed_workspace_role_invites(
+    cli_harness, monkeypatch, tmp_path
+):
+    """Mixed workspace roles for a workspace-only user should be called out before apply."""
+    cli_harness.orchestrator_factory.dest_client.get_responses["/api/v1/workspaces"] = [
+        {"id": "ws-1", "display_name": "Workspace 1"},
+        {"id": "ws-2", "display_name": "Workspace 2"},
+    ]
+    csv_path = tmp_path / "members.csv"
+    csv_path.write_text(
+        "email,langsmith_role,workspace_id\n"
+        "alice@example.com,Workspace Admin,ws-1\n"
+        "alice@example.com,Workspace Viewer,ws-2\n",
+        encoding="utf-8",
+    )
+
+    user_role_migrator = Mock()
+    user_role_migrator.build_role_mapping.return_value = {
+        "src-user": "dst-user",
+        "src-ws-admin": "dst-ws-admin",
+        "src-ws-viewer": "dst-ws-viewer",
+    }
+    user_role_migrator.list_source_roles.return_value = [
+        {"id": "src-user", "name": "ORGANIZATION_USER", "display_name": "User"},
+        {"id": "src-ws-admin", "name": "WORKSPACE_ADMIN", "display_name": "Workspace Admin"},
+        {"id": "src-ws-viewer", "name": "WORKSPACE_VIEWER", "display_name": "Workspace Viewer"},
+    ]
+    user_role_migrator.migrate_org_members.return_value = (1, 0, 0)
+    user_role_migrator.migrate_workspace_members.side_effect = [(1, 0, 0), (1, 0, 0)]
+    monkeypatch.setattr(cli_main, "UserRoleMigrator", lambda *args, **kwargs: user_role_migrator)
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(
+        [
+            "users",
+            "--api-key",
+            "sync-key",
+            "--url",
+            "https://sync.example",
+            "--csv",
+            str(csv_path),
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert "alice@example.com has multiple workspace roles" in cli_harness.console.text
+    user_role_migrator.migrate_org_members.assert_called_once_with(
+        [
+            {
+                "id": "alice@example.com",
+                "email": "alice@example.com",
+                "role_id": "src-user",
+                "full_name": "",
             }
         ],
         remove_missing=False,

--- a/tests/test_user_role_migrator.py
+++ b/tests/test_user_role_migrator.py
@@ -3,7 +3,8 @@
 import pytest
 from unittest.mock import Mock, call
 from langsmith_migrator.core.migrators import UserRoleMigrator
-from langsmith_migrator.utils.retry import APIError, ConflictError
+from langsmith_migrator.core.migrators.user_role import make_workspace_role_union_id
+from langsmith_migrator.utils.retry import APIError, AuthenticationError, ConflictError
 
 
 class TestUserRoleMigrator:
@@ -177,6 +178,360 @@ class TestUserRoleMigrator:
         assert second["src-custom-1"] == "dst-custom-1"
         assert second["src-custom-2"] == "dst-custom-2"
 
+    def test_materialize_workspace_role_union_creates_role_and_clones_access_policy(
+        self,
+        migrator,
+        migration_state,
+    ):
+        """Union roles combine permissions and carry over ABAC policy attachments."""
+        migrator.log = Mock()
+        union_role_id = make_workspace_role_union_id({"src-custom-1", "src-custom-2"})
+        source_roles = [
+            {
+                "id": "src-custom-1",
+                "name": "CUSTOM",
+                "display_name": "Assistant A",
+                "description": "Assistant A role",
+                "permissions": ["projects:read"],
+            },
+            {
+                "id": "src-custom-2",
+                "name": "CUSTOM",
+                "display_name": "Assistant B",
+                "description": "Assistant B role",
+                "permissions": ["datasets:read", "projects:read"],
+            },
+        ]
+        source_policy = {
+            "id": "src-policy-1",
+            "name": "Assistant project access",
+            "description": "Restrict projects by assistant",
+            "effect": "allow",
+            "condition_groups": [
+                {
+                    "permission": "projects:read",
+                    "resource_type": "project",
+                    "conditions": [
+                        {
+                            "attribute_name": "resource_tag_key",
+                            "attribute_key": "Assistant",
+                            "operator": "equals",
+                            "attribute_value": "A",
+                        }
+                    ],
+                }
+            ],
+            "role_ids": ["src-custom-1"],
+        }
+
+        def source_get(endpoint, params=None):
+            if endpoint == "/orgs/current/roles":
+                return source_roles
+            if endpoint.endswith("/v1/platform/orgs/current/access-policies"):
+                return {"access_policies": [source_policy]}
+            raise AssertionError(f"unexpected source GET {endpoint}")
+
+        def dest_get(endpoint, params=None):
+            if endpoint == "/orgs/current/roles":
+                return []
+            if endpoint.endswith("/v1/platform/orgs/current/access-policies"):
+                return {"access_policies": []}
+            raise AssertionError(f"unexpected dest GET {endpoint}")
+
+        def dest_post(endpoint, data):
+            if endpoint == "/orgs/current/roles":
+                return {"id": "dst-union-role"}
+            if endpoint.endswith("/v1/platform/orgs/current/access-policies"):
+                return {"id": "dst-policy-1"}
+            raise AssertionError(f"unexpected dest POST {endpoint}")
+
+        migrator.source.get.side_effect = source_get
+        migrator.dest.get.side_effect = dest_get
+        migrator.dest.post.side_effect = dest_post
+
+        mapping = migrator.materialize_workspace_role_unions({union_role_id})
+
+        assert mapping[union_role_id] == "dst-union-role"
+        assert migration_state.id_mappings["roles"][union_role_id] == "dst-union-role"
+        assert any(
+            "Created managed workspace role union" in call_args.args[0]
+            for call_args in migrator.log.call_args_list
+        )
+        assert any(
+            "Resolved workspace role union" in call_args.args[0]
+            for call_args in migrator.log.call_args_list
+        )
+        migrator.dest.post.assert_any_call(
+            "/orgs/current/roles",
+            {
+                "display_name": migrator._build_workspace_union_role(
+                    union_role_id,
+                    source_roles,
+                )["display_name"],
+                "description": (
+                    "Managed by langsmith-migrator. Union of source workspace roles: "
+                    "Assistant A (src-custom-1); Assistant B (src-custom-2)"
+                ),
+                "permissions": ["datasets:read", "projects:read"],
+            },
+        )
+        migrator.dest.post.assert_any_call(
+            "https://dest.api.test.com/v1/platform/orgs/current/access-policies",
+            {
+                "name": "Assistant project access",
+                "description": "Restrict projects by assistant",
+                "effect": "allow",
+                "condition_groups": source_policy["condition_groups"],
+                "role_ids": ["dst-union-role"],
+            },
+        )
+
+    def test_materialize_workspace_role_union_reuses_policy_and_attaches_role(
+        self,
+        migrator,
+    ):
+        """Equivalent destination ABAC policies are attached instead of duplicated."""
+        migrator.log = Mock()
+        union_role_id = make_workspace_role_union_id({"src-custom-1", "src-custom-2"})
+        source_roles = [
+            {
+                "id": "src-custom-1",
+                "name": "CUSTOM",
+                "display_name": "Assistant A",
+                "description": "Assistant A role",
+                "permissions": ["projects:read"],
+            },
+            {
+                "id": "src-custom-2",
+                "name": "CUSTOM",
+                "display_name": "Assistant B",
+                "description": "Assistant B role",
+                "permissions": ["datasets:read"],
+            },
+        ]
+        union_role = migrator._build_workspace_union_role(union_role_id, source_roles)
+        source_policy = {
+            "id": "src-policy-1",
+            "name": "Assistant project access",
+            "description": "Restrict projects by assistant",
+            "effect": "allow",
+            "condition_groups": [{"permission": "projects:read", "resource_type": "project", "conditions": []}],
+            "role_ids": ["src-custom-1"],
+        }
+        dest_policy = {
+            **source_policy,
+            "id": "dst-policy-1",
+            "role_ids": [],
+        }
+
+        migrator.source.get.side_effect = lambda endpoint, params=None: (
+            source_roles
+            if endpoint == "/orgs/current/roles"
+            else {"access_policies": [source_policy]}
+        )
+        migrator.dest.get.side_effect = lambda endpoint, params=None: (
+            [{**union_role, "id": "dst-union-role"}]
+            if endpoint == "/orgs/current/roles"
+            else {"access_policies": [dest_policy]}
+        )
+
+        mapping = migrator.materialize_workspace_role_unions({union_role_id})
+
+        assert mapping[union_role_id] == "dst-union-role"
+        assert any(
+            "Reused managed workspace role union" in call_args.args[0]
+            for call_args in migrator.log.call_args_list
+        )
+        assert any(
+            "Resolved workspace role union" in call_args.args[0]
+            for call_args in migrator.log.call_args_list
+        )
+        migrator.dest.patch.assert_not_called()
+        migrator.dest.post.assert_called_once_with(
+            "https://dest.api.test.com/v1/platform/orgs/current/access-policies/roles/"
+            "dst-union-role/access-policies",
+            {"access_policy_ids": ["dst-policy-1"]},
+        )
+
+    def test_materialize_workspace_role_union_fails_closed_when_policy_clone_fails(
+        self,
+        migrator,
+        migration_state,
+    ):
+        """A union role is not mapped when an ABAC policy clone cannot be created."""
+        union_role_id = make_workspace_role_union_id({"src-custom-1", "src-custom-2"})
+        source_roles = [
+            {
+                "id": "src-custom-1",
+                "name": "CUSTOM",
+                "display_name": "Assistant A",
+                "description": "Assistant A role",
+                "permissions": ["projects:read"],
+            },
+            {
+                "id": "src-custom-2",
+                "name": "CUSTOM",
+                "display_name": "Assistant B",
+                "description": "Assistant B role",
+                "permissions": ["datasets:read"],
+            },
+        ]
+        source_policy = {
+            "id": "src-policy-1",
+            "name": "Assistant project access",
+            "description": "Restrict projects by assistant",
+            "effect": "allow",
+            "condition_groups": [{"permission": "projects:read", "resource_type": "project", "conditions": []}],
+            "role_ids": ["src-custom-1"],
+        }
+
+        migrator.source.get.side_effect = lambda endpoint, params=None: (
+            source_roles
+            if endpoint == "/orgs/current/roles"
+            else {"access_policies": [source_policy]}
+        )
+        migrator.dest.get.side_effect = lambda endpoint, params=None: (
+            []
+            if endpoint == "/orgs/current/roles"
+            else {"access_policies": []}
+        )
+        migrator.dest.post.side_effect = [
+            {"id": "dst-union-role"},
+            {},
+        ]
+
+        with pytest.raises(APIError, match="Access policy create response did not include an id"):
+            migrator.materialize_workspace_role_unions({union_role_id})
+
+        assert union_role_id not in migrator._role_id_map
+        assert union_role_id not in migration_state.id_mappings.get("roles", {})
+
+    def test_materialize_workspace_role_union_fails_closed_when_policy_attach_fails(
+        self,
+        migrator,
+        migration_state,
+    ):
+        """A union role is not mapped when an existing ABAC policy cannot be attached."""
+        union_role_id = make_workspace_role_union_id({"src-custom-1", "src-custom-2"})
+        source_roles = [
+            {
+                "id": "src-custom-1",
+                "name": "CUSTOM",
+                "display_name": "Assistant A",
+                "description": "Assistant A role",
+                "permissions": ["projects:read"],
+            },
+            {
+                "id": "src-custom-2",
+                "name": "CUSTOM",
+                "display_name": "Assistant B",
+                "description": "Assistant B role",
+                "permissions": ["datasets:read"],
+            },
+        ]
+        union_role = migrator._build_workspace_union_role(union_role_id, source_roles)
+        source_policy = {
+            "id": "src-policy-1",
+            "name": "Assistant project access",
+            "description": "Restrict projects by assistant",
+            "effect": "allow",
+            "condition_groups": [{"permission": "projects:read", "resource_type": "project", "conditions": []}],
+            "role_ids": ["src-custom-1"],
+        }
+        dest_policy = {
+            **source_policy,
+            "id": "dst-policy-1",
+            "role_ids": [],
+        }
+
+        migrator.source.get.side_effect = lambda endpoint, params=None: (
+            source_roles
+            if endpoint == "/orgs/current/roles"
+            else {"access_policies": [source_policy]}
+        )
+        migrator.dest.get.side_effect = lambda endpoint, params=None: (
+            [{**union_role, "id": "dst-union-role"}]
+            if endpoint == "/orgs/current/roles"
+            else {"access_policies": [dest_policy]}
+        )
+        migrator.dest.post.side_effect = APIError(
+            "attach failed",
+            request_info={},
+        )
+
+        with pytest.raises(APIError, match="attach failed"):
+            migrator.materialize_workspace_role_unions({union_role_id})
+
+        assert union_role_id not in migrator._role_id_map
+        assert union_role_id not in migration_state.id_mappings.get("roles", {})
+
+    def test_materialize_workspace_role_union_skip_existing_leaves_role_and_policies(
+        self,
+        migrator,
+        sample_config,
+    ):
+        """skip_existing maps existing managed unions without mutating them."""
+        sample_config.migration.skip_existing = True
+        union_role_id = make_workspace_role_union_id({"src-custom-1", "src-custom-2"})
+        source_roles = [
+            {"id": "src-custom-1", "name": "CUSTOM", "display_name": "A", "permissions": ["projects:read"]},
+            {"id": "src-custom-2", "name": "CUSTOM", "display_name": "B", "permissions": ["datasets:read"]},
+        ]
+        union_role = migrator._build_workspace_union_role(union_role_id, source_roles)
+
+        migrator.source.get.side_effect = lambda endpoint, params=None: (
+            source_roles
+            if endpoint == "/orgs/current/roles"
+            else {"access_policies": [{"id": "src-policy", "role_ids": ["src-custom-1"]}]}
+        )
+        migrator.dest.get.side_effect = lambda endpoint, params=None: (
+            [{**union_role, "id": "dst-union-role", "permissions": []}]
+            if endpoint == "/orgs/current/roles"
+            else {"access_policies": []}
+        )
+
+        mapping = migrator.materialize_workspace_role_unions({union_role_id})
+
+        assert mapping[union_role_id] == "dst-union-role"
+        migrator.dest.patch.assert_not_called()
+        migrator.dest.post.assert_not_called()
+
+    def test_materialize_workspace_role_union_rejects_builtin_without_permissions(
+        self,
+        migrator,
+    ):
+        """Mixed built-in/custom unions fail closed when built-in permissions are absent."""
+        union_role_id = make_workspace_role_union_id({"src-custom-1", "src-ws-user"})
+        source_roles = [
+            {
+                "id": "src-custom-1",
+                "name": "CUSTOM",
+                "display_name": "Assistant A",
+                "permissions": ["projects:read"],
+            },
+            {
+                "id": "src-ws-user",
+                "name": "WORKSPACE_USER",
+                "display_name": "Workspace User",
+                "permissions": [],
+            },
+        ]
+        migrator.source.get.side_effect = lambda endpoint, params=None: (
+            source_roles
+            if endpoint == "/orgs/current/roles"
+            else {"access_policies": []}
+        )
+        migrator.dest.get.side_effect = lambda endpoint, params=None: (
+            []
+            if endpoint == "/orgs/current/roles"
+            else {"access_policies": []}
+        )
+
+        with pytest.raises(APIError, match="built-in role permissions were not exposed"):
+            migrator.materialize_workspace_role_unions({union_role_id})
+
+        migrator.dest.post.assert_not_called()
+
     def test_ensure_dest_email_index_caches_until_forced(self, migrator):
         """Destination org identities are cached unless a refresh is requested."""
         migrator.dest.get_paginated.side_effect = [
@@ -331,6 +686,7 @@ class TestUserRoleMigrator:
 
     def test_migrate_org_members_reinvites_pending_when_role_differs(self, migrator):
         """Pending invites with the wrong role are replaced in authoritative mode."""
+        migrator.log = Mock()
         migrator._role_id_map = {"src-role": "dst-role-new"}
         migrator.dest.get_paginated.side_effect = [
             iter([]),
@@ -350,6 +706,10 @@ class TestUserRoleMigrator:
         )
 
         assert (m, s, f) == (1, 0, 0)
+        assert any(
+            "Replacing pending invite for alice@example.com" in call_args.args[0]
+            for call_args in migrator.log.call_args_list
+        )
         migrator.dest.delete.assert_called_once_with(
             "/orgs/current/members/pending/pending-1"
         )
@@ -394,10 +754,82 @@ class TestUserRoleMigrator:
             {"email": "alice@example.com", "role_id": "dst-role-new"},
         )
 
+    def test_migrate_org_members_reinvites_pending_when_delete_paths_return_not_found(
+        self, migrator
+    ):
+        """Pending invite refresh should still re-invite when cancel endpoints report not found."""
+        migrator._role_id_map = {"src-role": "dst-role-new"}
+        migrator.dest.get_paginated.side_effect = [
+            iter([]),
+            iter([
+                {"id": "pending-1", "email": "alice@example.com", "role_id": "dst-role-old"},
+            ]),
+        ]
+        migrator.dest.delete.side_effect = [
+            APIError("Not found", status_code=404, request_info={}),
+            APIError("User not found", status_code=404, request_info={}),
+        ]
+        migrator.dest.post.return_value = {"id": "new-identity-1"}
+
+        members = [
+            {"id": "src-m1", "email": "alice@example.com", "role_id": "src-role"},
+        ]
+
+        m, s, f = migrator.migrate_org_members(
+            members,
+            remove_pending=True,
+        )
+
+        assert (m, s, f) == (1, 0, 0)
+        assert migrator.dest.delete.call_args_list == [
+            call("/orgs/current/members/pending/pending-1"),
+            call("/orgs/current/members/pending-1"),
+        ]
+        migrator.dest.post.assert_called_once_with(
+            "/orgs/current/members",
+            {"email": "alice@example.com", "role_id": "dst-role-new"},
+        )
+
+    def test_migrate_org_members_blocks_when_pending_cancel_is_unsupported(
+        self, migrator, migration_state
+    ):
+        """Unsupported pending invite cancel APIs block before replacement invite creation."""
+        migrator.state = migration_state
+        migrator._role_id_map = {"src-role": "dst-role-new"}
+        migrator.dest.get_paginated.side_effect = [
+            iter([]),
+            iter([
+                {"id": "pending-1", "email": "alice@example.com", "role_id": "dst-role-old"},
+            ]),
+        ]
+        migrator.dest.delete.side_effect = [
+            APIError("Method not allowed", status_code=405, request_info={}),
+            APIError("Method not allowed", status_code=405, request_info={}),
+        ]
+
+        members = [
+            {"id": "src-m1", "email": "alice@example.com", "role_id": "src-role"},
+        ]
+
+        m, s, f = migrator.migrate_org_members(
+            members,
+            remove_pending=True,
+        )
+
+        assert (m, s, f) == (0, 0, 1)
+        item = migration_state.get_item("org_member_alice@example.com")
+        assert item is not None
+        assert item.outcome_code == "org_member_pending_invite_cancel_unsupported"
+        assert item.evidence["existing_pending_invite_id"] == "pending-1"
+        assert item.evidence["desired_org_role_id"] == "dst-role-new"
+        assert migrator._pending_org_blockers["alice@example.com"]["item_id"] == item.id
+        migrator.dest.post.assert_not_called()
+
     def test_migrate_org_members_reinvites_pending_when_workspace_access_is_needed(
         self, migrator
     ):
         """Existing pending invites should be replaced when workspace access still needs to be attached."""
+        migrator.log = Mock()
         migrator._role_id_map = {
             "src-role": "dst-role",
             "src-ws-role": "dst-ws-role",
@@ -423,6 +855,10 @@ class TestUserRoleMigrator:
         m, s, f = migrator.migrate_org_members(members)
 
         assert (m, s, f) == (1, 0, 0)
+        assert any(
+            "Pending invite for alice@example.com will include workspace access" in call_args.args[0]
+            for call_args in migrator.log.call_args_list
+        )
         migrator.dest.delete.assert_called_once_with(
             "/orgs/current/members/pending/pending-1"
         )
@@ -442,6 +878,7 @@ class TestUserRoleMigrator:
         self, migrator
     ):
         """Existing pending invites are reused when they already include the requested workspace access."""
+        migrator.log = Mock()
         migrator._role_id_map = {
             "src-role": "dst-role",
             "src-ws-role": "dst-ws-role",
@@ -472,10 +909,230 @@ class TestUserRoleMigrator:
         m, s, f = migrator.migrate_org_members(members)
 
         assert (m, s, f) == (0, 1, 0)
+        assert any(
+            "Keeping pending invite for alice@example.com" in call_args.args[0]
+            for call_args in migrator.log.call_args_list
+        )
         assert migrator._pending_org_email_to_identity["alice@example.com"]["id"] == "pending-1"
         assert migrator._pending_workspace_invites == {("alice@example.com", "ws-1")}
         migrator.dest.delete.assert_not_called()
         migrator.dest.post.assert_not_called()
+
+    def test_migrate_org_members_source_of_truth_replaces_pending_invite_with_extra_workspace_access(
+        self, migrator
+    ):
+        """Authoritative sync should remove extra workspace grants embedded in pending invites."""
+        migrator._role_id_map = {
+            "src-role": "dst-role",
+            "src-ws-role": "dst-ws-role",
+        }
+        migrator.dest.get_paginated.side_effect = [
+            iter([]),
+            iter([
+                {
+                    "id": "pending-1",
+                    "email": "alice@example.com",
+                    "role_id": "dst-role",
+                    "workspace_ids": ["ws-1", "ws-2"],
+                    "workspace_role_id": "dst-ws-role",
+                },
+            ]),
+        ]
+        migrator.dest.post.return_value = {"id": "new-identity-1"}
+
+        members = [
+            {
+                "id": "src-m1",
+                "email": "alice@example.com",
+                "role_id": "src-role",
+                "workspace_ids": ["ws-1"],
+                "workspace_role_id": "src-ws-role",
+            },
+        ]
+
+        m, s, f = migrator.migrate_org_members(
+            members,
+            remove_missing=True,
+            remove_pending=True,
+        )
+
+        assert (m, s, f) == (1, 0, 0)
+        migrator.dest.delete.assert_called_once_with(
+            "/orgs/current/members/pending/pending-1"
+        )
+        migrator.dest.post.assert_called_once_with(
+            "/orgs/current/members",
+            {
+                "email": "alice@example.com",
+                "role_id": "dst-role",
+                "workspace_ids": ["ws-1"],
+                "workspace_role_id": "dst-ws-role",
+            },
+        )
+
+    def test_migrate_org_members_pending_replace_permission_failure_calls_out_org_admin_pat(
+        self, migrator, migration_state
+    ):
+        """Pending invite replacement failures should tell operators to use an org admin PAT."""
+        migrator.state = migration_state
+        migrator._role_id_map = {"src-role": "dst-role-new"}
+        migrator.dest.get_paginated.side_effect = [
+            iter([]),
+            iter([
+                {"id": "pending-1", "email": "alice@example.com", "role_id": "dst-role-old"},
+            ]),
+        ]
+        migrator.dest.delete.side_effect = AuthenticationError(
+            "Access denied for /orgs/current/members/pending/pending-1",
+            status_code=403,
+            request_info={"endpoint": "/orgs/current/members/pending/pending-1"},
+        )
+
+        members = [
+            {"id": "src-m1", "email": "alice@example.com", "role_id": "src-role"},
+        ]
+
+        m, s, f = migrator.migrate_org_members(
+            members,
+            remove_pending=True,
+        )
+
+        assert (m, s, f) == (0, 0, 1)
+        item = migration_state.get_item("org_member_alice@example.com")
+        assert item is not None
+        assert item.outcome_code == "org_member_pending_invite_replace_failed"
+        assert "Organization Admin PAT" in item.next_action
+        assert item.evidence["requires_org_admin_pat"] is True
+        migrator.dest.post.assert_not_called()
+
+    def test_migrate_org_members_pending_cancel_api_error_permission_failure_calls_out_org_admin_pat(
+        self, migrator, migration_state
+    ):
+        """403 not-allowed pending invite deletes should be treated as permission failures."""
+        migrator.state = migration_state
+        migrator._role_id_map = {"src-role": "dst-role-new"}
+        migrator.dest.get_paginated.side_effect = [
+            iter([]),
+            iter([
+                {"id": "pending-1", "email": "alice@example.com", "role_id": "dst-role-old"},
+            ]),
+        ]
+        migrator.dest.delete.side_effect = APIError(
+            "not allowed to delete pending invite",
+            status_code=403,
+            request_info={"endpoint": "/orgs/current/members/pending/pending-1"},
+        )
+
+        members = [
+            {"id": "src-m1", "email": "alice@example.com", "role_id": "src-role"},
+        ]
+
+        m, s, f = migrator.migrate_org_members(
+            members,
+            remove_pending=True,
+        )
+
+        assert (m, s, f) == (0, 0, 1)
+        item = migration_state.get_item("org_member_alice@example.com")
+        assert item is not None
+        assert item.outcome_code == "org_member_pending_invite_replace_failed"
+        assert "Organization Admin PAT" in item.next_action
+        assert item.evidence["requires_org_admin_pat"] is True
+        assert migrator.dest.delete.call_args_list == [
+            call("/orgs/current/members/pending/pending-1")
+        ]
+        migrator.dest.post.assert_not_called()
+
+    def test_migrate_org_members_pending_replace_conflict_is_specific(
+        self, migrator, migration_state
+    ):
+        """A replacement conflict after cancel is reported as a pending invite conflict."""
+        migrator.state = migration_state
+        migrator._role_id_map = {
+            "src-role": "dst-role-new",
+            "src-ws-role": "dst-ws-role",
+        }
+        migrator.dest.get_paginated.side_effect = [
+            iter([]),
+            iter([
+                {
+                    "id": "pending-1",
+                    "email": "alice@example.com",
+                    "role_id": "dst-role-old",
+                    "workspace_ids": ["ws-old"],
+                    "workspace_role_id": "dst-ws-old",
+                },
+            ]),
+        ]
+        migrator.dest.post.side_effect = ConflictError(
+            "pending invite already exists",
+            request_info={"endpoint": "/orgs/current/members"},
+        )
+
+        members = [
+            {
+                "id": "src-m1",
+                "email": "alice@example.com",
+                "role_id": "src-role",
+                "workspace_ids": ["ws-new"],
+                "workspace_role_id": "src-ws-role",
+            },
+        ]
+
+        m, s, f = migrator.migrate_org_members(
+            members,
+            remove_pending=True,
+        )
+
+        assert (m, s, f) == (0, 0, 1)
+        item = migration_state.get_item("org_member_alice@example.com")
+        assert item is not None
+        assert item.outcome_code == "org_member_pending_invite_replace_conflict"
+        assert item.evidence["existing_workspace_ids"] == ["ws-old"]
+        assert item.evidence["desired_workspace_ids"] == ["ws-new"]
+        assert item.evidence["existing_workspace_role_id"] == "dst-ws-old"
+        assert item.evidence["desired_workspace_role_id"] == "dst-ws-role"
+        assert migrator._pending_org_blockers["alice@example.com"]["code"] == (
+            "org_member_pending_invite_replace_conflict"
+        )
+
+    def test_migrate_org_members_source_of_truth_replaces_org_only_pending_invite_with_workspace_access(
+        self, migrator
+    ):
+        """Authoritative sync should remove pending workspace access when the CSV only wants org access."""
+        migrator._role_id_map = {"src-role": "dst-role"}
+        migrator.dest.get_paginated.side_effect = [
+            iter([]),
+            iter([
+                {
+                    "id": "pending-1",
+                    "email": "alice@example.com",
+                    "role_id": "dst-role",
+                    "workspace_ids": ["ws-1"],
+                    "workspace_role_id": "dst-ws-role",
+                },
+            ]),
+        ]
+        migrator.dest.post.return_value = {"id": "new-identity-1"}
+
+        members = [
+            {"id": "src-m1", "email": "alice@example.com", "role_id": "src-role"},
+        ]
+
+        m, s, f = migrator.migrate_org_members(
+            members,
+            remove_missing=True,
+            remove_pending=True,
+        )
+
+        assert (m, s, f) == (1, 0, 0)
+        migrator.dest.delete.assert_called_once_with(
+            "/orgs/current/members/pending/pending-1"
+        )
+        migrator.dest.post.assert_called_once_with(
+            "/orgs/current/members",
+            {"email": "alice@example.com", "role_id": "dst-role"},
+        )
 
     def test_migrate_org_members_remove_missing_active_and_pending(self, migrator):
         """Authoritative mode removes extra active members and pending invites."""
@@ -506,6 +1163,38 @@ class TestUserRoleMigrator:
         migrator.dest.delete.assert_any_call(
             "/orgs/current/members/pending/pending-remove"
         )
+
+    def test_migrate_org_members_remove_missing_treats_active_not_found_as_reconciled(
+        self, migrator
+    ):
+        """Authoritative org member removal is idempotent when DELETE reports already absent."""
+        migrator._role_id_map = {"src-role": "dst-role"}
+        migrator.dest.get_paginated.side_effect = [
+            iter([
+                {"id": "dst-keep", "email": "keep@example.com", "role_id": "dst-role"},
+                {"id": "dst-remove", "email": "remove@example.com", "role_id": "dst-role"},
+            ]),
+            iter([]),
+        ]
+        migrator.dest.delete.side_effect = APIError(
+            "User not found",
+            status_code=404,
+            request_info={"endpoint": "/orgs/current/members/dst-remove"},
+        )
+
+        members = [
+            {"id": "src-keep", "email": "keep@example.com", "role_id": "src-role"},
+        ]
+
+        m, s, f = migrator.migrate_org_members(
+            members,
+            remove_missing=True,
+            remove_pending=True,
+        )
+
+        assert (m, s, f) == (1, 1, 0)
+        assert migrator._last_org_member_removals == 1
+        migrator.dest.delete.assert_called_once_with("/orgs/current/members/dst-remove")
 
     # ── Phase 3: Workspace member migration ──
 
@@ -636,6 +1325,51 @@ class TestUserRoleMigrator:
 
         assert (m, s, f) == (0, 1, 0)
         migrator.dest.post.assert_not_called()
+
+    def test_migrate_workspace_members_blocks_pending_org_invite_without_user_id(self, migrator):
+        """Pending org invites without user_id need acceptance before workspace add."""
+        migrator._role_id_map = {"src-ws-role": "dst-ws-role"}
+        pending_identity = {"id": "pending-org-identity-1", "email": "alice@example.com"}
+        migrator._pending_org_email_to_identity = {"alice@example.com": pending_identity}
+        migrator._dest_email_to_identity = {"alice@example.com": pending_identity}
+        migrator.source.get_paginated.return_value = iter([
+            {"id": "src-ws-m1", "email": "alice@example.com", "role_id": "src-ws-role"},
+        ])
+        migrator.dest.get_paginated.return_value = iter([])
+
+        m, s, f = migrator.migrate_workspace_members()
+
+        assert (m, s, f) == (0, 0, 1)
+        migrator.dest.post.assert_not_called()
+        item = migrator.state.items["ws_member_ws-default-src_alice@example.com"]
+        assert item.outcome_code == "ws_member_pending_org_invite"
+
+    def test_migrate_workspace_members_skips_when_org_pending_reconciliation_blocked(
+        self, migrator
+    ):
+        """Workspace phase should not cascade a blocked org pending invite into add failures."""
+        migrator._role_id_map = {"src-ws-role": "dst-ws-role"}
+        migrator._dest_email_to_identity = {}
+        migrator._pending_org_blockers = {
+            "alice@example.com": {
+                "item_id": "org_member_alice@example.com",
+                "code": "org_member_pending_invite_cancel_unsupported",
+                "next_action": "Cancel or replace the pending org invite manually.",
+            }
+        }
+        migrator.source.get_paginated.return_value = iter([
+            {"id": "src-ws-m1", "email": "alice@example.com", "role_id": "src-ws-role"},
+        ])
+        migrator.dest.get_paginated.return_value = iter([])
+
+        m, s, f = migrator.migrate_workspace_members()
+
+        assert (m, s, f) == (0, 1, 0)
+        migrator.dest.post.assert_not_called()
+        item = migrator.state.items["ws_member_ws-default-src_alice@example.com"]
+        assert item.outcome_code == "ws_member_skipped_pending_org_blocker"
+        assert item.evidence["org_item_id"] == "org_member_alice@example.com"
+        assert item.evidence["org_blocker"] == "org_member_pending_invite_cancel_unsupported"
 
     def test_migrate_workspace_members_remove_missing(self, migrator):
         """Authoritative workspace sync removes extra memberships."""
@@ -1017,18 +1751,40 @@ class TestUserRoleMigrator:
         migrator._dest_email_to_identity = {"alice@example.com": {"id": "dst-1"}}
         assert migrator._dest_email_to_identity["alice@example.com"]["id"] == "dst-1"
 
-    def test_migrate_workspace_members_from_csv_rows_rejects_conflicting_roles(
+    def test_migrate_workspace_members_from_csv_rows_combines_custom_roles(
         self, migrator
     ):
-        """CSV workspace rows with conflicting role IDs for one email are rejected."""
+        """CSV workspace rows with multiple custom roles collapse to a union role."""
         migrator.source.session.headers["X-Tenant-Id"] = "ws-src-1"
+        migrator.migrate_workspace_members = Mock(return_value=(1, 0, 0))
         rows = [
-            {"email": "alice@example.com", "role_id": "role-1", "workspace_id": "ws-src-1"},
-            {"email": "alice@example.com", "role_id": "role-2", "workspace_id": "ws-src-1"},
+            {
+                "email": "alice@example.com",
+                "role_id": "src-custom-1",
+                "role_name": "CUSTOM",
+                "workspace_id": "ws-src-1",
+            },
+            {
+                "email": "alice@example.com",
+                "role_id": "src-custom-2",
+                "role_name": "CUSTOM",
+                "workspace_id": "ws-src-1",
+            },
         ]
 
-        with pytest.raises(APIError, match="Conflicting workspace role_id"):
-            migrator.migrate_workspace_members_from_csv_rows(rows)
+        assert migrator.migrate_workspace_members_from_csv_rows(rows) == (1, 0, 0)
+        migrator.migrate_workspace_members.assert_called_once_with(
+            selected_members=[
+                {
+                    "id": "ws-src-1:alice@example.com",
+                    "email": "alice@example.com",
+                    "role_id": make_workspace_role_union_id(
+                        {"src-custom-1", "src-custom-2"}
+                    ),
+                    "full_name": "",
+                }
+            ]
+        )
 
     def test_ws_member_item_id_includes_workspace(self, migrator, migration_state):
         """ws_member item_id includes source workspace to avoid cross-workspace collision."""
@@ -1085,6 +1841,32 @@ class TestUserRoleMigrator:
         assert item.outcome_code == "unmapped_role"
 
     # ── Capability probing ──
+
+    def test_require_destination_org_admin_for_authoritative_sync_fails_on_pending_permission_error(
+        self, migrator, migration_state
+    ):
+        """Authoritative sync should fail fast when pending invite lookup lacks org admin access."""
+        migrator.state = migration_state
+        migrator.dest.get.side_effect = [
+            [],
+            AuthenticationError(
+                "Access denied for /orgs/current/members/pending",
+                status_code=403,
+                request_info={"endpoint": "/orgs/current/members/pending"},
+            ),
+        ]
+
+        with pytest.raises(APIError, match="Organization Admin PAT"):
+            migrator.require_destination_org_admin_for_authoritative_sync()
+
+        assert migrator.dest.get.call_args_list == [
+            call("/orgs/current/members/active", params={"limit": 1}),
+            call("/orgs/current/members/pending", params={"limit": 1}),
+        ]
+        assert migration_state.capability_matrix["dest"]["org_member_management"][
+            "supported"
+        ] is False
+        assert migration_state.issue_log[-1].code == "dest_org_admin_pat_required"
 
     def test_probe_capabilities_success(self, migrator):
         """Probe records capabilities when endpoints succeed."""

--- a/tests/test_users_csv_input.py
+++ b/tests/test_users_csv_input.py
@@ -6,6 +6,7 @@ import click
 import pytest
 
 from langsmith_migrator.cli.main import (
+    _build_single_instance_users_plan,
     _configure_single_instance,
     _csv_rows_for_workspace,
     _csv_rows_to_org_members,
@@ -14,6 +15,9 @@ from langsmith_migrator.cli.main import (
     _normalize_csv_role_scopes,
     _resolve_single_instance_workspace_ids,
     _resolve_csv_role_names,
+)
+from langsmith_migrator.core.migrators.user_role import (
+    make_workspace_role_union_id,
 )
 from langsmith_migrator.utils.config import Config
 
@@ -101,6 +105,26 @@ def test_load_members_csv_accepts_utf8_bom_header(tmp_path: Path):
     ]
 
 
+def test_load_members_csv_preserves_non_empty_workspace_name(tmp_path: Path):
+    csv_path = tmp_path / "members.csv"
+    csv_path.write_text(
+        "email,langsmith_role,workspace_id,workspace_name\n"
+        "alice@example.com,Workspace Admin,ws-1,Workspace A\n",
+        encoding="utf-8",
+    )
+
+    rows = _load_members_csv(str(csv_path))
+
+    assert rows == [
+        {
+            "email": "alice@example.com",
+            "langsmith_role": "Workspace Admin",
+            "workspace_id": "ws-1",
+            "workspace_name": "Workspace A",
+        }
+    ]
+
+
 def test_load_members_csv_allows_empty_workspace_id(tmp_path: Path):
     csv_path = tmp_path / "members.csv"
     csv_path.write_text(
@@ -156,6 +180,21 @@ def test_resolve_csv_role_names_builtin_roles():
     assert resolved[0]["role_id"] == "src-admin"
     assert resolved[1]["role_id"] == "src-ws-admin"
     assert org_user_id == "src-user"
+
+
+def test_resolve_csv_role_names_preserves_workspace_name():
+    rows = [
+        {
+            "email": "b@example.com",
+            "langsmith_role": "Workspace Admin",
+            "workspace_id": "ws-1",
+            "workspace_name": "Workspace A",
+        },
+    ]
+
+    resolved, _ = _resolve_csv_role_names(rows, SOURCE_ROLES)
+
+    assert resolved[0]["workspace_name"] == "Workspace A"
 
 
 def test_resolve_csv_role_names_extended_builtin_aliases():
@@ -409,6 +448,31 @@ def test_csv_rows_to_org_members_single_instance_workspace_only_carries_workspac
     ]
 
 
+def test_csv_rows_to_org_members_single_instance_org_row_carries_workspace_invite():
+    rows = [
+        {"email": "alice@example.com", "role_id": "role-user", "workspace_id": ""},
+        {"email": "alice@example.com", "role_id": "role-ws-admin", "workspace_id": "ws-2"},
+        {"email": "alice@example.com", "role_id": "role-ws-admin", "workspace_id": "ws-1"},
+    ]
+
+    members = _csv_rows_to_org_members(
+        rows,
+        default_org_role_id="role-user",
+        direct_workspace_invites=True,
+    )
+
+    assert members == [
+        {
+            "id": "alice@example.com",
+            "email": "alice@example.com",
+            "role_id": "role-user",
+            "full_name": "",
+            "workspace_ids": ["ws-1", "ws-2"],
+            "workspace_role_id": "role-ws-admin",
+        }
+    ]
+
+
 def test_csv_rows_to_org_members_single_instance_mixed_workspace_roles_omit_direct_invite():
     rows = [
         {"email": "alice@example.com", "role_id": "role-ws-admin", "workspace_id": "ws-1"},
@@ -427,6 +491,42 @@ def test_csv_rows_to_org_members_single_instance_mixed_workspace_roles_omit_dire
             "email": "alice@example.com",
             "role_id": "role-user",
             "full_name": "",
+        }
+    ]
+
+
+def test_csv_rows_to_org_members_single_instance_combines_duplicate_custom_roles_for_invite():
+    rows = [
+        {
+            "email": "alice@example.com",
+            "role_id": "src-custom-1",
+            "role_name": "CUSTOM",
+            "workspace_id": "ws-1",
+        },
+        {
+            "email": "alice@example.com",
+            "role_id": "src-custom-2",
+            "role_name": "CUSTOM",
+            "workspace_id": "ws-1",
+        },
+    ]
+
+    members = _csv_rows_to_org_members(
+        rows,
+        default_org_role_id="role-user",
+        direct_workspace_invites=True,
+    )
+
+    assert members == [
+        {
+            "id": "alice@example.com",
+            "email": "alice@example.com",
+            "role_id": "role-user",
+            "full_name": "",
+            "workspace_ids": ["ws-1"],
+            "workspace_role_id": make_workspace_role_union_id(
+                {"src-custom-1", "src-custom-2"}
+            ),
         }
     ]
 
@@ -475,14 +575,111 @@ def test_csv_rows_for_workspace_dedupes_by_email():
     ]
 
 
-def test_csv_rows_for_workspace_rejects_conflicting_roles():
+def test_csv_rows_for_workspace_combines_custom_roles():
     rows = [
-        {"email": "alice@example.com", "role_id": "role-1", "workspace_id": "ws-1"},
-        {"email": "alice@example.com", "role_id": "role-2", "workspace_id": "ws-1"},
+        {
+            "email": "alice@example.com",
+            "role_id": "src-custom-1",
+            "role_name": "CUSTOM",
+            "workspace_id": "ws-1",
+        },
+        {
+            "email": "alice@example.com",
+            "role_id": "src-custom-2",
+            "role_name": "CUSTOM",
+            "workspace_id": "ws-1",
+        },
     ]
 
-    with pytest.raises(click.ClickException, match="conflicting role_id"):
-        _csv_rows_for_workspace(rows, "ws-1")
+    selected = _csv_rows_for_workspace(rows, "ws-1")
+
+    assert selected == [
+        {
+            "id": "ws-1:alice@example.com",
+            "email": "alice@example.com",
+            "role_id": make_workspace_role_union_id(
+                {"src-custom-1", "src-custom-2"}
+            ),
+            "full_name": "",
+        }
+    ]
+
+
+def test_csv_rows_for_workspace_picks_highest_builtin_role():
+    rows = [
+        {
+            "email": "alice@example.com",
+            "role_id": "src-ws-viewer",
+            "role_name": "WORKSPACE_VIEWER",
+            "workspace_id": "ws-1",
+        },
+        {
+            "email": "alice@example.com",
+            "role_id": "src-ws-admin",
+            "role_name": "WORKSPACE_ADMIN",
+            "workspace_id": "ws-1",
+        },
+        {
+            "email": "alice@example.com",
+            "role_id": "src-ws-user",
+            "role_name": "WORKSPACE_USER",
+            "workspace_id": "ws-1",
+        },
+    ]
+
+    selected = _csv_rows_for_workspace(rows, "ws-1")
+
+    assert selected[0]["role_id"] == "src-ws-admin"
+
+
+def test_csv_rows_for_workspace_unions_custom_role_with_workspace_admin():
+    rows = [
+        {
+            "email": "alice@example.com",
+            "role_id": "src-ws-admin",
+            "role_name": "WORKSPACE_ADMIN",
+            "workspace_id": "ws-1",
+        },
+        {
+            "email": "alice@example.com",
+            "role_id": "src-custom-1",
+            "role_name": "CUSTOM",
+            "workspace_id": "ws-1",
+        },
+    ]
+
+    selected = _csv_rows_for_workspace(rows, "ws-1")
+
+    assert selected[0]["role_id"] == make_workspace_role_union_id(
+        {"src-ws-admin", "src-custom-1"}
+    )
+
+
+def test_csv_rows_to_org_members_unions_custom_role_with_workspace_admin_for_invite():
+    rows = [
+        {
+            "email": "alice@example.com",
+            "role_id": "src-ws-admin",
+            "role_name": "WORKSPACE_ADMIN",
+            "workspace_id": "ws-1",
+        },
+        {
+            "email": "alice@example.com",
+            "role_id": "src-custom-1",
+            "role_name": "CUSTOM",
+            "workspace_id": "ws-1",
+        },
+    ]
+
+    members = _csv_rows_to_org_members(
+        rows,
+        default_org_role_id="role-user",
+        direct_workspace_invites=True,
+    )
+
+    assert members[0]["workspace_role_id"] == make_workspace_role_union_id(
+        {"src-ws-admin", "src-custom-1"}
+    )
 
 
 def test_csv_rows_for_workspace_ignores_org_rows():
@@ -629,3 +826,131 @@ def test_resolve_single_instance_workspace_ids_source_of_truth_uses_all_workspac
     )
 
     assert workspace_ids == ["ws-1", "ws-2"]
+
+
+def test_build_single_instance_users_plan_rejects_workspace_name_mismatch():
+    rows = [
+        {
+            "email": "alice@example.com",
+            "role_id": "role-ws-admin",
+            "workspace_id": "ws-1",
+            "workspace_name": "Workspace B",
+        },
+    ]
+
+    with pytest.raises(click.ClickException) as exc_info:
+        _build_single_instance_users_plan(
+            rows,
+            available_workspaces=[{"id": "ws-1", "display_name": "Workspace A"}],
+            default_org_role_id="role-user",
+            source_of_truth=False,
+        )
+
+    message = str(exc_info.value)
+    assert "workspace_name mismatch" in message
+    assert "Workspace B" in message
+    assert "Workspace A" in message
+
+
+def test_build_single_instance_users_plan_authoritative_includes_empty_workspaces():
+    rows = [
+        {
+            "email": "alice@example.com",
+            "role_id": "role-ws-admin",
+            "workspace_id": "ws-1",
+        },
+    ]
+
+    plan = _build_single_instance_users_plan(
+        rows,
+        available_workspaces=[
+            {"id": "ws-1", "display_name": "Workspace A"},
+            {"id": "ws-2", "display_name": "Workspace B"},
+        ],
+        default_org_role_id="role-user",
+        source_of_truth=True,
+    )
+
+    assert plan.workspace_ids == ["ws-1", "ws-2"]
+    assert plan.workspace_members_by_id["ws-1"] == [
+        {
+            "id": "ws-1:alice@example.com",
+            "email": "alice@example.com",
+            "role_id": "role-ws-admin",
+            "full_name": "",
+        }
+    ]
+    assert plan.workspace_members_by_id["ws-2"] == []
+
+
+def test_build_single_instance_users_plan_notes_mixed_workspace_roles():
+    rows = [
+        {
+            "email": "alice@example.com",
+            "role_id": "role-ws-admin",
+            "workspace_id": "ws-1",
+        },
+        {
+            "email": "alice@example.com",
+            "role_id": "role-ws-viewer",
+            "workspace_id": "ws-2",
+        },
+    ]
+
+    plan = _build_single_instance_users_plan(
+        rows,
+        available_workspaces=[
+            {"id": "ws-1", "display_name": "Workspace A"},
+            {"id": "ws-2", "display_name": "Workspace B"},
+        ],
+        default_org_role_id="role-user",
+        source_of_truth=False,
+    )
+
+    assert plan.org_members == [
+        {
+            "id": "alice@example.com",
+            "email": "alice@example.com",
+            "role_id": "role-user",
+            "full_name": "",
+        }
+    ]
+    assert any(
+        "alice@example.com has multiple workspace roles" in note
+        for note in plan.operator_notes
+    )
+
+
+def test_build_single_instance_users_plan_notes_org_row_with_mixed_workspace_roles():
+    rows = [
+        {
+            "email": "alice@example.com",
+            "role_id": "role-user",
+            "workspace_id": "",
+        },
+        {
+            "email": "alice@example.com",
+            "role_id": "role-ws-admin",
+            "workspace_id": "ws-1",
+        },
+        {
+            "email": "alice@example.com",
+            "role_id": "role-ws-viewer",
+            "workspace_id": "ws-2",
+        },
+    ]
+
+    plan = _build_single_instance_users_plan(
+        rows,
+        available_workspaces=[
+            {"id": "ws-1", "display_name": "Workspace A"},
+            {"id": "ws-2", "display_name": "Workspace B"},
+        ],
+        default_org_role_id="role-user",
+        source_of_truth=False,
+    )
+
+    assert any(
+        "alice@example.com has multiple workspace roles" in note
+        for note in plan.operator_notes
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.65"
+version = "0.0.66"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- prepare v0.0.66 with README/install snippets and changelog notes
- combine repeated CSV rows per user/workspace, including ABAC custom-role unionization with built-in workspace roles
- harden authoritative CSV sync for pending invites, removals, Org Admin PAT blockers, and automation-friendly remediation

## Test Plan
- uv run ruff check langsmith_migrator .github/scripts/check_wheel_contents.py
- uv run pytest -q tests/test_users_csv_input.py tests/test_user_role_migrator.py tests/functional/test_cli_functional.py -k "users_command or users_csv or single_instance or pending or workspace_admin or custom_role_with_workspace_admin"
- uv run pytest -q
- BASE_REF=main bash .github/scripts/check_readme_release_sync.sh
- uv build
- python3 .github/scripts/check_wheel_contents.py dist/langsmith_data_migration_tool-0.0.66-py3-none-any.whl
- uvx --from ./dist/langsmith_data_migration_tool-0.0.66-py3-none-any.whl langsmith-migrator --help