### PR TITLE
Fix chart project mapping ID handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.76] - 2026-05-18
+
+### Fixed
+- **Chart project mapper ID handoff**: Pressing `Enter` on a unique destination
+  suggestion in the `--map-projects` TUI now records the ID-bearing destination
+  row instead of the raw typed name, so charts and rules receive the source-ID
+  mapping that their dependency validators require.
+- **Chart mapping validation**: ID-based project mapping flows no longer count
+  unresolved text destinations as mapped, and chart dependency validation now
+  rejects saved mappings whose destination project ID is no longer present in
+  the active destination workspace.
+- **Chart remediation resume state**: A successful chart project remap now marks
+  the earlier chart-dependency blocker resolved so later `resume` runs do not
+  keep exiting on stale blocked migration state.
+
 ## [0.0.75] - 2026-05-18
 
 ### Changed
@@ -374,7 +389,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration documentation
 - API reference for core classes
 
-[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.74...HEAD
+[Unreleased]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.76...HEAD
+[0.0.76]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.75...v0.0.76
+[0.0.75]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.74...v0.0.75
 [0.0.74]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.73...v0.0.74
 [0.0.73]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.72...v0.0.73
 [0.0.72]: https://github.com/langchain-ai/langsmith-data-migration-tool/compare/v0.0.71...v0.0.72

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python CLI for migrating users and roles, datasets, experiments, annotation qu
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.75-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.76-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -58,20 +58,20 @@ The destination's `POST /runs/batch` endpoint rejects runs with timestamps outsi
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.75-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.76-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.75-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.76-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.75-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.76-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.75-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.76-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)
@@ -394,10 +394,10 @@ When `--skip-users` is omitted, `migrate-all` runs user/role migration as Step 0
 
 Rules and charts reference projects by ID. When migrating between instances, project IDs differ.
 
-- **Interactive TUI (`--map-projects`)**: Launch a visual TUI to map source projects to destination projects. Available on `rules`, `charts`, and `migrate-all` commands. Select a source project and type a destination name directly — existing projects appear as filterable suggestions below the input. Supports auto-match by name, skip, and custom name entry.
+- **Interactive TUI (`--map-projects`)**: Launch a visual TUI to map source projects to destination projects. Available on `rules`, `charts`, and `migrate-all` commands. Select a source project and type a destination name directly — existing projects appear as filterable suggestions below the input, and pressing `Enter` on a unique suggestion records the destination project ID used by downstream chart/rule validation. Supports auto-match by name, skip, and custom name entry. For ID-based chart/rule remapping, unresolved text entries remain unmapped instead of being counted as resolved.
 - **Rules (`--project-mapping`)**: Supply an explicit source→destination project ID mapping as JSON or a file path. Use `list-projects --source` and `list-projects --dest` to get IDs. The mapping is applied to both top-level project associations and project IDs embedded inside rule filters. Mutually exclusive with `--map-projects`.
 - **Rules queue targets**: When a rule references an annotation queue, the migrator first reuses any saved queue migration mapping, then falls back to an exact-name queue match in the destination workspace. If neither is safe, the rule is exported for remediation instead of being posted with the source queue ID.
-- **Charts**: Without `--map-projects`, project mapping is built automatically by matching project names between source and destination. When both sides point at the same deployment URL but use different API keys/workspaces, charts still remap project/session IDs; the tool does not treat that as `--same-instance`. Workspace-scoped `--map-projects` mappings are resolved against the active workspace pair so duplicate project names in other workspaces are ignored. Chart filters are normalized to the destination API's `session`/`session_id` project-scoping shape before create or update.
+- **Charts**: Without `--map-projects`, project mapping is built automatically by matching project names between source and destination. When both sides point at the same deployment URL but use different API keys/workspaces, charts still remap project/session IDs; the tool does not treat that as `--same-instance`. Workspace-scoped `--map-projects` mappings are resolved against the active workspace pair so duplicate project names in other workspaces are ignored. Chart dependency validation also verifies that saved destination project IDs still exist before migration. Chart filters are normalized to the destination API's `session`/`session_id` project-scoping shape before create or update.
 - **`migrate-all`**: Supports `--strip-projects`, `--map-projects`, and `--rules-create-enabled` for rules. Use the standalone `rules` command for `--project-mapping` JSON mappings.
 
 ### Interactive Selection
