### PR TITLE
Fix rules project mapping filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.67] - 2026-04-29
+
+### Fixed
+- **Rules project mapping**: `langsmith-migrator rules --project-mapping ...` now rewrites source project IDs embedded in `filter`, `trace_filter`, and `tree_filter` payloads, including dataset-associated rules whose project scope is hidden inside the rule filter body.
+
 ## [0.0.66] - 2026-04-29
 
 ### Added
@@ -302,7 +307,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration documentation
 - API reference for core classes
 
-[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.66...HEAD
+[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.67...HEAD
+[0.0.67]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.66...v0.0.67
 [0.0.66]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.65...v0.0.66
 [0.0.65]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.64...v0.0.65
 [0.0.64]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.63...v0.0.64

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python CLI for migrating users and roles, datasets, experiments, annotation qu
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.66-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.67-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -54,20 +54,20 @@ For trace data, use LangSmith's **Bulk Export** functionality: [LangSmith Bulk E
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.66-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.67-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.66-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.67-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.66-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.67-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.66-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.67-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)
@@ -390,7 +390,7 @@ When `--skip-users` is omitted, `migrate-all` runs user/role migration as Step 0
 Rules and charts reference projects by ID. When migrating between instances, project IDs differ.
 
 - **Interactive TUI (`--map-projects`)**: Launch a visual TUI to map source projects to destination projects. Available on `rules`, `charts`, and `migrate-all` commands. Select a source project and type a destination name directly — existing projects appear as filterable suggestions below the input. Supports auto-match by name, skip, and custom name entry.
-- **Rules (`--project-mapping`)**: Supply an explicit source→destination project ID mapping as JSON or a file path. Use `list-projects --source` and `list-projects --dest` to get IDs. Mutually exclusive with `--map-projects`.
+- **Rules (`--project-mapping`)**: Supply an explicit source→destination project ID mapping as JSON or a file path. Use `list-projects --source` and `list-projects --dest` to get IDs. The mapping is applied to both top-level project associations and project IDs embedded inside rule filters. Mutually exclusive with `--map-projects`.
 - **Charts**: Without `--map-projects`, project mapping is built automatically by matching project names between source and destination.
 - **`migrate-all`**: Supports `--strip-projects`, `--map-projects`, and `--rules-create-enabled` for rules. Use the standalone `rules` command for `--project-mapping` JSON mappings.
 

--- a/langsmith_migrator/__init__.py
+++ b/langsmith_migrator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("langsmith-data-migration-tool")
 except PackageNotFoundError:
-    __version__ = "0.0.66"
+    __version__ = "0.0.67"

--- a/langsmith_migrator/core/migrators/rules.py
+++ b/langsmith_migrator/core/migrators/rules.py
@@ -113,6 +113,48 @@ class RulesMigrator(BaseMigrator):
             self.log(f"Failed to check prompt existence for {prompt_handle}: {e}", "warning")
             return False
 
+    def _replace_project_ids(self, value: Any, project_map: Dict[str, str]) -> Any:
+        """Recursively replace source project IDs with destination project IDs."""
+        if not project_map:
+            return value
+        if isinstance(value, str):
+            mapped = value
+            for source_id, dest_id in sorted(
+                project_map.items(),
+                key=lambda item: len(item[0]),
+                reverse=True,
+            ):
+                if source_id and dest_id:
+                    mapped = mapped.replace(source_id, dest_id)
+            return mapped
+        if isinstance(value, list):
+            return [self._replace_project_ids(item, project_map) for item in value]
+        if isinstance(value, dict):
+            return {
+                self._replace_project_ids(key, project_map): self._replace_project_ids(
+                    item,
+                    project_map,
+                )
+                for key, item in value.items()
+            }
+        return value
+
+    def _map_project_references_in_rule_payload(
+        self,
+        payload: Dict[str, Any],
+        project_map: Dict[str, str],
+    ) -> Dict[str, Any]:
+        """Map project IDs embedded inside rule filter payload fields."""
+        mapped_payload = dict(payload)
+        for field in ("filter", "trace_filter", "tree_filter"):
+            if field in mapped_payload:
+                original = mapped_payload[field]
+                mapped = self._replace_project_ids(original, project_map)
+                if mapped != original:
+                    self.log(f"Mapped project references in rule {field}", "info")
+                mapped_payload[field] = mapped
+        return mapped_payload
+
     def _rule_item_id(self, rule: Dict[str, Any]) -> str:
         return f"rule_{rule.get('id', rule.get('display_name', 'unnamed'))}"
 
@@ -1032,6 +1074,11 @@ class RulesMigrator(BaseMigrator):
                 dest_dataset_id = dataset_map.get(source_dataset_id)
                 if not dest_dataset_id:
                     self.log(f"Warning: Dataset {source_dataset_id} not found in destination", "warning")
+
+            effective_project_map = dict(project_map)
+            if source_session_id and target_project_id:
+                effective_project_map[source_session_id] = target_project_id
+            payload = self._map_project_references_in_rule_payload(payload, effective_project_map)
 
             # Determine endpoint and payload based on project/dataset context
             if strip_project_reference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.66"
+version = "0.0.67"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -1923,6 +1923,45 @@ def test_rules_command_uses_custom_project_mapping_and_create_enabled(cli_harnes
     assert "Rules: 1 migrated, 0 skipped, 0 failed" in cli_harness.console.text
 
 
+def test_rules_command_uses_custom_project_mapping_for_selected_rule(cli_harness):
+    """Inline project mappings should also work through the interactive selector path."""
+
+    source_rule = {
+        "id": "rule-1",
+        "display_name": "Alignment",
+        "dataset_id": "dataset-1",
+    }
+    skipped_rule = {
+        "id": "rule-2",
+        "display_name": "Not Selected",
+        "dataset_id": "dataset-2",
+    }
+    cli_harness.migrators.rules.list_rules.return_value = [source_rule, skipped_rule]
+    cli_harness.migrators.rules.create_rule.return_value = "dest-rule-1"
+    cli_harness.controls.select_results = [[source_rule]]
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(
+        [
+            "rules",
+            "--project-mapping",
+            '{"source-project-id": "dest-project-id"}',
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert cli_harness.migrators.rules._project_id_map == {
+        "source-project-id": "dest-project-id"
+    }
+    cli_harness.migrators.rules.create_rule.assert_called_once_with(
+        source_rule,
+        strip_project_reference=False,
+        create_disabled=True,
+    )
+    assert "Selected 1 rule(s)" in cli_harness.console.text
+    assert "Rules: 1 migrated, 0 skipped, 0 failed" in cli_harness.console.text
+
+
 def test_rules_command_uses_workspace_project_mappings(cli_harness):
     """Standalone rules migration should consume per-workspace project mappings from workspace resolution."""
 

--- a/tests/test_rules_migrator.py
+++ b/tests/test_rules_migrator.py
@@ -323,6 +323,42 @@ class TestRulesMigrator:
         payload = call_args[0][1]
         assert payload.get('session_id') == 'dest-project-456'
 
+    def test_create_rule_remaps_project_ids_inside_rule_filters(
+        self, rules_migrator, mock_api_client, sample_config
+    ):
+        """Project mappings should rewrite project IDs embedded in rule filters."""
+        sample_config.migration.dry_run = False
+
+        project_filtered_rule = {
+            'id': 'rule-with-filtered-project',
+            'display_name': 'Project Filtered Rule',
+            'is_enabled': True,
+            'sampling_rate': 1.0,
+            'dataset_id': 'source-dataset-789',
+            'filter': 'and(eq(session_id, "source-project-123"), eq(is_root, true))',
+            'trace_filter': {
+                'op': 'eq',
+                'field': 'session_id',
+                'value': 'source-project-123',
+            },
+            'tree_filter': [
+                {'field': 'project_id', 'value': 'source-project-123'},
+            ],
+        }
+
+        rules_migrator._project_id_map = {'source-project-123': 'dest-project-456'}
+        rules_migrator._dataset_id_map = {'source-dataset-789': 'dest-dataset-abc'}
+        mock_api_client.post.return_value = {'id': 'new-rule-123'}
+
+        result = rules_migrator.create_rule(project_filtered_rule)
+
+        assert result == 'new-rule-123'
+        payload = mock_api_client.post.call_args[0][1]
+        assert 'source-project-123' not in str(payload)
+        assert 'dest-project-456' in payload['filter']
+        assert payload['trace_filter']['value'] == 'dest-project-456'
+        assert payload['tree_filter'][0]['value'] == 'dest-project-456'
+
     def test_create_rule_with_both_project_and_dataset(self, rules_migrator, mock_api_client, sample_config):
         """Test creating a rule with both project and dataset mapping."""
         sample_config.migration.dry_run = False

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.66"
+version = "0.0.67"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- apply `rules --project-mapping` to source project IDs embedded inside rule `filter`, `trace_filter`, and `tree_filter` payloads
- cover the selected-rule CLI path for `rules --project-mapping mapping.json`
- bump release metadata/docs to `0.0.67`

## Validation
- `uv run pytest -q`
- `uv run pytest -q tests/test_rules_migrator.py tests/functional/test_cli_functional.py::test_rules_command_uses_custom_project_mapping_for_selected_rule tests/functional/test_cli_functional.py::test_rules_command_uses_custom_project_mapping_and_create_enabled tests/functional/test_cli_functional.py::test_rules_command_uses_workspace_project_mappings`
- `uv build`
- `python3 .github/scripts/check_wheel_contents.py dist/langsmith_data_migration_tool-0.0.67-py3-none-any.whl`
- `BASE_REF=main bash .github/scripts/check_readme_release_sync.sh`