### PR TITLE
Fix chart string-filter dependency guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.73] - 2026-05-01
+
+### Fixed
+- **Chart string-filter dependency guards**: Cross-workspace chart migration now detects source project IDs that remain only inside serialized filter strings and blocks with a single unresolved dependency diagnostic instead of allowing unmapped source IDs to survive chart remapping.
+
 ## [0.0.72] - 2026-05-01
 
 ### Fixed
@@ -339,7 +344,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration documentation
 - API reference for core classes
 
-[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.72...HEAD
+[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.73...HEAD
+[0.0.73]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.72...v0.0.73
 [0.0.72]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.71...v0.0.72
 [0.0.71]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.70...v0.0.71
 [0.0.70]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.69...v0.0.70

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python CLI for migrating users and roles, datasets, experiments, annotation qu
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.72-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.73-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -54,20 +54,20 @@ For trace data, use LangSmith's **Bulk Export** functionality: [LangSmith Bulk E
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.72-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.73-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.72-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.73-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.72-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.73-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.72-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.73-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)

--- a/langsmith_migrator/__init__.py
+++ b/langsmith_migrator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("langsmith-data-migration-tool")
 except PackageNotFoundError:
-    __version__ = "0.0.72"
+    __version__ = "0.0.73"

--- a/langsmith_migrator/core/migrators/chart.py
+++ b/langsmith_migrator/core/migrators/chart.py
@@ -15,6 +15,7 @@ class ChartMigrator(BaseMigrator):
         super().__init__(source_client, dest_client, state, config)
         self._project_id_map = None  # Lazy-loaded cache
         self._project_mapping_complete = False
+        self._source_project_ids = None  # Lazy-loaded source project IDs for string filters
         self._dataset_id_map = None  # Lazy-loaded cache
         self._dest_section_map = None  # Lazy-loaded cache for dest sections
         self._section_strategy = None
@@ -314,6 +315,73 @@ class ChartMigrator(BaseMigrator):
 
         visit(charts)
         return dependencies
+
+    def _mark_unresolved_string_project_dependencies(
+        self,
+        chart: Any,
+        project_map: Dict[str, str],
+        unresolved: Dict[str, set[str]],
+    ) -> None:
+        """Record source project IDs that remain inside serialized filter strings."""
+        known_project_ids = set(self._source_project_ids or set(project_map))
+        if not known_project_ids:
+            return
+
+        remaining_source_ids = self._project_ids_in_serialized_strings(
+            chart,
+            known_project_ids,
+        )
+        for project_id in remaining_source_ids:
+            if project_id not in project_map:
+                unresolved["session_id"].add(project_id)
+
+    def _project_ids_in_serialized_strings(
+        self,
+        obj: Any,
+        known_project_ids: set[str],
+        *,
+        parent_key: Optional[str] = None,
+    ) -> set[str]:
+        """Find known source project IDs inside non-structured string fields."""
+        found: set[str] = set()
+        structured_keys = {"project_id", "session_id", "dataset_id", "session"}
+
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                if isinstance(value, str):
+                    if key not in structured_keys:
+                        found.update(
+                            project_id
+                            for project_id in known_project_ids
+                            if project_id and project_id in value
+                        )
+                else:
+                    found.update(
+                        self._project_ids_in_serialized_strings(
+                            value,
+                            known_project_ids,
+                            parent_key=key,
+                        )
+                    )
+        elif isinstance(obj, list):
+            for value in obj:
+                if isinstance(value, str):
+                    if parent_key not in structured_keys:
+                        found.update(
+                            project_id
+                            for project_id in known_project_ids
+                            if project_id and project_id in value
+                        )
+                else:
+                    found.update(
+                        self._project_ids_in_serialized_strings(
+                            value,
+                            known_project_ids,
+                            parent_key=parent_key,
+                        )
+                    )
+
+        return found
 
     def _list_charts(
         self,
@@ -976,6 +1044,12 @@ class ChartMigrator(BaseMigrator):
             same_instance=same_instance,
             source_session_id=source_session_id,
         )
+        if not same_instance:
+            self._mark_unresolved_string_project_dependencies(
+                chart_copy,
+                project_map,
+                unresolved_dependencies,
+            )
         unresolved_dependencies = self._normalize_unresolved_dependencies(unresolved_dependencies)
         if unresolved_dependencies:
             self.log(
@@ -1367,6 +1441,9 @@ class ChartMigrator(BaseMigrator):
             for project in self.source.get_paginated("/sessions", page_size=100):
                 if isinstance(project, dict):
                     source_records.append(project)
+            self._source_project_ids = {
+                project["id"] for project in source_records if project.get("id")
+            }
 
             dest_records: List[Dict[str, Any]] = []
             for project in self.dest.get_paginated("/sessions", page_size=100):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.72"
+version = "0.0.73"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_chart_migrator.py
+++ b/tests/test_chart_migrator.py
@@ -574,6 +574,64 @@ def test_migrate_chart_rewrites_project_ids_embedded_in_string_filters(
     migrator._export_chart_manual_apply.assert_not_called()
 
 
+def test_migrate_chart_exports_unmapped_project_ids_embedded_only_in_string_filters(
+    sample_config,
+    migration_state,
+):
+    """String-only chart project dependencies must not survive cross-workspace remap."""
+
+    mapped_source_id = "11111111-1111-1111-1111-111111111111"
+    mapped_dest_id = "22222222-2222-2222-2222-222222222222"
+    unmapped_source_id = "33333333-3333-3333-3333-333333333333"
+    source_client = _mock_client()
+    dest_client = _mock_client()
+
+    def source_get_paginated(endpoint, page_size=100):
+        if endpoint == "/sessions":
+            return [
+                {"id": mapped_source_id, "name": "Mapped Project"},
+                {"id": unmapped_source_id, "name": "Unmapped Project"},
+            ]
+        return []
+
+    def dest_get_paginated(endpoint, page_size=100):
+        if endpoint == "/sessions":
+            return [{"id": mapped_dest_id, "name": "Mapped Project"}]
+        return []
+
+    source_client.get_paginated.side_effect = source_get_paginated
+    dest_client.get_paginated.side_effect = dest_get_paginated
+
+    migrator = ChartMigrator(
+        source_client,
+        dest_client,
+        migration_state,
+        sample_config,
+    )
+    migrator.create_chart = Mock()
+    migrator._export_chart_manual_apply = Mock(return_value="/tmp/chart.json")
+
+    chart_id = migrator.migrate_chart(
+        {
+            "id": "source-chart",
+            "title": "Latency",
+            "series": [
+                {
+                    "filters": {
+                        "filter": f'eq(session_id, "{unmapped_source_id}")',
+                    }
+                }
+            ],
+        },
+        same_instance=False,
+    )
+
+    assert chart_id is None
+    migrator.create_chart.assert_not_called()
+    analysis = migrator._export_chart_manual_apply.call_args.kwargs["analysis"]
+    assert analysis["unresolved_dependencies"] == {"session_id": [unmapped_source_id]}
+
+
 def test_migrate_chart_same_instance_preserves_multiple_project_filters(
     sample_config,
     migration_state,

--- a/uv.lock
+++ b/uv.lock
@@ -1286,7 +1286,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.72"
+version = "0.0.73"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- detect source project IDs that remain only inside serialized chart filter strings during cross-workspace chart migration
- export a single unresolved dependency diagnostic instead of allowing unmapped source IDs to survive chart remapping
- bump release metadata to v0.0.73

## Verification
- `uv lock --check`
- `uv run --extra test ruff check langsmith_migrator/core/migrators/chart.py tests/test_chart_migrator.py pyproject.toml langsmith_migrator/__init__.py`
- `uv run pytest tests/test_chart_migrator.py -q`
- `uv run pytest tests/test_orchestrator_resume.py -k 'chart' -q`
- `uv run pytest tests/functional/test_cli_functional.py -k 'chart' -q`
- `uv run pytest tests/test_tui_project_mapper.py -q`
- `uv run pytest -q`
- `uv build`
- `python3 .github/scripts/check_wheel_contents.py dist/langsmith_data_migration_tool-0.0.73-py3-none-any.whl`
- `uvx --from ./dist/langsmith_data_migration_tool-0.0.73-py3-none-any.whl langsmith-migrator --help`
- wheel-level behavior smoke: `wheel_string_filter_guard=pass`