@@ -454,7 +454,7 @@ Every migration session persists state and writes a remediation bundle when ther
 - org members
 - workspace members
 
-For chart items, `resume` revalidates saved `--same-instance` metadata against the current source/destination and workspace context. If the mode changed, it re-resolves the destination project/session before retrying; if that cannot be resolved safely, the item is checkpointed with guidance to rerun `charts` with project mapping. Global or dataset-only charts that have no project/session dependency can resume with `dest_session_id=None`.
+For chart items, `resume` revalidates saved `--same-instance` metadata against the current source/destination and workspace context. If the mode changed, it re-resolves the destination project/session before retrying; if that cannot be resolved safely, the item is checkpointed with guidance to rerun `charts` with project mapping. A later successful `charts --map-projects` run marks the prior chart dependency blocker resolved so `resume` does not keep looping on stale blocked state. Global or dataset-only charts that have no project/session dependency can resume with `dest_session_id=None`.
 
 Use `langsmith-migrator clean` to remove saved sessions once you no longer need their state or remediation bundles.
 

--- a/langsmith_migrator/__init__.py
+++ b/langsmith_migrator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("langsmith-data-migration-tool")
 except PackageNotFoundError:
-    __version__ = "0.0.74"
+    __version__ = "0.0.76"

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -262,24 +262,83 @@ def _persist_project_id_map(orchestrator, config, project_id_map: dict | None) -
     orchestrator.state_manager.save()
 
 
+def _ensure_chart_dependency_project_records(
+    orchestrator,
+    source_projects: list,
+    dest_projects: list,
+) -> tuple[list, list]:
+    """Fetch project records when chart dependency validation needs ID proof."""
+    if source_projects and dest_projects:
+        return source_projects, dest_projects
+
+    console.print("Fetching projects for chart dependency validation... ", end="")
+    source_records = source_projects or _list_projects(orchestrator.source_client)
+    dest_records = dest_projects or _list_projects(orchestrator.dest_client)
+    console.print(f"[green]✓[/green] ({len(source_records)} source, {len(dest_records)} destination)")
+    return source_records, dest_records
+
+
 def _unresolved_chart_project_dependencies(
     chart_migrator,
     dependency_ids: set[str],
     *,
     same_instance: bool,
+    dest_projects: list | None = None,
 ) -> list[str]:
     """Return dependency IDs that still cannot resolve to destination projects."""
     if same_instance:
         return []
+    dest_project_ids = set(_project_by_id(dest_projects or []))
     missing = []
     for dependency_id in sorted(dependency_ids):
         dest_id = chart_migrator.resolve_destination_session_id(
             dependency_id,
             same_instance=False,
         )
-        if not dest_id:
+        if not dest_id or (dest_project_ids and dest_id not in dest_project_ids):
             missing.append(dependency_id)
     return missing
