### PR TITLE
Release v0.0.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.71] - 2026-05-01
+
+### Fixed
+- **Chart project/session remapping**: Chart migration now applies source→destination project mappings to every project/session dependency in chart payloads, including nested `session` lists and charts with multiple project filters, instead of depending on a single nullable `dest_session_id`.
+
 ## [0.0.70] - 2026-05-01
 
 ### Fixed
@@ -327,7 +332,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration documentation
 - API reference for core classes
 
-[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.70...HEAD
+[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.71...HEAD
+[0.0.71]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.70...v0.0.71
 [0.0.70]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.69...v0.0.70
 [0.0.69]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.68...v0.0.69
 [0.0.68]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.67...v0.0.68

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python CLI for migrating users and roles, datasets, experiments, annotation qu
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.70-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.71-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -54,20 +54,20 @@ For trace data, use LangSmith's **Bulk Export** functionality: [LangSmith Bulk E
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.70-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.71-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.70-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.71-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.70-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.71-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.70-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.71-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)

--- a/langsmith_migrator/__init__.py
+++ b/langsmith_migrator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("langsmith-data-migration-tool")
 except PackageNotFoundError:
-    __version__ = "0.0.70"
+    __version__ = "0.0.71"

--- a/langsmith_migrator/core/migrators/chart.py
+++ b/langsmith_migrator/core/migrators/chart.py
@@ -864,10 +864,12 @@ class ChartMigrator(BaseMigrator):
         chart_copy = copy.deepcopy(chart)
 
         # Map IDs within chart config
+        source_session_id = self._extract_session_id(chart)
         unresolved_dependencies = self._map_ids_in_chart(
             chart_copy,
             dest_session_id,
             same_instance=same_instance,
+            source_session_id=source_session_id,
         )
         unresolved_dependencies = self._normalize_unresolved_dependencies(
             unresolved_dependencies
@@ -1097,6 +1099,7 @@ class ChartMigrator(BaseMigrator):
         unresolved: Optional[Dict[str, set[str]]] = None,
         *,
         same_instance: bool = False,
+        source_session_id: Optional[str] = None,
     ) -> Dict[str, set[str]]:
         """
         Recursively map project and dataset IDs within a chart object.
@@ -1104,8 +1107,8 @@ class ChartMigrator(BaseMigrator):
 
         Args:
             obj: Chart object or sub-structure
-            dest_session_id: If provided, forcibly sets project_id/session_id to this value
-                             instead of using the mapping (useful when we know the target)
+            dest_session_id: If provided, used as a fallback for the chart's source
+                             project/session dependency when no mapping is available.
         """
         if unresolved is None:
             unresolved = {
@@ -1117,26 +1120,24 @@ class ChartMigrator(BaseMigrator):
         if isinstance(obj, dict):
             # Check for specific keys to map
             if "project_id" in obj:
-                if dest_session_id:
-                    obj["project_id"] = dest_session_id
-                else:
-                    self._map_id_field(
-                        obj,
-                        "project_id",
-                        self._build_project_mapping(),
-                        unresolved,
-                    )
+                self._map_project_session_field(
+                    obj,
+                    "project_id",
+                    dest_session_id,
+                    unresolved,
+                    same_instance=same_instance,
+                    source_session_id=source_session_id,
+                )
 
             if "session_id" in obj:
-                if dest_session_id:
-                    obj["session_id"] = dest_session_id
-                else:
-                    self._map_id_field(
-                        obj,
-                        "session_id",
-                        self._build_project_mapping(),
-                        unresolved,
-                    )
+                self._map_project_session_field(
+                    obj,
+                    "session_id",
+                    dest_session_id,
+                    unresolved,
+                    same_instance=same_instance,
+                    source_session_id=source_session_id,
+                )
 
             if "dataset_id" in obj:
                 self._map_id_field(
@@ -1150,23 +1151,22 @@ class ChartMigrator(BaseMigrator):
             if "session" in obj and isinstance(obj["session"], list):
                 # Map list of session IDs (used in common_filters)
                 new_ids = []
-                # Only build mapping if we don't have a forced destination ID
-                mapping = {}
-                if not dest_session_id:
-                    mapping = self._build_project_mapping()
-
-                # If forced ID, just use that
-                if dest_session_id:
-                    new_ids = [dest_session_id]
-                else:
-                    # Map each ID
-                    for old_id in obj["session"]:
-                        if isinstance(old_id, str) and old_id in mapping:
-                            new_ids.append(mapping[old_id])
-                        else:
-                            if isinstance(old_id, str) and old_id:
-                                unresolved["session_id"].add(old_id)
-                            new_ids.append(old_id)
+                mapping = {} if same_instance else self._build_project_mapping()
+                for old_id in obj["session"]:
+                    if same_instance:
+                        new_ids.append(old_id)
+                    elif isinstance(old_id, str) and old_id in mapping:
+                        new_ids.append(mapping[old_id])
+                    elif (
+                        isinstance(old_id, str)
+                        and dest_session_id
+                        and (not source_session_id or old_id == source_session_id)
+                    ):
+                        new_ids.append(dest_session_id)
+                    else:
+                        if isinstance(old_id, str) and old_id:
+                            unresolved["session_id"].add(old_id)
+                        new_ids.append(old_id)
                 obj["session"] = new_ids
 
             # Handle special 'tag_value_id' which might be project ID in some contexts
@@ -1179,6 +1179,7 @@ class ChartMigrator(BaseMigrator):
                     dest_session_id,
                     unresolved,
                     same_instance=same_instance,
+                    source_session_id=source_session_id,
                 )
 
         elif isinstance(obj, list):
@@ -1188,9 +1189,36 @@ class ChartMigrator(BaseMigrator):
                     dest_session_id,
                     unresolved,
                     same_instance=same_instance,
+                    source_session_id=source_session_id,
                 )
 
         return unresolved
+
+    def _map_project_session_field(
+        self,
+        obj: Dict,
+        field: str,
+        dest_session_id: Optional[str],
+        unresolved: Dict[str, set[str]],
+        *,
+        same_instance: bool = False,
+        source_session_id: Optional[str] = None,
+    ) -> None:
+        """Map one project/session field without collapsing unrelated dependencies."""
+        old_id = obj.get(field)
+        if not isinstance(old_id, str) or not old_id:
+            return
+
+        if same_instance:
+            return
+
+        mapping = self._build_project_mapping()
+        if old_id in mapping:
+            obj[field] = mapping[old_id]
+        elif dest_session_id and (not source_session_id or old_id == source_session_id):
+            obj[field] = dest_session_id
+        else:
+            unresolved[field].add(old_id)
 
     def _map_id_field(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.70"
+version = "0.0.71"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -2638,6 +2638,133 @@ def test_charts_map_projects_resolves_nested_session_filters_for_resume_metadata
     assert item.metadata["dest_session_id"] == "cc3ac580-destination-project"
 
 
+def test_charts_map_projects_same_deployment_cross_workspace_remaps_metadata(
+    cli_harness,
+):
+    """Same deployment plus different workspaces should still remap chart metadata."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={},
+        workspaces_to_create=[],
+    )
+    cli_harness.controls.project_mapping_result = {"Shared Project": "Shared Project"}
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {
+            "id": "source-project-id",
+            "name": "Shared Project",
+            "tenant_id": "src-ws",
+        },
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {
+            "id": "dest-project-id",
+            "name": "Shared Project",
+            "tenant_id": "dst-ws",
+        },
+    ]
+    cli_harness.migrators.chart.list_charts.return_value = [
+        {
+            "id": "chart-1",
+            "title": "Chart One",
+            "series": [{"filters": {"session": ["source-project-id"]}}],
+        }
+    ]
+    real_chart_migrator = object.__new__(RealChartMigrator)
+    cli_harness.migrators.chart._extract_session_id.side_effect = (
+        lambda chart: RealChartMigrator._extract_session_id(
+            real_chart_migrator,
+            chart,
+        )
+    )
+    cli_harness.migrators.chart.migrate_all_charts.return_value = {
+        "source-project-id": {"chart-1": "dest-chart-1"}
+    }
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(
+        [
+            "--source-key",
+            "shared-key",
+            "--dest-key",
+            "shared-key",
+            "--source-url",
+            "https://same.example",
+            "--dest-url",
+            "https://same.example/api/v1",
+            "charts",
+            "--map-projects",
+        ],
+        add_base_args=False,
+    )
+
+    assert result.exit_code == 0
+    cli_harness.migrators.chart.migrate_all_charts.assert_called_once_with(
+        same_instance=False
+    )
+    cli_harness.migrators.chart.resolve_destination_session_id.assert_called_with(
+        "source-project-id",
+        same_instance=False,
+    )
+    state = cli_harness.orchestrator_factory.state
+    item = state.get_item("chart_src-ws_chart-1")
+    assert item.metadata["dest_session_id"] == "dest-project-id"
+    assert item.metadata["same_instance"] is False
+    assert "Mode: Remapped project/session IDs" in cli_harness.console.text
+
+
+def test_charts_command_same_instance_override_cross_workspace_reuses_ids(
+    cli_harness,
+):
+    """Explicit --same-instance should remain an operator override."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={},
+        workspaces_to_create=[],
+    )
+    cli_harness.migrators.chart.list_charts.return_value = [
+        {"id": "chart-1", "title": "Chart One", "project_id": "source-project-id"},
+    ]
+    cli_harness.migrators.chart._extract_session_id.side_effect = (
+        lambda chart: chart.get("project_id")
+    )
+    cli_harness.migrators.chart.migrate_all_charts.return_value = {
+        "source-project-id": {"chart-1": "dest-chart-1"}
+    }
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(
+        [
+            "--source-key",
+            "shared-key",
+            "--dest-key",
+            "shared-key",
+            "--source-url",
+            "https://same.example",
+            "--dest-url",
+            "https://same.example/api/v1",
+            "charts",
+            "--same-instance",
+        ],
+        add_base_args=False,
+    )
+
+    assert result.exit_code == 0
+    cli_harness.migrators.chart.resolve_destination_session_id.assert_called_with(
+        "source-project-id",
+        same_instance=True,
+    )
+    cli_harness.migrators.chart.migrate_all_charts.assert_called_once_with(
+        same_instance=True
+    )
+    state = cli_harness.orchestrator_factory.state
+    item = state.get_item("chart_src-ws_chart-1")
+    assert item.metadata["dest_session_id"] == "source-project-id"
+    assert item.metadata["same_instance"] is True
+    assert "Mode: Same instance" in cli_harness.console.text
+
+
 def test_charts_command_uses_saved_project_mapping_for_session_migration(cli_harness):
     """Session-scoped chart migration should resolve the destination project from saved state."""
 
@@ -2748,6 +2875,98 @@ def test_charts_command_session_same_deployment_identical_workspace_reuses_ids_w
     assert "Using same session ID for destination" in cli_harness.console.text
 
 
+def test_charts_command_session_same_deployment_cross_workspace_uses_mapping(
+    cli_harness,
+):
+    """Session-scoped same-deployment cross-workspace runs should remap projects."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={"src-ws": {"Source Session": "Destination Session"}},
+        workspaces_to_create=[],
+    )
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {"id": "source-session", "name": "Source Session", "tenant_id": "src-ws"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {"id": "dest-session", "name": "Destination Session", "tenant_id": "dst-ws"},
+    ]
+    cli_harness.migrators.chart.list_sessions.return_value = [
+        {"id": "source-session", "name": "Source Session"},
+    ]
+    cli_harness.migrators.chart.migrate_session_charts.return_value = {
+        "chart-1": "dest-chart-1"
+    }
+
+    result = cli_harness.invoke(
+        [
+            "--source-key",
+            "shared-key",
+            "--dest-key",
+            "shared-key",
+            "--source-url",
+            "https://same.example",
+            "--dest-url",
+            "https://same.example/api/v1",
+            "charts",
+            "--session",
+            "Source Session",
+        ],
+        add_base_args=False,
+    )
+
+    assert result.exit_code == 0
+    cli_harness.migrators.chart.resolve_destination_session_id.assert_called_with(
+        "source-session",
+        same_instance=False,
+    )
+    cli_harness.migrators.chart.migrate_session_charts.assert_called_once_with(
+        "source-session",
+        "dest-session",
+        same_instance=False,
+    )
+
+
+def test_charts_command_session_same_deployment_cross_workspace_blocks_without_mapping(
+    cli_harness,
+):
+    """Session-scoped cross-workspace chart runs need a destination project mapping."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={},
+        workspaces_to_create=[],
+    )
+    cli_harness.migrators.chart.list_sessions.return_value = [
+        {"id": "source-session", "name": "Source Session"},
+    ]
+
+    result = cli_harness.invoke(
+        [
+            "--source-key",
+            "shared-key",
+            "--dest-key",
+            "shared-key",
+            "--source-url",
+            "https://same.example",
+            "--dest-url",
+            "https://same.example/api/v1",
+            "charts",
+            "--session",
+            "Source Session",
+        ],
+        add_base_args=False,
+    )
+
+    assert result.exit_code == 0
+    cli_harness.migrators.chart.resolve_destination_session_id.assert_called_with(
+        "source-session",
+        same_instance=False,
+    )
+    cli_harness.migrators.chart.migrate_session_charts.assert_not_called()
+    assert "No destination mapping found" in cli_harness.console.text
+
+
 def test_migrate_all_chart_step_same_key_cross_workspace_uses_remap_mode(cli_harness):
     """migrate-all should keep chart migration in remap mode for different workspace pairs."""
 
