### PR TITLE
Release v0.0.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.70] - 2026-05-01
+
+### Fixed
+- **Nested chart project/session filters**: `charts --map-projects` now discovers project dependencies nested inside chart filter trees, so remediation/resume metadata records the mapped destination session instead of `null` for charts whose filters use nested `session` lists.
+
 ## [0.0.69] - 2026-05-01
 
 ### Fixed
@@ -322,7 +327,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration documentation
 - API reference for core classes
 
-[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.69...HEAD
+[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.70...HEAD
+[0.0.70]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.69...v0.0.70
 [0.0.69]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.68...v0.0.69
 [0.0.68]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.67...v0.0.68
 [0.0.67]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.66...v0.0.67

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python CLI for migrating users and roles, datasets, experiments, annotation qu
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.69-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.70-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -54,20 +54,20 @@ For trace data, use LangSmith's **Bulk Export** functionality: [LangSmith Bulk E
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.69-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.70-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.69-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.70-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.69-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.70-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.69-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.70-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)

--- a/langsmith_migrator/__init__.py
+++ b/langsmith_migrator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("langsmith-data-migration-tool")
 except PackageNotFoundError:
-    __version__ = "0.0.69"
+    __version__ = "0.0.70"

--- a/langsmith_migrator/core/migrators/chart.py
+++ b/langsmith_migrator/core/migrators/chart.py
@@ -1058,26 +1058,35 @@ class ChartMigrator(BaseMigrator):
 
     def _extract_session_id(self, chart: Dict[str, Any]) -> Optional[str]:
         """Extract session/project ID from chart config."""
-        # Top level
-        if chart.get('session_id'): return chart['session_id']
-        if chart.get('project_id'): return chart['project_id']
+        found = self._find_session_dependency(chart)
+        if found:
+            return found
+        return None
 
-        # In series
-        for s in chart.get('series', []):
-            if isinstance(s, dict):
-                filters = s.get('filters')
-                if not filters:
-                    continue
+    def _find_session_dependency(self, obj: Any) -> Optional[str]:
+        """Find the first project/session dependency in a chart filter tree."""
+        if isinstance(obj, dict):
+            for key in ("session_id", "project_id"):
+                value = obj.get(key)
+                if isinstance(value, str) and value:
+                    return value
 
-                if filters.get('project_id'): return filters['project_id']
-                if filters.get('session_id'): return filters['session_id']
+            sessions = obj.get("session")
+            if isinstance(sessions, list):
+                for value in sessions:
+                    if isinstance(value, str) and value:
+                        return value
 
-        # In common_filters
-        common_filters = chart.get('common_filters')
-        if isinstance(common_filters, dict):
-            sessions = common_filters.get('session')
-            if isinstance(sessions, list) and sessions:
-                return sessions[0]  # Return first session ID found
+            for value in obj.values():
+                found = self._find_session_dependency(value)
+                if found:
+                    return found
+
+        elif isinstance(obj, list):
+            for item in obj:
+                found = self._find_session_dependency(item)
+                if found:
+                    return found
 
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.69"
+version = "0.0.70"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -6,6 +6,7 @@ import json
 from unittest.mock import Mock, call
 
 from langsmith_migrator.cli import main as cli_main
+from langsmith_migrator.core.migrators.chart import ChartMigrator as RealChartMigrator
 from langsmith_migrator.cli.tui_workspace_mapper import WorkspaceProjectResult
 from langsmith_migrator.utils.retry import APIError
 from langsmith_migrator.utils.state import (
@@ -2565,6 +2566,75 @@ def test_charts_map_projects_filters_duplicate_names_for_active_workspace_pair(c
     item = state.get_item(
         "chart_src-ws_chart-1"
     )
+    assert item.metadata["dest_session_id"] == "cc3ac580-destination-project"
+
+
+def test_charts_map_projects_resolves_nested_session_filters_for_resume_metadata(
+    cli_harness,
+):
+    """--map-projects should pre-resolve nested session filters before chart resume."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={},
+        workspaces_to_create=[],
+    )
+    cli_harness.controls.project_mapping_result = {"Shared Project": "Shared Project"}
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {
+            "id": "a3cee8e2-40bb-472e-8456-c660b5ea1f3d",
+            "name": "Shared Project",
+            "tenant_id": "src-ws",
+        },
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {
+            "id": "cc3ac580-destination-project",
+            "name": "Shared Project",
+            "tenant_id": "dst-ws",
+        },
+    ]
+    cli_harness.migrators.chart.list_charts.return_value = [
+        {
+            "id": "chart-1",
+            "title": "Chart One",
+            "series": [
+                {
+                    "filters": {
+                        "operator": "and",
+                        "children": [
+                            {
+                                "session": [
+                                    "a3cee8e2-40bb-472e-8456-c660b5ea1f3d"
+                                ]
+                            }
+                        ],
+                    }
+                }
+            ],
+        }
+    ]
+    real_chart_migrator = object.__new__(RealChartMigrator)
+    cli_harness.migrators.chart._extract_session_id.side_effect = (
+        lambda chart: RealChartMigrator._extract_session_id(
+            real_chart_migrator,
+            chart,
+        )
+    )
+    cli_harness.migrators.chart.migrate_all_charts.return_value = {
+        "a3cee8e2-40bb-472e-8456-c660b5ea1f3d": {"chart-1": "dest-chart-1"}
+    }
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(["charts", "--map-projects"])
+
+    assert result.exit_code == 0
+    cli_harness.migrators.chart.resolve_destination_session_id.assert_called_with(
+        "a3cee8e2-40bb-472e-8456-c660b5ea1f3d",
+        same_instance=False,
+    )
+    state = cli_harness.orchestrator_factory.state
+    item = state.get_item("chart_src-ws_chart-1")
     assert item.metadata["dest_session_id"] == "cc3ac580-destination-project"
 
 

--- a/tests/test_chart_migrator.py
+++ b/tests/test_chart_migrator.py
@@ -170,6 +170,88 @@ def test_resolve_destination_session_id_uses_saved_project_mapping_before_listin
     dest_client.get_paginated.assert_not_called()
 
 
+def test_extract_session_id_finds_nested_session_filter(
+    sample_config,
+    migration_state,
+):
+    """Chart pre-resolution should find session filters that migration remaps."""
+
+    source_client = _mock_client()
+    dest_client = _mock_client()
+    migrator = ChartMigrator(
+        source_client,
+        dest_client,
+        migration_state,
+        sample_config,
+    )
+
+    assert (
+        migrator._extract_session_id(
+            {
+                "id": "chart-1",
+                "title": "Chart One",
+                "series": [
+                    {
+                        "filters": {
+                            "operator": "and",
+                            "children": [
+                                {
+                                    "session": [
+                                        "a3cee8e2-40bb-472e-8456-c660b5ea1f3d"
+                                    ]
+                                }
+                            ],
+                        }
+                    }
+                ],
+            }
+        )
+        == "a3cee8e2-40bb-472e-8456-c660b5ea1f3d"
+    )
+
+
+def test_migrate_all_charts_resolves_nested_session_filter(
+    sample_config,
+    migration_state,
+):
+    """All-chart migration should pass mapped destination IDs for nested filters."""
+
+    source_session_id = "a3cee8e2-40bb-472e-8456-c660b5ea1f3d"
+    dest_session_id = "cc3ac580-destination-project"
+    source_client = _mock_client()
+    dest_client = _mock_client()
+    migrator = ChartMigrator(
+        source_client,
+        dest_client,
+        migration_state,
+        sample_config,
+    )
+    chart = {
+        "id": "chart-1",
+        "title": "Chart One",
+        "series": [
+            {
+                "filters": {
+                    "operator": "and",
+                    "children": [{"session": [source_session_id]}],
+                }
+            }
+        ],
+    }
+    migrator._project_id_map = {source_session_id: dest_session_id}
+    migrator.list_charts = Mock(return_value=[chart])
+    migrator.migrate_chart = Mock(return_value="dest-chart-1")
+
+    mappings = migrator.migrate_all_charts(same_instance=False)
+
+    assert mappings == {source_session_id: {"chart-1": "dest-chart-1"}}
+    migrator.migrate_chart.assert_called_once_with(
+        chart,
+        dest_session_id,
+        same_instance=False,
+    )
+
+
 def test_migrate_chart_exports_when_dependencies_are_unresolved(
     sample_config,
     migration_state,

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.69"
+version = "0.0.70"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- fix chart project/session dependency extraction for nested filter trees such as `series[].filters.children[].session`
- ensure `charts --map-projects` stores the mapped destination session in chart resume/remediation metadata
- bump release metadata to v0.0.70

## Verification
- `uv run pytest tests/test_chart_migrator.py -q`
- `uv run pytest tests/functional/test_cli_functional.py -k charts_map_projects -q`
- `uv run pytest tests/test_chart_migrator.py tests/functional/test_cli_functional.py tests/test_orchestrator_resume.py -q`
- `uv lock --check`
- `uv run --with ruff ruff check langsmith_migrator/core/migrators/chart.py tests/test_chart_migrator.py tests/functional/test_cli_functional.py`
- `git diff --check`
- `uv run pytest -q`
- `uv build`
- `python3 .github/scripts/check_wheel_contents.py dist/langsmith_data_migration_tool-0.0.70-py3-none-any.whl`
- `uvx --from ./dist/langsmith_data_migration_tool-0.0.70-py3-none-any.whl langsmith-migrator --help`