### PR TITLE
Guard stale chart same-instance resume metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Chart resume mode changes**: `resume` now detects stale chart `--same-instance` metadata, re-resolves the destination project/session for the current source/destination context, and checkpoints with clear guidance if remapping cannot be resolved safely.
+
 ## [0.0.67] - 2026-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -450,6 +450,8 @@ Every migration session persists state and writes a remediation bundle when ther
 - org members
 - workspace members
 
+For chart items, `resume` revalidates saved `--same-instance` metadata against the current source/destination and workspace context. If the mode changed, it re-resolves the destination project/session before retrying; if that cannot be resolved safely, the item is checkpointed with guidance to rerun `charts` with project mapping.
+
 Use `langsmith-migrator clean` to remove saved sessions once you no longer need their state or remediation bundles.
 
 ## SSL Certificate Issues

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -15,6 +15,12 @@ from rich.prompt import Confirm
 from rich.progress import Progress
 from rich.table import Table
 
+from ..utils.chart_mode import (
+    is_same_deployment as _chart_is_same_deployment,
+    normalize_deployment_url as _chart_normalize_deployment_url,
+    should_reuse_chart_ids,
+    workspace_pair_allows_same_instance as _chart_workspace_pair_allows_same_instance,
+)
 from ..utils.config import Config
 from ..utils.state import MigrationStatus, ResolutionOutcome, StateManager, VerificationState
 from ..core.migrators import (
@@ -116,26 +122,20 @@ def _name_mapping_to_id_mapping(
 
 def _normalize_deployment_url(base_url: str) -> str:
     """Normalize a LangSmith deployment URL for same-deployment comparisons."""
-    normalized = (base_url or "").strip().rstrip("/").lower()
-    for suffix in ("/api/v1", "/api/v2"):
-        if normalized.endswith(suffix):
-            normalized = normalized[: -len(suffix)]
-            break
-    return normalized
+    return _chart_normalize_deployment_url(base_url)
 
 
 def _is_same_deployment(config: Config) -> bool:
     """Return True when source and destination point at the same deployment."""
-    return _normalize_deployment_url(config.source.base_url) == _normalize_deployment_url(
-        config.destination.base_url
-    )
+    return _chart_is_same_deployment(config)
 
 
 def _workspace_pair_allows_same_instance(source_workspace_id=None, dest_workspace_id=None) -> bool:
     """Return True when chart IDs can safely be reused across the active workspace scope."""
-    if not source_workspace_id and not dest_workspace_id:
-        return True
-    return bool(source_workspace_id) and source_workspace_id == dest_workspace_id
+    return _chart_workspace_pair_allows_same_instance(
+        source_workspace_id,
+        dest_workspace_id,
+    )
 
 
 def _auto_detect_chart_same_instance(
@@ -151,10 +151,7 @@ def _auto_detect_chart_same_instance(
         bool(source_workspace_id)
         and source_workspace_id == dest_workspace_id
     )
-    if _workspace_pair_allows_same_instance(source_workspace_id, dest_workspace_id) and (
-        config.source.api_key == config.destination.api_key
-        or same_workspace_scope
-    ):
+    if should_reuse_chart_ids(config, source_workspace_id, dest_workspace_id):
         if same_workspace_scope and config.source.api_key != config.destination.api_key:
             console.print(
                 "[dim]Detected the same deployment with an identical workspace scope "

--- a/langsmith_migrator/core/migrators/orchestrator.py
+++ b/langsmith_migrator/core/migrators/orchestrator.py
@@ -14,6 +14,7 @@ from ...utils.state import (
     StateManager,
     VerificationState,
 )
+from ...utils.chart_mode import should_reuse_chart_ids
 from .dataset import DatasetMigrator
 from .experiment import ExperimentMigrator
 from .feedback import FeedbackMigrator
@@ -522,6 +523,100 @@ class MigrationOrchestrator:
         else:
             self.clear_workspace_context()
 
+    def _prepare_chart_resume_context(
+        self,
+        item: MigrationItem,
+        chart_payload,
+        chart_migrator,
+    ) -> tuple[bool, str | None, bool]:
+        """Validate and refresh chart resume mode metadata for the current config."""
+        saved_same_instance_present = "same_instance" in item.metadata
+        saved_same_instance = bool(item.metadata.get("same_instance", False))
+        saved_dest_session_id = item.metadata.get("dest_session_id")
+        workspace_pair = self.workspace_pair()
+        current_same_instance = should_reuse_chart_ids(
+            self.config,
+            workspace_pair.get("source"),
+            workspace_pair.get("dest"),
+        )
+
+        if not saved_same_instance_present or saved_same_instance == current_same_instance:
+            return True, saved_dest_session_id, saved_same_instance
+
+        chart_name = item.name or item.source_id
+        self.console.print(
+            "[yellow]Chart resume context changed for "
+            f"{chart_name}: saved same-instance mode was {saved_same_instance}, "
+            f"current source/destination context expects {current_same_instance}. "
+            "Re-resolving destination project/session before retrying.[/yellow]"
+        )
+
+        source_session_id = chart_migrator._extract_session_id(chart_payload)
+        dest_session_id = chart_migrator.resolve_destination_session_id(
+            source_session_id,
+            same_instance=current_same_instance,
+        )
+        evidence = {
+            "source_session_id": source_session_id,
+            "saved_same_instance": saved_same_instance,
+            "current_same_instance": current_same_instance,
+            "saved_dest_session_id": saved_dest_session_id,
+            "resolved_dest_session_id": dest_session_id,
+            "workspace_pair": workspace_pair,
+        }
+
+        if not dest_session_id:
+            message = (
+                "Cannot resume chart with stale same-instance metadata because "
+                "the current source/destination context could not resolve a "
+                "destination project/session."
+            )
+            next_action = (
+                "Start a fresh `langsmith-migrator charts` run with the current "
+                "source/destination configuration, or run with `--map-projects` "
+                "so the destination project/session can be resolved."
+            )
+            self.console.print(f"[yellow]{message}[/yellow]")
+            issue = self.state.add_issue(
+                "configuration",
+                "chart_resume_context_changed",
+                message,
+                item_id=item.id,
+                next_action=next_action,
+                evidence=evidence,
+                workspace_pair=workspace_pair,
+            )
+            self.state.queue_remediation(
+                issue_id=issue.id,
+                item_id=item.id,
+                next_action=next_action,
+                command="langsmith-migrator charts --map-projects",
+            )
+            self.state.mark_terminal(
+                item.id,
+                ResolutionOutcome.BLOCKED_WITH_CHECKPOINT,
+                "chart_resume_context_changed",
+                verification_state=VerificationState.BLOCKED,
+                next_action=next_action,
+                evidence=evidence,
+                error=message,
+            )
+            return False, None, current_same_instance
+
+        self.state.update_item_checkpoint(
+            item.id,
+            stage="resume_context_refreshed",
+            metadata={
+                "same_instance": current_same_instance,
+                "dest_session_id": dest_session_id,
+                "previous_same_instance": saved_same_instance,
+                "previous_dest_session_id": saved_dest_session_id,
+            },
+            evidence=evidence,
+        )
+        self.state_manager.save()
+        return True, dest_session_id, current_same_instance
+
     def resume_items(self, items_to_process: List[MigrationItem]) -> Dict[str, List[str]]:
         """Resume pending and failed items using typed dispatch."""
         self.ensure_state()
@@ -669,10 +764,21 @@ class MigrationOrchestrator:
                 elif item.type == "chart":
                     chart_payload = item.metadata.get("chart")
                     if chart_payload:
+                        can_resume, dest_session_id, same_instance = (
+                            self._prepare_chart_resume_context(
+                                item,
+                                chart_payload,
+                                chart_migrator,
+                            )
+                        )
+                        if not can_resume:
+                            results["blocked"].append(f"{item.type}:{item.source_id}")
+                            self.state_manager.save()
+                            continue
                         destination_id = chart_migrator.migrate_chart(
                             chart_payload,
-                            item.metadata.get("dest_session_id"),
-                            same_instance=item.metadata.get("same_instance", False),
+                            dest_session_id,
+                            same_instance=same_instance,
                         )
                         if destination_id and not self.state.get_item(item.id).terminal_state:
                             self.state.update_item_status(

--- a/langsmith_migrator/utils/chart_mode.py
+++ b/langsmith_migrator/utils/chart_mode.py
@@ -1,0 +1,54 @@
+"""Helpers for deciding whether chart migration may reuse source IDs."""
+
+from __future__ import annotations
+
+from .config import Config
+
+
+def normalize_deployment_url(base_url: str) -> str:
+    """Normalize a LangSmith deployment URL for same-deployment comparisons."""
+    normalized = (base_url or "").strip().rstrip("/").lower()
+    for suffix in ("/api/v1", "/api/v2"):
+        if normalized.endswith(suffix):
+            normalized = normalized[: -len(suffix)]
+            break
+    return normalized
+
+
+def is_same_deployment(config: Config) -> bool:
+    """Return True when source and destination point at the same deployment."""
+    return normalize_deployment_url(config.source.base_url) == normalize_deployment_url(
+        config.destination.base_url
+    )
+
+
+def workspace_pair_allows_same_instance(
+    source_workspace_id: str | None = None,
+    dest_workspace_id: str | None = None,
+) -> bool:
+    """Return True when chart IDs can safely be reused for a workspace pair."""
+    if not source_workspace_id and not dest_workspace_id:
+        return True
+    return bool(source_workspace_id) and source_workspace_id == dest_workspace_id
+
+
+def should_reuse_chart_ids(
+    config: Config,
+    source_workspace_id: str | None = None,
+    dest_workspace_id: str | None = None,
+) -> bool:
+    """Return whether chart migration should run in same-instance ID reuse mode."""
+    if not is_same_deployment(config):
+        return False
+
+    same_workspace_scope = (
+        bool(source_workspace_id)
+        and source_workspace_id == dest_workspace_id
+    )
+    return workspace_pair_allows_same_instance(
+        source_workspace_id,
+        dest_workspace_id,
+    ) and (
+        config.source.api_key == config.destination.api_key
+        or same_workspace_scope
+    )

--- a/tests/test_orchestrator_resume.py
+++ b/tests/test_orchestrator_resume.py
@@ -6,7 +6,12 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 from langsmith_migrator.core.migrators.orchestrator import MigrationOrchestrator
-from langsmith_migrator.utils.state import MigrationItem, MigrationStatus, StateManager
+from langsmith_migrator.utils.state import (
+    MigrationItem,
+    MigrationStatus,
+    ResolutionOutcome,
+    StateManager,
+)
 
 
 class _FakeClient:
@@ -21,6 +26,14 @@ class _FakeClient:
 
     def close(self) -> None:
         return None
+
+
+class _FakeConsole:
+    def __init__(self) -> None:
+        self.text = ""
+
+    def print(self, *args, end="\n", **kwargs) -> None:
+        self.text += "".join(str(arg) for arg in args) + end
 
 
 def test_resume_items_continues_non_user_items_when_dest_org_prefetch_fails(
@@ -111,6 +124,10 @@ def test_resume_items_forwards_chart_same_instance_metadata(
 ):
     """Resume should preserve same-instance chart metadata when retrying chart items."""
 
+    sample_config.source.base_url = "https://api.smith.langchain.com"
+    sample_config.destination.base_url = "https://api.smith.langchain.com/api/v1"
+    sample_config.destination.api_key = sample_config.source.api_key
+
     clients = [_FakeClient(), _FakeClient()]
     monkeypatch.setattr(
         "langsmith_migrator.core.migrators.orchestrator.EnhancedAPIClient",
@@ -170,3 +187,173 @@ def test_resume_items_forwards_chart_same_instance_metadata(
         "source-session",
         same_instance=True,
     )
+
+
+def test_resume_items_re_resolves_chart_when_same_instance_metadata_is_stale(
+    monkeypatch, sample_config, migration_state, tmp_path
+):
+    """Stale same-instance chart resume metadata should be repaired before replay."""
+
+    sample_config.source.base_url = "https://api.smith.langchain.com"
+    sample_config.destination.base_url = "https://api.smith.langchain.com"
+    sample_config.source.api_key = "source-workspace-key"
+    sample_config.destination.api_key = "dest-workspace-key"
+    migration_state.id_mappings["project"] = {"source-session": "dest-session"}
+
+    clients = [_FakeClient(), _FakeClient()]
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.EnhancedAPIClient",
+        lambda **kwargs: clients.pop(0),
+    )
+
+    chart_migrator = Mock()
+    chart_migrator._extract_session_id.return_value = "source-session"
+    chart_migrator.resolve_destination_session_id.return_value = "dest-session"
+    chart_migrator.migrate_chart.return_value = "dest-chart-1"
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.chart.ChartMigrator",
+        lambda *args, **kwargs: chart_migrator,
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.prompt.PromptMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.annotation_queue.AnnotationQueueMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.rules.RulesMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.ExperimentMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.FeedbackMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+
+    state_manager = StateManager(tmp_path / "state")
+    orchestrator = MigrationOrchestrator(sample_config, state_manager)
+    orchestrator.console = _FakeConsole()
+    orchestrator.state = migration_state
+
+    chart_payload = {
+        "id": "chart-1",
+        "title": "Chart One",
+        "project_id": "source-session",
+        "series": [],
+    }
+    chart_item = MigrationItem(
+        id="chart_default_chart-1",
+        type="chart",
+        name="Chart One",
+        source_id="chart-1",
+        status=MigrationStatus.PENDING,
+        metadata={
+            "chart": chart_payload,
+            "dest_session_id": "source-session",
+            "same_instance": True,
+        },
+    )
+    migration_state.add_item(chart_item)
+
+    results = orchestrator.resume_items([chart_item])
+
+    assert results["resumed"] == ["chart:chart-1"]
+    assert results["blocked"] == []
+    assert "Chart resume context changed" in orchestrator.console.text
+    chart_migrator.resolve_destination_session_id.assert_called_once_with(
+        "source-session",
+        same_instance=False,
+    )
+    chart_migrator.migrate_chart.assert_called_once_with(
+        chart_payload,
+        "dest-session",
+        same_instance=False,
+    )
+    assert chart_item.metadata["same_instance"] is False
+    assert chart_item.metadata["dest_session_id"] == "dest-session"
+    assert chart_item.metadata["previous_same_instance"] is True
+    assert chart_item.metadata["previous_dest_session_id"] == "source-session"
+
+
+def test_resume_items_blocks_chart_when_stale_context_cannot_resolve_destination(
+    monkeypatch, sample_config, migration_state, tmp_path
+):
+    """Stale chart resume metadata should checkpoint if remap resolution is unsafe."""
+
+    sample_config.source.base_url = "https://api.smith.langchain.com"
+    sample_config.destination.base_url = "https://api.smith.langchain.com"
+    sample_config.source.api_key = "source-workspace-key"
+    sample_config.destination.api_key = "dest-workspace-key"
+
+    clients = [_FakeClient(), _FakeClient()]
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.EnhancedAPIClient",
+        lambda **kwargs: clients.pop(0),
+    )
+
+    chart_migrator = Mock()
+    chart_migrator._extract_session_id.return_value = "source-session"
+    chart_migrator.resolve_destination_session_id.return_value = None
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.chart.ChartMigrator",
+        lambda *args, **kwargs: chart_migrator,
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.prompt.PromptMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.annotation_queue.AnnotationQueueMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.rules.RulesMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.ExperimentMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.FeedbackMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+
+    state_manager = StateManager(tmp_path / "state")
+    orchestrator = MigrationOrchestrator(sample_config, state_manager)
+    orchestrator.console = _FakeConsole()
+    orchestrator.state = migration_state
+
+    chart_item = MigrationItem(
+        id="chart_default_chart-1",
+        type="chart",
+        name="Chart One",
+        source_id="chart-1",
+        status=MigrationStatus.PENDING,
+        metadata={
+            "chart": {
+                "id": "chart-1",
+                "title": "Chart One",
+                "project_id": "source-session",
+                "series": [],
+            },
+            "dest_session_id": "source-session",
+            "same_instance": True,
+        },
+    )
+    migration_state.add_item(chart_item)
+
+    results = orchestrator.resume_items([chart_item])
+
+    assert results["resumed"] == []
+    assert results["blocked"] == ["chart:chart-1"]
+    assert "Cannot resume chart" in orchestrator.console.text
+    chart_migrator.migrate_chart.assert_not_called()
+    assert chart_item.terminal_state == ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value
+    assert chart_item.outcome_code == "chart_resume_context_changed"
+    assert "fresh `langsmith-migrator charts` run" in chart_item.next_action


### PR DESCRIPTION
## Summary
- add shared chart same-instance mode helpers used by CLI detection and resume
- make chart resume detect stale same-instance metadata, re-resolve destination project/session for the current source/dest context, and continue when safe
- checkpoint with clear remediation guidance when remap resolution cannot be made safely

## Verification
- uv run pytest -q
- uv run --extra test ruff check langsmith_migrator .github/scripts/check_wheel_contents.py
- uv build
- python3 .github/scripts/check_wheel_contents.py dist/langsmith_data_migration_tool-0.0.67-py3-none-any.whl
- uvx --from ./dist/langsmith_data_migration_tool-0.0.67-py3-none-any.whl langsmith-migrator resume --help