@@ -2841,6 +3060,67 @@ def test_migrate_all_chart_step_same_deployment_identical_workspace_reuses_ids_w
         same_instance=True
     )
     assert "identical workspace scope" in cli_harness.console.text
+
+
+def test_migrate_all_chart_step_same_deployment_cross_workspace_maps_metadata(
+    cli_harness,
+):
+    """migrate-all chart step should checkpoint remapped sessions across workspaces."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={"src-ws": {"Source Project": "Destination Project"}},
+        workspaces_to_create=[],
+    )
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {"id": "source-project-id", "name": "Source Project", "tenant_id": "src-ws"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {"id": "dest-project-id", "name": "Destination Project", "tenant_id": "dst-ws"},
+    ]
+    cli_harness.migrators.chart.list_charts.return_value = [
+        {"id": "chart-1", "title": "Chart One", "project_id": "source-project-id"},
+    ]
+    cli_harness.migrators.chart._extract_session_id.side_effect = (
+        lambda chart: chart.get("project_id")
+    )
+    cli_harness.migrators.chart.migrate_all_charts.return_value = {
+        "source-project-id": {"chart-1": "dest-chart-1"}
+    }
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(
+        [
+            "--source-key",
+            "src-key",
+            "--dest-key",
+            "dst-key",
+            "--source-url",
+            "https://same.example",
+            "--dest-url",
+            "https://same.example/api/v1",
+            "migrate-all",
+            "--skip-users",
+            "--skip-datasets",
+            "--skip-prompts",
+            "--skip-queues",
+            "--skip-rules",
+        ],
+        add_base_args=False,
+    )
+
+    assert result.exit_code == 0
+    cli_harness.migrators.chart.resolve_destination_session_id.assert_called_with(
+        "source-project-id",
+        same_instance=False,
+    )
+    cli_harness.migrators.chart.migrate_all_charts.assert_called_once_with(
+        same_instance=False
+    )
+    state = cli_harness.orchestrator_factory.state
+    item = state.get_item("chart_src-ws_chart-1")
+    assert item.metadata["dest_session_id"] == "dest-project-id"
+    assert item.metadata["same_instance"] is False
 
 
 def test_resume_command_retries_pending_datasets(cli_harness):

--- a/tests/test_chart_migrator.py
+++ b/tests/test_chart_migrator.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import Mock
 
+import pytest
+
 from langsmith_migrator.core.api_client import EnhancedAPIClient
 from langsmith_migrator.core.migrators import ChartMigrator
 
@@ -210,6 +212,57 @@ def test_extract_session_id_finds_nested_session_filter(
     )
 
 
+@pytest.mark.parametrize(
+    "chart",
+    [
+        {"id": "chart-1", "project_id": "source-project"},
+        {"id": "chart-1", "session_id": "source-project"},
+        {"id": "chart-1", "series": [{"filters": {"project_id": "source-project"}}]},
+        {"id": "chart-1", "series": [{"filters": {"session_id": "source-project"}}]},
+        {"id": "chart-1", "common_filters": {"session": ["source-project"]}},
+        {
+            "id": "chart-1",
+            "series": [
+                {
+                    "filters": {
+                        "children": [
+                            {"session": ["source-project"]},
+                        ]
+                    }
+                }
+            ],
+        },
+        {
+            "id": "chart-1",
+            "series": [
+                {
+                    "filters": {
+                        "children": [
+                            {"nested": {"project_id": "source-project"}},
+                        ]
+                    }
+                }
+            ],
+        },
+    ],
+)
+def test_extract_session_id_finds_all_project_dependency_shapes(
+    sample_config,
+    migration_state,
+    chart,
+):
+    """Pre-resolution should find every project/session shape remapping supports."""
+
+    migrator = ChartMigrator(
+        _mock_client(),
+        _mock_client(),
+        migration_state,
+        sample_config,
+    )
+
+    assert migrator._extract_session_id(chart) == "source-project"
+
+
 def test_migrate_all_charts_resolves_nested_session_filter(
     sample_config,
     migration_state,
@@ -250,6 +303,60 @@ def test_migrate_all_charts_resolves_nested_session_filter(
         dest_session_id,
         same_instance=False,
     )
+
+
+def test_migrate_all_charts_preserves_multiple_remapped_project_dependencies(
+    sample_config,
+    migration_state,
+):
+    """All-chart remap should keep every mapped project dependency distinct."""
+
+    source_client = _mock_client()
+    dest_client = _mock_client()
+    migrator = ChartMigrator(
+        source_client,
+        dest_client,
+        migration_state,
+        sample_config,
+    )
+    migrator._project_id_map = {
+        "source-project-a": "dest-project-a",
+        "source-project-b": "dest-project-b",
+    }
+    migrator._project_mapping_complete = True
+    migrator._dataset_id_map = {}
+    migrator.list_charts = Mock(
+        return_value=[
+            {
+                "id": "chart-1",
+                "title": "Chart One",
+                "project_id": "source-project-a",
+                "series": [
+                    {
+                        "filters": {
+                            "session": [
+                                "source-project-a",
+                                "source-project-b",
+                            ]
+                        }
+                    }
+                ],
+            }
+        ]
+    )
+    migrator.create_chart = Mock(return_value="dest-chart-1")
+    migrator._export_chart_manual_apply = Mock(return_value="/tmp/chart.json")
+
+    mappings = migrator.migrate_all_charts(same_instance=False)
+
+    assert mappings == {"source-project-a": {"chart-1": "dest-chart-1"}}
+    payload = migrator.create_chart.call_args.args[0]
+    assert payload["project_id"] == "dest-project-a"
+    assert payload["series"][0]["filters"]["session"] == [
+        "dest-project-a",
+        "dest-project-b",
+    ]
+    migrator._export_chart_manual_apply.assert_not_called()
 
 
 def test_migrate_chart_exports_when_dependencies_are_unresolved(
@@ -360,6 +467,169 @@ def test_migrate_chart_exports_unresolved_dataset_filter_in_remap_mode(
     migrator.create_chart.assert_not_called()
     analysis = migrator._export_chart_manual_apply.call_args.kwargs["analysis"]
     assert analysis["unresolved_dependencies"] == {"dataset_id": ["source-dataset"]}
+
+
+def test_migrate_chart_maps_each_project_dependency_when_dest_session_is_known(
+    sample_config,
+    migration_state,
+):
+    """Cross-workspace chart remap should not collapse multiple project filters."""
+
+    source_client = _mock_client()
+    dest_client = _mock_client()
+
+    migrator = ChartMigrator(
+        source_client,
+        dest_client,
+        migration_state,
+        sample_config,
+    )
+    migrator._project_id_map = {
+        "source-project-a": "dest-project-a",
+        "source-project-b": "dest-project-b",
+    }
+    migrator._project_mapping_complete = True
+    migrator._dataset_id_map = {}
+    migrator.create_chart = Mock(return_value="dest-chart")
+    migrator._export_chart_manual_apply = Mock(return_value="/tmp/chart.json")
+
+    chart_id = migrator.migrate_chart(
+        {
+            "id": "source-chart",
+            "title": "Latency",
+            "project_id": "source-project-a",
+            "series": [
+                {
+                    "filters": {
+                        "session_id": "source-project-b",
+                        "nested": {
+                            "session": [
+                                "source-project-a",
+                                "source-project-b",
+                            ]
+                        },
+                    }
+                }
+            ],
+        },
+        dest_session_id="dest-project-a",
+        same_instance=False,
+    )
+
+    assert chart_id == "dest-chart"
+    payload = migrator.create_chart.call_args.args[0]
+    assert payload["project_id"] == "dest-project-a"
+    assert payload["series"][0]["filters"]["session_id"] == "dest-project-b"
+    assert payload["series"][0]["filters"]["nested"]["session"] == [
+        "dest-project-a",
+        "dest-project-b",
+    ]
+    migrator._export_chart_manual_apply.assert_not_called()
+
+
+def test_migrate_chart_same_instance_preserves_multiple_project_filters(
+    sample_config,
+    migration_state,
+):
+    """Same-instance chart mode should preserve all source project IDs."""
+
+    source_client = _mock_client()
+    dest_client = _mock_client()
+
+    migrator = ChartMigrator(
+        source_client,
+        dest_client,
+        migration_state,
+        sample_config,
+    )
+    migrator._project_id_map = {}
+    migrator._project_mapping_complete = True
+    migrator._dataset_id_map = {}
+    migrator.create_chart = Mock(return_value="dest-chart")
+    migrator._export_chart_manual_apply = Mock(return_value="/tmp/chart.json")
+
+    chart_id = migrator.migrate_chart(
+        {
+            "id": "source-chart",
+            "title": "Latency",
+            "project_id": "source-project-a",
+            "series": [
+                {
+                    "filters": {
+                        "session_id": "source-project-b",
+                        "nested": {
+                            "session": [
+                                "source-project-a",
+                                "source-project-b",
+                            ]
+                        },
+                    }
+                }
+            ],
+        },
+        dest_session_id="source-project-a",
+        same_instance=True,
+    )
+
+    assert chart_id == "dest-chart"
+    payload = migrator.create_chart.call_args.args[0]
+    assert payload["project_id"] == "source-project-a"
+    assert payload["series"][0]["filters"]["session_id"] == "source-project-b"
+    assert payload["series"][0]["filters"]["nested"]["session"] == [
+        "source-project-a",
+        "source-project-b",
+    ]
+    migrator._export_chart_manual_apply.assert_not_called()
+
+
+def test_migrate_chart_exports_unmapped_secondary_project_dependency(
+    sample_config,
+    migration_state,
+):
+    """Cross-workspace remap should not hide missing secondary project mappings."""
+
+    source_client = _mock_client()
+    dest_client = _mock_client()
+
+    migrator = ChartMigrator(
+        source_client,
+        dest_client,
+        migration_state,
+        sample_config,
+    )
+    migrator._project_id_map = {"source-project-a": "dest-project-a"}
+    migrator._project_mapping_complete = True
+    migrator._dataset_id_map = {}
+    migrator.create_chart = Mock()
+    migrator._export_chart_manual_apply = Mock(return_value="/tmp/chart.json")
+
+    chart_id = migrator.migrate_chart(
+        {
+            "id": "source-chart",
+            "title": "Latency",
+            "project_id": "source-project-a",
+            "series": [
+                {
+                    "filters": {
+                        "session": [
+                            "source-project-a",
+                            "source-project-b",
+                        ]
+                    }
+                }
+            ],
+        },
+        dest_session_id="dest-project-a",
+        same_instance=False,
+    )
+
+    assert chart_id is None
+    migrator.create_chart.assert_not_called()
+    analysis = migrator._export_chart_manual_apply.call_args.kwargs["analysis"]
+    assert analysis["dest_session_id"] == "dest-project-a"
+    assert analysis["unresolved_dependencies"] == {
+        "session_id": ["source-project-b"]
+    }
 
 
 def test_migrate_session_charts_forwards_same_instance(

--- a/tests/test_chart_mode.py
+++ b/tests/test_chart_mode.py
@@ -1,0 +1,168 @@
+"""Chart same-instance mode decision tests."""
+
+import pytest
+
+from langsmith_migrator.utils.chart_mode import (
+    normalize_deployment_url,
+    should_reuse_chart_ids,
+    workspace_pair_allows_same_instance,
+)
+from langsmith_migrator.utils.config import Config
+
+
+def _config(
+    *,
+    source_url: str = "https://same.example",
+    dest_url: str = "https://same.example/api/v1",
+    source_key: str = "shared-key",
+    dest_key: str = "shared-key",
+) -> Config:
+    return Config(
+        source_api_key=source_key,
+        dest_api_key=dest_key,
+        source_url=source_url,
+        dest_url=dest_url,
+    )
+
+
+@pytest.mark.parametrize(
+    ("source_url", "dest_url", "expected"),
+    [
+        ("https://same.example", "https://same.example/", True),
+        ("https://same.example", "https://same.example/api/v1", True),
+        ("https://same.example/api/v2/", "https://same.example", True),
+        ("https://SAME.example/api/v1/", "https://same.example/api/v2", True),
+        ("https://source.example", "https://dest.example", False),
+    ],
+)
+def test_normalize_deployment_url_permutations(source_url, dest_url, expected):
+    """Deployment comparison should ignore API suffixes, trailing slashes, and case."""
+
+    assert (
+        normalize_deployment_url(source_url) == normalize_deployment_url(dest_url)
+    ) is expected
+
+
+@pytest.mark.parametrize(
+    ("source_ws", "dest_ws", "expected"),
+    [
+        (None, None, True),
+        ("", "", True),
+        ("shared-ws", "shared-ws", True),
+        ("src-ws", "dst-ws", False),
+        ("src-ws", None, False),
+        (None, "dst-ws", False),
+        ("src-ws", "", False),
+        ("", "dst-ws", False),
+    ],
+)
+def test_workspace_pair_allows_same_instance_permutations(
+    source_ws,
+    dest_ws,
+    expected,
+):
+    """Workspace scoping must only allow ID reuse for identical or unscoped pairs."""
+
+    assert workspace_pair_allows_same_instance(source_ws, dest_ws) is expected
+
+
+@pytest.mark.parametrize(
+    (
+        "source_url",
+        "dest_url",
+        "source_key",
+        "dest_key",
+        "source_ws",
+        "dest_ws",
+        "expected",
+    ),
+    [
+        (
+            "https://same.example",
+            "https://same.example/api/v1",
+            "shared-key",
+            "shared-key",
+            None,
+            None,
+            True,
+        ),
+        (
+            "https://same.example",
+            "https://same.example/api/v1",
+            "shared-key",
+            "shared-key",
+            "shared-ws",
+            "shared-ws",
+            True,
+        ),
+        (
+            "https://same.example",
+            "https://same.example/api/v1",
+            "shared-key",
+            "shared-key",
+            "src-ws",
+            "dst-ws",
+            False,
+        ),
+        (
+            "https://same.example",
+            "https://same.example/api/v1",
+            "src-key",
+            "dst-key",
+            "shared-ws",
+            "shared-ws",
+            True,
+        ),
+        (
+            "https://same.example",
+            "https://same.example/api/v1",
+            "src-key",
+            "dst-key",
+            "src-ws",
+            "dst-ws",
+            False,
+        ),
+        (
+            "https://same.example",
+            "https://same.example/api/v1",
+            "src-key",
+            "dst-key",
+            None,
+            None,
+            False,
+        ),
+        (
+            "https://source.example",
+            "https://dest.example",
+            "shared-key",
+            "shared-key",
+            "shared-ws",
+            "shared-ws",
+            False,
+        ),
+    ],
+)
+def test_should_reuse_chart_ids_permutations(
+    source_url,
+    dest_url,
+    source_key,
+    dest_key,
+    source_ws,
+    dest_ws,
+    expected,
+):
+    """Chart ID reuse is safe only for same deployment plus same key or workspace."""
+
+    assert (
+        should_reuse_chart_ids(
+            _config(
+                source_url=source_url,
+                dest_url=dest_url,
+                source_key=source_key,
+                dest_key=dest_key,
+            ),
+            source_ws,
+            dest_ws,
+        )
+        is expected
+    )

--- a/tests/test_orchestrator_resume.py
+++ b/tests/test_orchestrator_resume.py
@@ -17,8 +17,10 @@ from langsmith_migrator.utils.state import (
 class _FakeClient:
     def __init__(self) -> None:
         self.session = SimpleNamespace(headers={})
+        self.workspace_calls = []
 
     def set_workspace(self, workspace_id: str | None) -> None:
+        self.workspace_calls.append(workspace_id)
         if workspace_id is None:
             self.session.headers.pop("X-Tenant-Id", None)
         else:
@@ -265,6 +267,101 @@ def test_resume_items_re_resolves_chart_when_same_instance_metadata_is_stale(
     assert results["resumed"] == ["chart:chart-1"]
     assert results["blocked"] == []
     assert "Chart resume context changed" in orchestrator.console.text
+    chart_migrator.resolve_destination_session_id.assert_called_once_with(
+        "source-session",
+        same_instance=False,
+    )
+    chart_migrator.migrate_chart.assert_called_once_with(
+        chart_payload,
+        "dest-session",
+        same_instance=False,
+    )
+    assert chart_item.metadata["same_instance"] is False
+    assert chart_item.metadata["dest_session_id"] == "dest-session"
+    assert chart_item.metadata["previous_same_instance"] is True
+    assert chart_item.metadata["previous_dest_session_id"] == "source-session"
+
+
+def test_resume_items_re_resolves_same_key_chart_across_different_workspaces(
+    monkeypatch, sample_config, migration_state, tmp_path
+):
+    """Same URL and API key still need remap mode when workspace scopes differ."""
+
+    sample_config.source.base_url = "https://api.smith.langchain.com"
+    sample_config.destination.base_url = "https://api.smith.langchain.com/api/v1"
+    sample_config.source.api_key = "shared-key"
+    sample_config.destination.api_key = "shared-key"
+    migration_state.id_mappings["project"] = {"source-session": "dest-session"}
+
+    source_client = _FakeClient()
+    dest_client = _FakeClient()
+    clients = [source_client, dest_client]
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.EnhancedAPIClient",
+        lambda **kwargs: clients.pop(0),
+    )
+
+    chart_migrator = Mock()
+    chart_migrator._extract_session_id.return_value = "source-session"
+    chart_migrator.resolve_destination_session_id.return_value = "dest-session"
+    chart_migrator.migrate_chart.return_value = "dest-chart-1"
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.chart.ChartMigrator",
+        lambda *args, **kwargs: chart_migrator,
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.prompt.PromptMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.annotation_queue.AnnotationQueueMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.rules.RulesMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.ExperimentMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.orchestrator.FeedbackMigrator",
+        lambda *args, **kwargs: Mock(),
+    )
+
+    state_manager = StateManager(tmp_path / "state")
+    orchestrator = MigrationOrchestrator(sample_config, state_manager)
+    orchestrator.console = _FakeConsole()
+    orchestrator.state = migration_state
+
+    chart_payload = {
+        "id": "chart-1",
+        "title": "Chart One",
+        "project_id": "source-session",
+        "series": [],
+    }
+    chart_item = MigrationItem(
+        id="chart_src-ws_chart-1",
+        type="chart",
+        name="Chart One",
+        source_id="chart-1",
+        status=MigrationStatus.PENDING,
+        workspace_pair={"source": "src-ws", "dest": "dst-ws"},
+        metadata={
+            "chart": chart_payload,
+            "dest_session_id": "source-session",
+            "same_instance": True,
+        },
+    )
+    migration_state.add_item(chart_item)
+
+    results = orchestrator.resume_items([chart_item])
+
+    assert results["resumed"] == ["chart:chart-1"]
+    assert results["blocked"] == []
+    assert source_client.workspace_calls == ["src-ws", None]
+    assert dest_client.workspace_calls == ["dst-ws", None]
     chart_migrator.resolve_destination_session_id.assert_called_once_with(
         "source-session",
         same_instance=False,

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.70"
+version = "0.0.71"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- fix chart project/session remapping so every chart project dependency uses explicit/source-to-destination mappings
- preserve same-instance behavior only for true ID-reuse mode
- add regression coverage for same-deployment/different-workspace chart migration permutations
- bump release metadata to v0.0.71

## Verification
- uv lock --check
- uv run pytest tests/test_chart_mode.py tests/test_chart_migrator.py tests/functional/test_cli_functional.py tests/test_orchestrator_resume.py -q
- uv run --with ruff ruff check langsmith_migrator/core/migrators/chart.py tests/test_chart_mode.py tests/test_chart_migrator.py tests/functional/test_cli_functional.py tests/test_orchestrator_resume.py
- uv run pytest -q
- uv build
- python3 .github/scripts/check_wheel_contents.py dist/langsmith_data_migration_tool-0.0.71-py3-none-any.whl
- uvx --from ./dist/langsmith_data_migration_tool-0.0.71-py3-none-any.whl langsmith-migrator --help
- BASE_REF=main bash .github/scripts/check_readme_release_sync.sh