+
+
+def _mark_chart_project_dependencies_resolved(
+    orchestrator,
+    config,
+    dependency_ids: set[str],
+    project_id_map: dict | None,
+) -> None:
+    """Clear a previous chart dependency checkpoint once all mappings resolve."""
+    if not dependency_ids:
+        return
+    if not orchestrator.state:
+        return
+
+    workspace_pair = _active_workspace_pair(orchestrator)
+    item_id = _state_item_id(
+        "chart_dependency",
+        "project_mappings",
+        workspace_pair["source"],
+    )
+    item = orchestrator.state.get_item(item_id)
+    if not item or item.terminal_state != ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value:
+        return
+
+    orchestrator.state.update_item_status(
+        item_id,
+        MigrationStatus.COMPLETED,
+        stage="resolved",
+    )
+    orchestrator.state.mark_terminal(
+        item_id,
+        ResolutionOutcome.MIGRATED,
+        "chart_project_mapping_resolved",
+        verification_state=VerificationState.VERIFIED,
+        evidence={
+            "resolved_dependency_ids": sorted(dependency_ids),
+            "project_map_size": len(project_id_map or {}),
+            "workspace_pair": workspace_pair,
+        },
+    )
+    orchestrator.state_manager.save()
 
 
 def _block_unresolved_chart_project_dependencies(
@@ -3807,6 +3866,14 @@ def _migrate_all_for_workspace(
                 _ensure_migration_session(orchestrator, config)
                 chart_migrator.state = orchestrator.state
                 if not same_instance:
+                    (
+                        source_projects_for_mapping,
+                        dest_projects_for_mapping,
+                    ) = _ensure_chart_dependency_project_records(
+                        orchestrator,
+                        source_projects_for_mapping,
+                        dest_projects_for_mapping,
+                    )
                     chart_dependency_ids = _chart_project_dependency_ids(
                         source_charts,
                         source_projects_for_mapping,
@@ -3833,6 +3900,7 @@ def _migrate_all_for_workspace(
                         chart_migrator,
                         chart_dependency_ids,
                         same_instance=False,
+                        dest_projects=dest_projects_for_mapping,
                     )
                     if missing_project_ids:
                         _block_unresolved_chart_project_dependencies(
@@ -3845,6 +3913,12 @@ def _migrate_all_for_workspace(
                             "[yellow]Skipped charts until mappings are resolved[/yellow]\n"
                         )
                         return
+                    _mark_chart_project_dependencies_resolved(
+                        orchestrator,
+                        config,
+                        chart_dependency_ids,
+                        chart_migrator._project_id_map,
+                    )
 
                 tracked_chart_items = {}
 
@@ -4149,14 +4223,14 @@ def charts(
             tracked_chart_items = {}
             source_charts = chart_migrator.list_charts()
             if not effective_same_instance:
-                if chart_migrator._project_id_map and not source_projects_for_mapping:
-                    console.print("Fetching projects for chart dependency validation... ", end="")
-                    source_projects_for_mapping = _list_projects(orchestrator.source_client)
-                    dest_projects_for_mapping = _list_projects(orchestrator.dest_client)
-                    console.print(
-                        f"[green]✓[/green] ({len(source_projects_for_mapping)} source, "
-                        f"{len(dest_projects_for_mapping)} destination)"
-                    )
+                (
+                    source_projects_for_mapping,
+                    dest_projects_for_mapping,
+                ) = _ensure_chart_dependency_project_records(
+                    orchestrator,
+                    source_projects_for_mapping,
+                    dest_projects_for_mapping,
+                )
 
                 chart_dependency_ids = _chart_project_dependency_ids(
                     source_charts,
@@ -4184,6 +4258,7 @@ def charts(
                     chart_migrator,
                     chart_dependency_ids,
                     same_instance=False,
+                    dest_projects=dest_projects_for_mapping,
                 )
                 if missing_project_ids:
                     _block_unresolved_chart_project_dependencies(
@@ -4194,6 +4269,12 @@ def charts(
                     )
                     console.print("[yellow]Skipped charts until mappings are resolved[/yellow]")
                     continue
+                _mark_chart_project_dependencies_resolved(
+                    orchestrator,
+                    config,
+                    chart_dependency_ids,
+                    chart_migrator._project_id_map,
+                )
 
             for chart in source_charts:
                 chart_id = chart.get("id")

--- a/langsmith_migrator/cli/tui_project_mapper.py
+++ b/langsmith_migrator/cli/tui_project_mapper.py
@@ -216,9 +216,26 @@ class DestinationPickerScreen(ModalScreen[Optional[str]]):
         self._refresh_table()
         self._filter_timer = None
 
+    def _submitted_value(self, value: str) -> Optional[str]:
+        """Resolve Enter in the input to an unambiguous visible destination label."""
+        value = value.strip()
+        if not value:
+            return None
+        if value in self.dest_labels:
+            return value
+
+        value_lower = value.lower()
+        matching_labels = [
+            label for label in self.dest_labels if value_lower in label.lower()
+        ]
+        if len(matching_labels) == 1:
+            return matching_labels[0]
+
+        return value
+
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Confirm whatever text is in the input."""
-        value = event.value.strip()
+        value = self._submitted_value(event.value)
         if value:
             self.dismiss(value)
 
@@ -574,6 +591,9 @@ class ProjectMapperApp(App):
             mapping.dest_name = value
             mapping.dest_id = None
             mapping.dest_label = value
+            if self.return_ids:
+                mapping.status = MappingStatus.UNMAPPED
+                return
         mapping.status = (
             self._status_for_same_name(mapping.source_name)
             if mapping.dest_name == mapping.source_name
@@ -592,6 +612,9 @@ class ProjectMapperApp(App):
             mapping.dest_name = mapping.source_name
             mapping.dest_id = None
             mapping.dest_label = mapping.source_name
+            if self.return_ids:
+                mapping.status = MappingStatus.UNMAPPED
+                return
         mapping.status = self._status_for_same_name(mapping.source_name)
 
     def _refresh_and_stats(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.75"
+version = "0.0.76"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -2690,6 +2690,154 @@ def test_charts_blocks_once_when_all_chart_project_dependencies_are_unmapped(
     assert item.metadata["unmapped_dependency_ids"] == ["source-project-id"]
 
 
+def test_charts_map_projects_resolves_prior_chart_dependency_blocker(cli_harness):
+    """A successful remap should clear the stale chart-dependency checkpoint."""
+
+    source_project_id = "a3cee8e2-40bb-472e-8456-c660b5ea1f3d"
+    dest_project_id = "cc3ac580-destination-project"
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={},
+        workspaces_to_create=[],
+    )
+    cli_harness.migrators.chart.list_charts.return_value = [
+        {
+            "id": "chart-1",
+            "title": "Chart One",
+            "project_id": source_project_id,
+        }
+    ]
+    cli_harness.migrators.chart._extract_session_id.side_effect = lambda chart: chart.get(
+        "project_id"
+    )
+
+    first_result = cli_harness.invoke(
+        [
+            "--non-interactive",
+            "--source-key",
+            "shared-key",
+            "--dest-key",
+            "shared-key",
+            "--source-url",
+            "https://same.example",
+            "--dest-url",
+            "https://same.example/api/v1",
+            "charts",
+        ],
+        add_base_args=False,
+    )
+
+    assert first_result.exit_code == 2
+    state = cli_harness.orchestrator_factory.state
+    blocked_item = state.get_item("chart_dependency_src-ws_project_mappings")
+    assert blocked_item.terminal_state == ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value
+
+    cli_harness.controls.project_mapping_result = {source_project_id: dest_project_id}
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {
+            "id": source_project_id,
+            "name": "smoke-997-career-advisor-agent",
+            "tenant_id": "src-ws",
+        },
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {
+            "id": dest_project_id,
+            "name": "smoke-997-career-advisor-agent",
+            "tenant_id": "dst-ws",
+        },
+    ]
+    cli_harness.migrators.chart.migrate_all_charts.return_value = {
+        source_project_id: {"chart-1": "dest-chart-1"}
+    }
+
+    second_result = cli_harness.invoke(
+        [
+            "--non-interactive",
+            "--source-key",
+            "shared-key",
+            "--dest-key",
+            "shared-key",
+            "--source-url",
+            "https://same.example",
+            "--dest-url",
+            "https://same.example/api/v1",
+            "charts",
+            "--map-projects",
+        ],
+        add_base_args=False,
+    )
+
+    assert second_result.exit_code == 0
+    resolved_item = state.get_item("chart_dependency_src-ws_project_mappings")
+    assert resolved_item.terminal_state == ResolutionOutcome.MIGRATED.value
+    assert resolved_item.outcome_code == "chart_project_mapping_resolved"
+    assert state.get_terminal_counts()[ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value] == 0
+
+
+def test_charts_rejects_stale_state_mapping_to_missing_destination_project(cli_harness):
+    """Stored project mappings should not bypass validation if the destination ID vanished."""
+
+    source_project_id = "source-project-id"
+    stale_dest_project_id = "deleted-dest-project"
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={},
+        workspaces_to_create=[],
+    )
+    cli_harness.orchestrator_factory.state.set_mapped_id(
+        "project",
+        source_project_id,
+        stale_dest_project_id,
+    )
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {
+            "id": source_project_id,
+            "name": "Source Project",
+            "tenant_id": "src-ws",
+        },
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {
+            "id": "different-destination-project",
+            "name": "Different Project",
+            "tenant_id": "dst-ws",
+        },
+    ]
+    cli_harness.migrators.chart.list_charts.return_value = [
+        {
+            "id": "chart-1",
+            "title": "Chart One",
+            "project_id": source_project_id,
+        }
+    ]
+    cli_harness.migrators.chart._extract_session_id.side_effect = lambda chart: chart.get(
+        "project_id"
+    )
+
+    result = cli_harness.invoke(
+        [
+            "--non-interactive",
+            "--source-key",
+            "shared-key",
+            "--dest-key",
+            "shared-key",
+            "--source-url",
+            "https://same.example",
+            "--dest-url",
+            "https://same.example/api/v1",
+            "charts",
+        ],
+        add_base_args=False,
+    )
+
+    assert result.exit_code == 2
+    cli_harness.migrators.chart.migrate_all_charts.assert_not_called()
+    assert "Unmapped source project IDs: source-p" in cli_harness.console.text
+
+
 def test_charts_map_projects_resolves_nested_session_filters_for_resume_metadata(
     cli_harness,
 ):

--- a/tests/test_tui_project_mapper.py
+++ b/tests/test_tui_project_mapper.py
@@ -1,6 +1,71 @@
-"""Unit tests for the project mapping TUI model."""
+"""Tests for the standalone project mapper TUI helpers."""
 
-from langsmith_migrator.cli.tui_project_mapper import ProjectMapperApp
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from langsmith_migrator.cli.tui_project_mapper import (
+    DestinationPickerScreen,
+    MappingStatus,
+    ProjectMapperApp,
+)
+
+
+def test_destination_picker_enter_uses_only_matching_suggestion_label(monkeypatch):
+    """Pressing Enter in the input should select the single visible ID-bearing row."""
+
+    destination_label = (
+        "smoke-997-career-advisor-agent (cc3ac580) "
+        "· ws:12c99b9c-0753-4c51-a22e-828e24f9e908"
+    )
+    screen = DestinationPickerScreen(
+        "smoke-997-career-advisor-agent (a3cee8e2)",
+        [destination_label],
+        {},
+        initial_value="smoke-997-career-advisor-agent",
+    )
+    captured: list[str] = []
+    monkeypatch.setattr(screen, "dismiss", captured.append)
+
+    screen.on_input_submitted(SimpleNamespace(value="smoke-997-career-advisor-agent"))
+
+    assert captured == [destination_label]
+
+
+def test_destination_picker_enter_keeps_custom_value_when_no_suggestions(monkeypatch):
+    """No-match text remains a custom destination name for name-mapping callers."""
+
+    screen = DestinationPickerScreen(
+        "Source Project (src)",
+        ["Existing Project (dst)"],
+        {},
+        initial_value="New Project",
+    )
+    captured: list[str] = []
+    monkeypatch.setattr(screen, "dismiss", captured.append)
+
+    screen.on_input_submitted(SimpleNamespace(value="New Project"))
+
+    assert captured == ["New Project"]
+
+
+def test_id_mapper_does_not_count_unresolved_text_destination_as_mapped():
+    """ID-returning mapper rows need a destination ID before they count as mapped."""
+
+    app = ProjectMapperApp(
+        [{"id": "src-project", "name": "Shared Project"}],
+        [
+            {"id": "dst-project-a", "name": "Shared Project"},
+            {"id": "dst-project-b", "name": "Shared Project"},
+        ],
+        return_ids=True,
+    )
+    mapping = app.mappings[0]
+
+    app._set_destination(mapping, "Shared Project")
+
+    assert mapping.dest_id is None
+    assert mapping.status == MappingStatus.UNMAPPED
 
 
 def test_project_mapper_keeps_duplicate_source_project_ids_visible():

--- a/uv.lock
+++ b/uv.lock
@@ -1295,7 +1295,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.75"
+version = "0.0.76"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- fix the `--map-projects` destination picker so Enter on a unique suggestion returns the ID-bearing destination row, not just the typed name
- keep unresolved text destinations unmapped in ID-return mode, validate saved chart mappings against the active destination projects, and clear resolved chart-dependency blockers
- bump release metadata/docs to `0.0.76` with README and changelog notes

## Test Plan
- `uv lock --check`
- `uv run pytest tests/test_tui_project_mapper.py -q`
- `uv run pytest tests/functional/test_cli_functional.py -q -k 'charts'`
- `uv run --extra test ruff check langsmith_migrator/cli/main.py langsmith_migrator/cli/tui_project_mapper.py tests/test_tui_project_mapper.py tests/functional/test_cli_functional.py`
- `uv run pytest -q`
- `uv build`
- `python3 .github/scripts/check_wheel_contents.py dist/langsmith_data_migration_tool-0.0.76-py3-none-any.whl`
- `uv run --with ./dist/langsmith_data_migration_tool-0.0.76-py3-none-any.whl langsmith-migrator --help`