### PR TITLE
Prepare v0.0.75 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.75] - 2026-05-18
+
 ### Changed
 - Experiment run migration now rewrites every run's `start_time`, `end_time`,
   `dotted_order` timestamps, and `events[].time` (plus the parent experiment's
@@ -16,7 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   experiments would have zero runs migrated. Relative offsets between runs
   within an experiment are preserved exactly. The delta is persisted in
   migration state per experiment so resume replays use the same shift as the
-  initial attempt.
+  initial attempt. When `end_time` is missing or malformed, the shift falls
+  back to `start_time` so partially-corrupt experiment metadata still gets
+  a valid anchor.
+- Bumped `langsmith` 0.7.31 → 0.8.5.
+
+### Security
+- Bumped `urllib3` 2.6.3 → 2.7.0 to pick up fixes for two high-severity
+  advisories: GHSA-mf9v-mfxr-j63j (decompression-bomb safeguard bypass on
+  `HTTPResponse.drain_conn()` and Brotli streaming reads) and
+  GHSA-qccp-gfcp-xxvc (sensitive headers not stripped on cross-host redirects
+  when using `ProxyManager.connection_from_url`).
 
 ## [0.0.74] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python CLI for migrating users and roles, datasets, experiments, annotation qu
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.74-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.75-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -58,20 +58,20 @@ The destination's `POST /runs/batch` endpoint rejects runs with timestamps outsi
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.74-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.75-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.74-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.75-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.74-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.75-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.74-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.75-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.74"
+version = "0.0.75"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1295,7 +1295,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.74"
+version = "0.0.75"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bumps version: 0.0.74 → 0.0.75
- Dates the `[Unreleased]` CHANGELOG block and consolidates everything that landed since 0.0.74 (#97 dependency bumps + #98 timestamp rewrite)
- Bumps the install URLs in README to the new wheel

## What's in 0.0.75
- **Experiment run migration** rewrites every run's timestamps (`start_time`, `end_time`, `dotted_order`, `events[].time`) and the parent experiment's `start_time`/`end_time` by a per-experiment delta so the newest timestamp lands at "now" — required to satisfy the destination's 24h `POST /runs/batch` window. Relative offsets preserved exactly. Shift persisted in state for resume consistency. Malformed `end_time` falls back to `start_time`.
- **Security**: urllib3 2.6.3 → 2.7.0 picks up fixes for GHSA-mf9v-mfxr-j63j (decompression-bomb safeguard bypass) and GHSA-qccp-gfcp-xxvc (proxy redirect header stripping).
- **Dependency bump**: langsmith 0.7.31 → 0.8.5.

## Test plan
- [x] `uv run pytest -q` — 381 passed
- [x] `uv run ruff check langsmith_migrator` — clean
- [x] `uv build` — produces `langsmith_data_migration_tool-0.0.75-py3-none-any.whl` and `.tar.gz`
- [ ] After merge: tag `v0.0.75`, push tag, create GitHub release, upload built artifacts