### PR TITLE
Release v0.0.69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.69] - 2026-05-01
+
+### Fixed
+- **Workspace-scoped chart project mappings**: `charts --map-projects` and workspace-level project mappings now resolve duplicate project names within the active source/destination workspace pair before saving chart destination session metadata.
+- **Chart resume without project dependencies**: `resume` no longer blocks global or dataset-only charts that legitimately have no destination session mapping, while still re-resolving chart items that do depend on a source project/session.
+
 ## [0.0.68] - 2026-04-29
 
 ### Fixed
@@ -316,7 +322,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration documentation
 - API reference for core classes
 
-[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.68...HEAD
+[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.69...HEAD
+[0.0.69]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.68...v0.0.69
 [0.0.68]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.67...v0.0.68
 [0.0.67]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.66...v0.0.67
 [0.0.66]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.65...v0.0.66

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python CLI for migrating users and roles, datasets, experiments, annotation qu
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.68-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.69-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -54,20 +54,20 @@ For trace data, use LangSmith's **Bulk Export** functionality: [LangSmith Bulk E
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.68-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.69-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.68-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.69-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.68-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.69-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.68-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.69-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)
@@ -393,7 +393,7 @@ Rules and charts reference projects by ID. When migrating between instances, pro
 - **Interactive TUI (`--map-projects`)**: Launch a visual TUI to map source projects to destination projects. Available on `rules`, `charts`, and `migrate-all` commands. Select a source project and type a destination name directly — existing projects appear as filterable suggestions below the input. Supports auto-match by name, skip, and custom name entry.
 - **Rules (`--project-mapping`)**: Supply an explicit source→destination project ID mapping as JSON or a file path. Use `list-projects --source` and `list-projects --dest` to get IDs. The mapping is applied to both top-level project associations and project IDs embedded inside rule filters. Mutually exclusive with `--map-projects`.
 - **Rules queue targets**: When a rule references an annotation queue, the migrator first reuses any saved queue migration mapping, then falls back to an exact-name queue match in the destination workspace. If neither is safe, the rule is exported for remediation instead of being posted with the source queue ID.
-- **Charts**: Without `--map-projects`, project mapping is built automatically by matching project names between source and destination. When both sides point at the same deployment URL but use different API keys/workspaces, charts still remap project/session IDs; the tool does not treat that as `--same-instance`.
+- **Charts**: Without `--map-projects`, project mapping is built automatically by matching project names between source and destination. When both sides point at the same deployment URL but use different API keys/workspaces, charts still remap project/session IDs; the tool does not treat that as `--same-instance`. Workspace-scoped `--map-projects` mappings are resolved against the active workspace pair so duplicate project names in other workspaces are ignored.
 - **`migrate-all`**: Supports `--strip-projects`, `--map-projects`, and `--rules-create-enabled` for rules. Use the standalone `rules` command for `--project-mapping` JSON mappings.
 
 ### Interactive Selection
@@ -450,7 +450,7 @@ Every migration session persists state and writes a remediation bundle when ther
 - org members
 - workspace members
 
-For chart items, `resume` revalidates saved `--same-instance` metadata against the current source/destination and workspace context. If the mode changed, it re-resolves the destination project/session before retrying; if that cannot be resolved safely, the item is checkpointed with guidance to rerun `charts` with project mapping.
+For chart items, `resume` revalidates saved `--same-instance` metadata against the current source/destination and workspace context. If the mode changed, it re-resolves the destination project/session before retrying; if that cannot be resolved safely, the item is checkpointed with guidance to rerun `charts` with project mapping. Global or dataset-only charts that have no project/session dependency can resume with `dest_session_id=None`.
 
 Use `langsmith-migrator clean` to remove saved sessions once you no longer need their state or remediation bundles.
 

--- a/langsmith_migrator/__init__.py
+++ b/langsmith_migrator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("langsmith-data-migration-tool")
 except PackageNotFoundError:
-    __version__ = "0.0.68"
+    __version__ = "0.0.69"

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -107,17 +107,78 @@ def _name_mapping_to_id_mapping(
     name_mapping: dict,
     source_projects: list,
     dest_projects: list,
+    source_workspace_id=None,
+    dest_workspace_id=None,
 ) -> dict:
     """Convert a name-based project mapping to an ID-based mapping."""
-    src_name_to_id = {p['name']: p['id'] for p in source_projects if 'name' in p and 'id' in p}
-    dst_name_to_id = {p['name']: p['id'] for p in dest_projects if 'name' in p and 'id' in p}
+    source_projects = _filter_projects_for_workspace(source_projects, source_workspace_id)
+    dest_projects = _filter_projects_for_workspace(dest_projects, dest_workspace_id)
+
+    src_name_to_ids = _project_ids_by_name(source_projects)
+    dst_name_to_ids = _project_ids_by_name(dest_projects)
     id_map = {}
     for src_name, dst_name in name_mapping.items():
-        src_id = src_name_to_id.get(src_name)
-        dst_id = dst_name_to_id.get(dst_name)
-        if src_id and dst_id:
+        src_ids = src_name_to_ids.get(src_name, [])
+        dst_ids = dst_name_to_ids.get(dst_name, [])
+        if not src_ids or len(dst_ids) != 1:
+            continue
+        dst_id = dst_ids[0]
+        for src_id in src_ids:
             id_map[src_id] = dst_id
     return id_map
+
+
+def _project_ids_by_name(projects: list) -> dict:
+    """Group project IDs by project name."""
+    ids_by_name = {}
+    for project in projects:
+        name = project.get("name")
+        project_id = project.get("id")
+        if name and project_id:
+            ids_by_name.setdefault(name, []).append(project_id)
+    return ids_by_name
+
+
+def _workspace_ids_from_value(value) -> set[str]:
+    """Extract workspace IDs from common project workspace metadata shapes."""
+    if isinstance(value, str):
+        return {value} if value else set()
+    if isinstance(value, dict):
+        ids = set()
+        for key in ("id", "tenant_id", "workspace_id"):
+            nested = value.get(key)
+            if isinstance(nested, str) and nested:
+                ids.add(nested)
+        return ids
+    if isinstance(value, (list, tuple, set)):
+        ids = set()
+        for item in value:
+            ids.update(_workspace_ids_from_value(item))
+        return ids
+    return set()
+
+
+def _project_workspace_ids(project: dict) -> set[str]:
+    """Return workspace IDs advertised on a project/session record."""
+    ids = set()
+    for key in ("tenant_id", "workspace_id", "workspace_ids", "tenant", "workspace"):
+        if key in project:
+            ids.update(_workspace_ids_from_value(project[key]))
+    return ids
+
+
+def _filter_projects_for_workspace(projects: list, workspace_id=None) -> list:
+    """Filter project records to a workspace when records carry workspace metadata."""
+    project_list = list(projects)
+    if not workspace_id:
+        return project_list
+
+    filtered = [
+        project
+        for project in project_list
+        if workspace_id in _project_workspace_ids(project)
+    ]
+    return filtered or project_list
 
 
 def _normalize_deployment_url(base_url: str) -> str:
@@ -250,7 +311,13 @@ def _workspace_scoped_project_id_map(orchestrator, ws_result, source_workspace_i
         f"[green]✓[/green] ({len(source_projects)} source, {len(dest_projects)} destination)"
     )
 
-    id_map = _name_mapping_to_id_mapping(name_mapping, source_projects, dest_projects)
+    id_map = _name_mapping_to_id_mapping(
+        name_mapping,
+        source_projects,
+        dest_projects,
+        source_workspace_id=source_workspace_id,
+        dest_workspace_id=ws_result.workspace_mapping.get(source_workspace_id),
+    )
     console.print(f"Using workspace-scoped project mapping with {len(id_map)} project(s)")
     return id_map
 
@@ -2602,7 +2669,13 @@ def rules(ctx, select_all, strip_projects, project_mapping, create_enabled, map_
                 console.print("[yellow]Cancelled[/yellow]")
                 continue
 
-            id_map = _name_mapping_to_id_mapping(name_mapping, source_projects, dest_projects)
+            id_map = _name_mapping_to_id_mapping(
+                name_mapping,
+                source_projects,
+                dest_projects,
+                source_workspace_id=src_ws,
+                dest_workspace_id=dst_ws,
+            )
             rules_migrator._project_id_map = id_map
             console.print(f"Using interactive project mapping with {len(id_map)} project(s)")
 
@@ -2896,7 +2969,8 @@ def migrate_all(ctx, skip_users, skip_datasets, skip_experiments, skip_prompts, 
 
         _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_experiments,
                                    skip_prompts, skip_queues, skip_rules, skip_charts, include_all_commits,
-                                   strip_projects, map_projects, rules_create_enabled, ws_project_mapping)
+                                   strip_projects, map_projects, rules_create_enabled, ws_project_mapping,
+                                   src_ws, dst_ws)
 
     if ws_result:
         orchestrator.clear_workspace_context()
@@ -2909,7 +2983,8 @@ def migrate_all(ctx, skip_users, skip_datasets, skip_experiments, skip_prompts, 
 
 def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_experiments,
                                 skip_prompts, skip_queues, skip_rules, skip_charts, include_all_commits,
-                                strip_projects, map_projects, rules_create_enabled=None, ws_project_mapping=None):
+                                strip_projects, map_projects, rules_create_enabled=None, ws_project_mapping=None,
+                                source_workspace_id=None, dest_workspace_id=None):
     """Run the full migrate_all flow for a single workspace pair (or no workspace).
 
     Args:
@@ -2927,7 +3002,13 @@ def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_ex
         source_projects = _list_projects(orchestrator.source_client)
         dest_projects = _list_projects(orchestrator.dest_client)
         console.print(f"[green]✓[/green] ({len(source_projects)} source, {len(dest_projects)} destination)")
-        project_id_map = _name_mapping_to_id_mapping(ws_project_mapping, source_projects, dest_projects)
+        project_id_map = _name_mapping_to_id_mapping(
+            ws_project_mapping,
+            source_projects,
+            dest_projects,
+            source_workspace_id=source_workspace_id,
+            dest_workspace_id=dest_workspace_id,
+        )
         console.print(f"Using workspace-scoped project mapping with {len(project_id_map)} project(s)\n")
     elif map_projects:
         console.print("Fetching projects from both instances... ", end="")
@@ -2940,7 +3021,13 @@ def _migrate_all_for_workspace(ctx, orchestrator, config, skip_datasets, skip_ex
             console.print("[yellow]Cancelled[/yellow]")
             return
 
-        project_id_map = _name_mapping_to_id_mapping(name_mapping, source_projects, dest_projects)
+        project_id_map = _name_mapping_to_id_mapping(
+            name_mapping,
+            source_projects,
+            dest_projects,
+            source_workspace_id=source_workspace_id,
+            dest_workspace_id=dest_workspace_id,
+        )
         console.print(f"Using interactive project mapping with {len(project_id_map)} project(s)\n")
 
     # Track dataset ID mappings for use in rules migration
@@ -3411,7 +3498,13 @@ def charts(ctx, session, same_instance, map_projects, source_workspace, dest_wor
                 console.print("[yellow]Cancelled[/yellow]")
                 continue
 
-            id_map = _name_mapping_to_id_mapping(name_mapping, source_projects, dest_projects)
+            id_map = _name_mapping_to_id_mapping(
+                name_mapping,
+                source_projects,
+                dest_projects,
+                source_workspace_id=src_ws,
+                dest_workspace_id=dst_ws,
+            )
             chart_migrator._project_id_map = id_map
             console.print(f"Using interactive project mapping with {len(id_map)} project(s)")
 

--- a/langsmith_migrator/core/migrators/orchestrator.py
+++ b/langsmith_migrator/core/migrators/orchestrator.py
@@ -539,19 +539,68 @@ class MigrationOrchestrator:
             workspace_pair.get("source"),
             workspace_pair.get("dest"),
         )
+        source_session_id = chart_migrator._extract_session_id(chart_payload)
+        has_source_session_dependency = bool(source_session_id)
 
-        if not saved_same_instance_present or saved_same_instance == current_same_instance:
+        missing_dest_session = (
+            saved_same_instance_present
+            and has_source_session_dependency
+            and not saved_dest_session_id
+        )
+        if (
+            not saved_same_instance_present
+            or (
+                saved_same_instance == current_same_instance
+                and not missing_dest_session
+            )
+        ):
             return True, saved_dest_session_id, saved_same_instance
 
         chart_name = item.name or item.source_id
-        self.console.print(
-            "[yellow]Chart resume context changed for "
-            f"{chart_name}: saved same-instance mode was {saved_same_instance}, "
-            f"current source/destination context expects {current_same_instance}. "
-            "Re-resolving destination project/session before retrying.[/yellow]"
-        )
+        if not has_source_session_dependency:
+            evidence = {
+                "source_session_id": source_session_id,
+                "saved_same_instance": saved_same_instance,
+                "current_same_instance": current_same_instance,
+                "saved_dest_session_id": saved_dest_session_id,
+                "resolved_dest_session_id": None,
+                "workspace_pair": workspace_pair,
+            }
+            self.console.print(
+                "[yellow]Chart resume context changed for "
+                f"{chart_name}: saved same-instance mode was {saved_same_instance}, "
+                f"current source/destination context expects {current_same_instance}. "
+                "The chart has no project/session dependency, so refreshing resume "
+                "mode before retrying.[/yellow]"
+            )
+            self.state.update_item_checkpoint(
+                item.id,
+                stage="resume_context_refreshed",
+                metadata={
+                    "same_instance": current_same_instance,
+                    "dest_session_id": None,
+                    "previous_same_instance": saved_same_instance,
+                    "previous_dest_session_id": saved_dest_session_id,
+                },
+                evidence=evidence,
+            )
+            self.state_manager.save()
+            return True, None, current_same_instance
 
-        source_session_id = chart_migrator._extract_session_id(chart_payload)
+        if missing_dest_session:
+            self.console.print(
+                "[yellow]Chart resume item has a missing destination session for "
+                f"{chart_name}. Re-resolving destination project/session before "
+                "retrying.[/yellow]"
+            )
+        else:
+            self.console.print(
+                "[yellow]Chart resume context changed for "
+                f"{chart_name}: saved same-instance mode was {saved_same_instance}, "
+                f"current source/destination context expects {current_same_instance}. "
+                "Re-resolving destination project/session before retrying.[/yellow]"
+            )
+
         dest_session_id = chart_migrator.resolve_destination_session_id(
             source_session_id,
             same_instance=current_same_instance,
@@ -566,11 +615,18 @@ class MigrationOrchestrator:
         }
 
         if not dest_session_id:
-            message = (
-                "Cannot resume chart with stale same-instance metadata because "
-                "the current source/destination context could not resolve a "
-                "destination project/session."
-            )
+            if missing_dest_session:
+                message = (
+                    "Cannot resume chart with missing destination session metadata "
+                    "because the current source/destination context could not "
+                    "resolve a destination project/session."
+                )
+            else:
+                message = (
+                    "Cannot resume chart with stale same-instance metadata because "
+                    "the current source/destination context could not resolve a "
+                    "destination project/session."
+                )
             next_action = (
                 "Start a fresh `langsmith-migrator charts` run with the current "
                 "source/destination configuration, or run with `--map-projects` "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.68"
+version = "0.0.69"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -78,6 +78,42 @@ def test_name_mapping_to_id_mapping_ignores_unknown_project_names():
     assert result == {"src-a": "dst-a"}
 
 
+def test_name_mapping_to_id_mapping_filters_common_workspace_metadata_shapes():
+    """Workspace-scoped project mappings should survive duplicate names across workspaces."""
+
+    result = cli_main._name_mapping_to_id_mapping(
+        {"Shared Project": "Shared Project"},
+        source_projects=[
+            {
+                "id": "source-target",
+                "name": "Shared Project",
+                "tenant": {"tenant_id": "src-ws"},
+            },
+            {
+                "id": "source-other",
+                "name": "Shared Project",
+                "workspace_ids": ["other-src-ws"],
+            },
+        ],
+        dest_projects=[
+            {
+                "id": "dest-target",
+                "name": "Shared Project",
+                "workspace": {"id": "dst-ws"},
+            },
+            {
+                "id": "dest-other",
+                "name": "Shared Project",
+                "workspace_ids": ["other-dst-ws"],
+            },
+        ],
+        source_workspace_id="src-ws",
+        dest_workspace_id="dst-ws",
+    )
+
+    assert result == {"source-target": "dest-target"}
+
+
 def test_normalize_deployment_url_treats_api_suffixes_as_the_same_deployment():
     """Same-deployment detection should ignore trailing API path suffixes."""
 
@@ -2436,6 +2472,100 @@ def test_charts_command_uses_workspace_project_mappings(cli_harness):
         "source-project-id": "dest-project-id"
     }
     assert "Using workspace-scoped project mapping" in cli_harness.console.text
+
+
+def test_charts_command_workspace_project_mapping_filters_duplicate_project_names(cli_harness):
+    """Workspace-scoped project mappings should resolve the project in the active pair."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={"src-ws": {"Shared Project": "Shared Project"}},
+        workspaces_to_create=[],
+    )
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {"id": "source-project-id", "name": "Shared Project", "tenant_id": "src-ws"},
+        {"id": "other-source-project-id", "name": "Shared Project", "tenant_id": "other-src-ws"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {"id": "dest-project-id", "name": "Shared Project", "tenant_id": "dst-ws"},
+        {"id": "other-dest-project-id", "name": "Shared Project", "tenant_id": "other-dst-ws"},
+    ]
+    cli_harness.migrators.chart.migrate_all_charts.return_value = {
+        "source-project-id": {"chart-1": "dest-chart-1"}
+    }
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(["charts"])
+
+    assert result.exit_code == 0
+    assert cli_harness.migrators.chart._project_id_map == {
+        "source-project-id": "dest-project-id"
+    }
+
+
+def test_charts_map_projects_filters_duplicate_names_for_active_workspace_pair(cli_harness):
+    """Explicit --map-projects should resolve duplicate project names in the active workspace."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={},
+        workspaces_to_create=[],
+    )
+    cli_harness.controls.project_mapping_result = {"Shared Project": "Shared Project"}
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {
+            "id": "a3cee8e2-40bb-472e-8456-c660b5ea1f3d",
+            "name": "Shared Project",
+            "tenant_id": "src-ws",
+        },
+        {
+            "id": "other-source-project-id",
+            "name": "Shared Project",
+            "tenant_id": "other-src-ws",
+        },
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {
+            "id": "cc3ac580-destination-project",
+            "name": "Shared Project",
+            "tenant_id": "dst-ws",
+        },
+        {
+            "id": "other-dest-project-id",
+            "name": "Shared Project",
+            "tenant_id": "other-dst-ws",
+        },
+    ]
+    cli_harness.migrators.chart.list_charts.return_value = [
+        {
+            "id": "chart-1",
+            "title": "Chart One",
+            "project_id": "a3cee8e2-40bb-472e-8456-c660b5ea1f3d",
+        }
+    ]
+    cli_harness.migrators.chart._extract_session_id.side_effect = (
+        lambda chart: chart.get("project_id")
+    )
+    cli_harness.migrators.chart.migrate_all_charts.return_value = {
+        "a3cee8e2-40bb-472e-8456-c660b5ea1f3d": {"chart-1": "dest-chart-1"}
+    }
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(["charts", "--map-projects"])
+
+    assert result.exit_code == 0
+    assert cli_harness.migrators.chart._project_id_map == {
+        "a3cee8e2-40bb-472e-8456-c660b5ea1f3d": "cc3ac580-destination-project"
+    }
+    cli_harness.migrators.chart.resolve_destination_session_id.assert_called_with(
+        "a3cee8e2-40bb-472e-8456-c660b5ea1f3d",
+        same_instance=False,
+    )
+    state = cli_harness.orchestrator_factory.state
+    item = state.get_item(
+        "chart_src-ws_chart-1"
+    )
+    assert item.metadata["dest_session_id"] == "cc3ac580-destination-project"
 
 
 def test_charts_command_uses_saved_project_mapping_for_session_migration(cli_harness):

--- a/tests/test_chart_migrator.py
+++ b/tests/test_chart_migrator.py
@@ -142,6 +142,34 @@ def test_resolve_destination_session_id_falls_back_to_exact_name_matching(
     )
 
 
+def test_resolve_destination_session_id_uses_saved_project_mapping_before_listing(
+    sample_config,
+    migration_state,
+):
+    """Saved TUI/state project mappings should directly resolve chart destination sessions."""
+
+    source_session_id = "a3cee8e2-40bb-472e-8456-c660b5ea1f3d"
+    dest_session_id = "cc3ac580-destination-project"
+    migration_state.set_mapped_id("project", source_session_id, dest_session_id)
+    source_client = _mock_client()
+    dest_client = _mock_client()
+
+    migrator = ChartMigrator(
+        source_client,
+        dest_client,
+        migration_state,
+        sample_config,
+    )
+
+    assert (
+        migrator.resolve_destination_session_id(source_session_id, same_instance=False)
+        == dest_session_id
+    )
+    assert migrator._project_id_map == {source_session_id: dest_session_id}
+    source_client.get_paginated.assert_not_called()
+    dest_client.get_paginated.assert_not_called()
+
+
 def test_migrate_chart_exports_when_dependencies_are_unresolved(
     sample_config,
     migration_state,

--- a/tests/test_orchestrator_resume.py
+++ b/tests/test_orchestrator_resume.py
@@ -280,6 +280,262 @@ def test_resume_items_re_resolves_chart_when_same_instance_metadata_is_stale(
     assert chart_item.metadata["previous_dest_session_id"] == "source-session"
 
 
+def test_resume_items_re_resolves_chart_when_dest_session_metadata_is_missing(
+    monkeypatch, sample_config, migration_state, tmp_path
+):
+    """Resume should repair chart items that checkpointed without a destination session."""
+
+    sample_config.source.base_url = "https://api.smith.langchain.com"
+    sample_config.destination.base_url = "https://api.smith.langchain.com"
+    sample_config.source.api_key = "source-workspace-key"
+    sample_config.destination.api_key = "dest-workspace-key"
+
+    clients = [_FakeClient(), _FakeClient()]
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.EnhancedAPIClient",
+        lambda **kwargs: clients.pop(0),
+    )
+
+    chart_migrator = Mock()
+    chart_migrator._extract_session_id.return_value = "source-session"
+    chart_migrator.resolve_destination_session_id.return_value = "dest-session"
+    chart_migrator.migrate_chart.return_value = "dest-chart-1"
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.chart.ChartMigrator",
+        lambda *args, **kwargs: chart_migrator,
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.prompt.PromptMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.annotation_queue.AnnotationQueueMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.rules.RulesMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.ExperimentMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.FeedbackMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+
+    state_manager = StateManager(tmp_path / "state")
+    orchestrator = MigrationOrchestrator(sample_config, state_manager)
+    orchestrator.console = _FakeConsole()
+    orchestrator.state = migration_state
+
+    chart_payload = {
+        "id": "chart-1",
+        "title": "Chart One",
+        "project_id": "source-session",
+        "series": [],
+    }
+    chart_item = MigrationItem(
+        id="chart_default_chart-1",
+        type="chart",
+        name="Chart One",
+        source_id="chart-1",
+        status=MigrationStatus.PENDING,
+        metadata={
+            "chart": chart_payload,
+            "dest_session_id": None,
+            "same_instance": False,
+        },
+    )
+    migration_state.add_item(chart_item)
+
+    results = orchestrator.resume_items([chart_item])
+
+    assert results["resumed"] == ["chart:chart-1"]
+    assert results["blocked"] == []
+    assert "missing destination session" in orchestrator.console.text
+    chart_migrator.resolve_destination_session_id.assert_called_once_with(
+        "source-session",
+        same_instance=False,
+    )
+    chart_migrator.migrate_chart.assert_called_once_with(
+        chart_payload,
+        "dest-session",
+        same_instance=False,
+    )
+    assert chart_item.metadata["same_instance"] is False
+    assert chart_item.metadata["dest_session_id"] == "dest-session"
+    assert chart_item.metadata["previous_dest_session_id"] is None
+
+
+def test_resume_items_allows_chart_without_project_dependency_and_no_dest_session(
+    monkeypatch, sample_config, migration_state, tmp_path
+):
+    """Charts without project/session filters do not need destination session metadata."""
+
+    sample_config.source.base_url = "https://api.smith.langchain.com"
+    sample_config.destination.base_url = "https://api.smith.langchain.com"
+    sample_config.source.api_key = "source-workspace-key"
+    sample_config.destination.api_key = "dest-workspace-key"
+
+    clients = [_FakeClient(), _FakeClient()]
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.EnhancedAPIClient",
+        lambda **kwargs: clients.pop(0),
+    )
+
+    chart_migrator = Mock()
+    chart_migrator._extract_session_id.return_value = None
+    chart_migrator.resolve_destination_session_id.return_value = None
+    chart_migrator.migrate_chart.return_value = "dest-chart-1"
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.chart.ChartMigrator",
+        lambda *args, **kwargs: chart_migrator,
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.prompt.PromptMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.annotation_queue.AnnotationQueueMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.rules.RulesMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.ExperimentMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.FeedbackMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+
+    state_manager = StateManager(tmp_path / "state")
+    orchestrator = MigrationOrchestrator(sample_config, state_manager)
+    orchestrator.console = _FakeConsole()
+    orchestrator.state = migration_state
+
+    chart_payload = {
+        "id": "chart-1",
+        "title": "Global Chart",
+        "series": [{"filters": {}}],
+    }
+    chart_item = MigrationItem(
+        id="chart_default_chart-1",
+        type="chart",
+        name="Global Chart",
+        source_id="chart-1",
+        status=MigrationStatus.PENDING,
+        metadata={
+            "chart": chart_payload,
+            "dest_session_id": None,
+            "same_instance": False,
+        },
+    )
+    migration_state.add_item(chart_item)
+
+    results = orchestrator.resume_items([chart_item])
+
+    assert results["resumed"] == ["chart:chart-1"]
+    assert results["blocked"] == []
+    chart_migrator.resolve_destination_session_id.assert_not_called()
+    chart_migrator.migrate_chart.assert_called_once_with(
+        chart_payload,
+        None,
+        same_instance=False,
+    )
+
+
+def test_resume_items_refreshes_stale_chart_mode_without_project_dependency(
+    monkeypatch, sample_config, migration_state, tmp_path
+):
+    """Resume mode can refresh without resolving sessions for global charts."""
+
+    sample_config.source.base_url = "https://api.smith.langchain.com"
+    sample_config.destination.base_url = "https://api.smith.langchain.com"
+    sample_config.source.api_key = "source-workspace-key"
+    sample_config.destination.api_key = "dest-workspace-key"
+
+    clients = [_FakeClient(), _FakeClient()]
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.EnhancedAPIClient",
+        lambda **kwargs: clients.pop(0),
+    )
+
+    chart_migrator = Mock()
+    chart_migrator._extract_session_id.return_value = None
+    chart_migrator.resolve_destination_session_id.return_value = None
+    chart_migrator.migrate_chart.return_value = "dest-chart-1"
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.chart.ChartMigrator",
+        lambda *args, **kwargs: chart_migrator,
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.prompt.PromptMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.annotation_queue.AnnotationQueueMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.rules.RulesMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.ExperimentMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.FeedbackMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+
+    state_manager = StateManager(tmp_path / "state")
+    orchestrator = MigrationOrchestrator(sample_config, state_manager)
+    orchestrator.console = _FakeConsole()
+    orchestrator.state = migration_state
+
+    chart_payload = {
+        "id": "chart-1",
+        "title": "Global Chart",
+        "series": [{"filters": {}}],
+    }
+    chart_item = MigrationItem(
+        id="chart_default_chart-1",
+        type="chart",
+        name="Global Chart",
+        source_id="chart-1",
+        status=MigrationStatus.PENDING,
+        metadata={
+            "chart": chart_payload,
+            "dest_session_id": None,
+            "same_instance": True,
+        },
+    )
+    migration_state.add_item(chart_item)
+
+    results = orchestrator.resume_items([chart_item])
+
+    assert results["resumed"] == ["chart:chart-1"]
+    assert results["blocked"] == []
+    assert "no project/session dependency" in orchestrator.console.text
+    chart_migrator.resolve_destination_session_id.assert_not_called()
+    chart_migrator.migrate_chart.assert_called_once_with(
+        chart_payload,
+        None,
+        same_instance=False,
+    )
+    assert chart_item.metadata["same_instance"] is False
+    assert chart_item.metadata["dest_session_id"] is None
+    assert chart_item.metadata["previous_same_instance"] is True
+    assert chart_item.metadata["previous_dest_session_id"] is None
+
+
 def test_resume_items_blocks_chart_when_stale_context_cannot_resolve_destination(
     monkeypatch, sample_config, migration_state, tmp_path
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.68"
+version = "0.0.69"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Fix workspace-scoped chart project mapping so `charts --map-projects` resolves duplicate project names within the active workspace pair.
- Allow chart resume to proceed with `dest_session_id=None` when a chart has no project/session dependency.
- Bump release metadata and docs to `0.0.69`.

## Test Plan
- `uv lock --check`
- `bash .github/scripts/check_readme_release_sync.sh` (skipped locally because `BASE_REF` is not set)
- `uv run pytest tests/test_chart_migrator.py tests/test_orchestrator_resume.py tests/functional/test_cli_functional.py -q`
- `uv run --with ruff ruff check langsmith_migrator/cli/main.py langsmith_migrator/core/migrators/orchestrator.py tests/functional/test_cli_functional.py tests/test_chart_migrator.py tests/test_orchestrator_resume.py`
- `uv run pytest -q`
- `uv build`
- `python3 .github/scripts/check_wheel_contents.py dist/langsmith_data_migration_tool-0.0.69-py3-none-any.whl`
- `uvx --from ./dist/langsmith_data_migration_tool-0.0.69-py3-none-any.whl langsmith-migrator --help`
