### PR TITLE
Prepare v0.0.67 release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.67] - 2026-04-29
+
 ### Added
 - **Rules annotation queue remapping**: Rules that target annotation queues now reuse saved queue mappings or exact-name destination queue matches, and export for remediation when the queue dependency cannot be resolved safely.
 
 ### Fixed
-- **Chart dependency remapping**: Chart migration now records unresolved project/session/dataset dependencies for manual remediation instead of posting charts with source IDs, while preserving dataset IDs in true same-instance chart runs.
-
-## [0.0.67] - 2026-04-29
-
-### Fixed
 - **Rules project mapping**: `langsmith-migrator rules --project-mapping ...` now rewrites source project IDs embedded in `filter`, `trace_filter`, and `tree_filter` payloads, including dataset-associated rules whose project scope is hidden inside the rule filter body.
+- **Chart dependency remapping**: Chart migration now records unresolved project/session/dataset dependencies for manual remediation instead of posting charts with source IDs, while preserving dataset IDs in true same-instance chart runs.
 
 ## [0.0.66] - 2026-04-29
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ langsmith-migrator rules --create-enabled      # Create rules enabled (default: 
 langsmith-migrator charts
 langsmith-migrator charts --session "project-name"
 langsmith-migrator charts --map-projects        # Interactive TUI project mapping
-langsmith-migrator charts --same-instance       # Reuse source project/session IDs on destination
+langsmith-migrator charts --same-instance       # Reuse source IDs only when both sides share IDs
 
 # Utilities
 langsmith-migrator list-projects --source
@@ -335,7 +335,7 @@ The prompt default is `No` (rules are created disabled).
 ```bash
 --session TEXT          Migrate charts for a specific session/project (by name or ID)
 --map-projects          Launch interactive TUI to map source projects to destination projects
---same-instance         Source and destination are the same instance (use same session IDs)
+--same-instance         Reuse source project/session IDs on destination only when both sides truly share IDs
 ```
 
 ### Users Options
@@ -385,6 +385,7 @@ Rules are created disabled by default. Use `--create-enabled` on the `rules` com
 ```
 
 When `--skip-users` is omitted, `migrate-all` runs user/role migration as Step 0 before all other resources. Phases 1-2 (roles + org members) run once; phase 3 (workspace members) runs per workspace pair.
+
 ### Project Mapping
 
 Rules and charts reference projects by ID. When migrating between instances, project IDs differ.


### PR DESCRIPTION
## Summary
- move the merged rules/chart fixes into the 0.0.67 changelog entry
- tighten README wording for charts --same-instance and fix Project Mapping spacing

## Verification
- BASE_REF=main bash .github/scripts/check_readme_release_sync.sh
- uv run pytest -q
- uv build
- python3 .github/scripts/check_wheel_contents.py dist/langsmith_data_migration_tool-0.0.67-py3-none-any.whl
- uvx --from ./dist/langsmith_data_migration_tool-0.0.67-py3-none-any.whl langsmith-migrator --help