### PR TITLE
feat: add headless --project-mapping to charts and migrate-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Headless chart project mapping (`charts --project-mapping`)**: The `charts`
+  command now accepts an explicit source->destination project ID mapping as a
+  JSON string or file path, mirroring the existing `rules --project-mapping`
+  flag. This runs the mapping with no interactive TUI, so chart migration can be
+  driven from a backend/CI onboarding job. Mutually exclusive with
+  `--map-projects`.
+- **`migrate-all --project-mapping`**: The same headless JSON/file mapping is now
+  available on `migrate-all`, feeding both rules and charts, so an entire
+  migration can run non-interactively. Mutually exclusive with `--map-projects`.
+
 ## [0.0.77] - 2026-06-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,11 @@ uv run langsmith-migrator rules --map-projects                      # Interactiv
 uv run langsmith-migrator rules --create-enabled                    # Create rules enabled
 uv run langsmith-migrator charts       # Migrate charts
 uv run langsmith-migrator charts --map-projects                     # Charts with interactive project mapping
+uv run langsmith-migrator charts --project-mapping '{"old": "new"}' # Charts with headless project ID mapping (no TUI)
 uv run langsmith-migrator charts --same-instance                    # Reuse source session IDs
 uv run langsmith-migrator migrate-all  # Migrate everything
 uv run langsmith-migrator migrate-all --map-projects                # Migrate all with interactive project mapping
+uv run langsmith-migrator migrate-all --project-mapping '{"old": "new"}'  # Migrate all with headless project ID mapping (no TUI)
 uv run langsmith-migrator migrate-all --rules-create-enabled        # Create migrated rules enabled
 uv run langsmith-migrator resume       # Resume interrupted dataset migration
 uv run langsmith-migrator list-projects # List available projects

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ langsmith-migrator rules --create-enabled      # Create rules enabled (default: 
 langsmith-migrator charts
 langsmith-migrator charts --session "project-name"
 langsmith-migrator charts --map-projects        # Interactive TUI project mapping
+langsmith-migrator charts --project-mapping '{"old-project-id": "new-project-id"}'  # Headless, no TUI
+langsmith-migrator charts --project-mapping mapping.json   # Headless, from file
 langsmith-migrator charts --same-instance       # Reuse source IDs only when both sides share IDs
 
 # Utilities
@@ -360,6 +362,7 @@ The prompt default is `No` (rules are created disabled).
 --include-all-commits   Include all prompt commit history
 --strip-projects        Strip project associations from rules
 --map-projects          Launch interactive TUI to map source projects to destination projects
+--project-mapping TEXT  JSON string or file path with project ID mapping (headless, no TUI; mutually exclusive with --map-projects)
 --rules-create-enabled  Create migrated rules as enabled instead of asking interactively
 ```
 
@@ -368,6 +371,7 @@ The prompt default is `No` (rules are created disabled).
 ```bash
 --session TEXT          Migrate charts for a specific session/project (by name or ID)
 --map-projects          Launch interactive TUI to map source projects to destination projects
+--project-mapping TEXT  JSON string or file path with project ID mapping (headless, no TUI; mutually exclusive with --map-projects)
 --same-instance         Reuse source project/session IDs on destination only when both sides truly share IDs
 ```
 
@@ -424,10 +428,10 @@ When `--skip-users` is omitted, `migrate-all` runs user/role migration as Step 0
 Rules and charts reference projects by ID. When migrating between instances, project IDs differ.
 
 - **Interactive TUI (`--map-projects`)**: Launch a visual TUI to map source projects to destination projects. Available on `rules`, `charts`, and `migrate-all` commands. Select a source project and type a destination name directly — existing projects appear as filterable suggestions below the input, and pressing `Enter` on a unique suggestion records the destination project ID used by downstream chart/rule validation. Supports auto-match by name, skip, and custom name entry. For ID-based chart/rule remapping, unresolved text entries remain unmapped instead of being counted as resolved.
-- **Rules (`--project-mapping`)**: Supply an explicit source→destination project ID mapping as JSON or a file path. Use `list-projects --source` and `list-projects --dest` to get IDs. The mapping is applied to both top-level project associations and project IDs embedded inside rule filters. Mutually exclusive with `--map-projects`.
+- **Headless mapping (`--project-mapping`)**: Available on `rules`, `charts`, and `migrate-all`. Supply an explicit source->destination project ID mapping as a JSON string or a file path (e.g. `'{"<source-project-id>": "<dest-project-id>"}'`). Use `list-projects --source` and `list-projects --dest` to get IDs. This runs the mapping with no interactive TUI, so the migration can be driven from a backend/CI onboarding job. For `rules`, the mapping is applied to both top-level project associations and project IDs embedded inside rule filters. Mutually exclusive with `--map-projects`.
 - **Rules queue targets**: When a rule references an annotation queue, the migrator first reuses any saved queue migration mapping, then falls back to an exact-name queue match in the destination workspace. If neither is safe, the rule is exported for remediation instead of being posted with the source queue ID.
 - **Charts**: Without `--map-projects`, project mapping is built automatically by matching project names between source and destination. When both sides point at the same deployment URL but use different API keys/workspaces, charts still remap project/session IDs; the tool does not treat that as `--same-instance`. Workspace-scoped `--map-projects` mappings are resolved against the active workspace pair so duplicate project names in other workspaces are ignored. Chart dependency validation also verifies that saved destination project IDs still exist before migration. Chart filters are normalized to the destination API's `session`/`session_id` project-scoping shape before create or update.
-- **`migrate-all`**: Supports `--strip-projects`, `--map-projects`, and `--rules-create-enabled` for rules. Use the standalone `rules` command for `--project-mapping` JSON mappings.
+- **`migrate-all`**: Supports `--strip-projects`, `--map-projects`, `--project-mapping` (headless JSON/file mapping applied to both rules and charts), and `--rules-create-enabled` for rules.
 
 ### Interactive Selection
 

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -3210,9 +3210,15 @@ def rules(
             orchestrator.source_client, orchestrator.dest_client, None, config
         )
 
-        ws_project_id_map = _workspace_scoped_project_id_map(orchestrator, ws_result, src_ws)
-        if ws_project_id_map:
-            rules_migrator._project_id_map = ws_project_id_map
+        ws_project_id_map = None
+        # Apply headless project mapping (no TUI) when provided via --project-mapping.
+        # Explicit CLI mappings take precedence over workspace/TUI mappings.
+        if custom_mapping is not None:
+            rules_migrator._project_id_map = dict(custom_mapping)
+        else:
+            ws_project_id_map = _workspace_scoped_project_id_map(orchestrator, ws_result, src_ws)
+            if ws_project_id_map:
+                rules_migrator._project_id_map = ws_project_id_map
 
         # Launch interactive TUI project mapper (inside loop for workspace-scoped projects)
         if map_projects and not ws_project_id_map:
@@ -3237,10 +3243,6 @@ def rules(
             )
             rules_migrator._project_id_map = id_map
             console.print(f"Using interactive project mapping with {len(id_map)} project(s)")
-
-        # Apply custom project mapping if provided
-        if custom_mapping:
-            rules_migrator._project_id_map = custom_mapping
 
         console.print("Fetching rules... ", end="")
         rules = rules_migrator.list_rules()
@@ -3674,7 +3676,7 @@ def _migrate_all_for_workspace(
     source_projects_for_mapping = []
     dest_projects_for_mapping = []
     project_name_mapping = None
-    if custom_project_mapping:
+    if custom_project_mapping is not None:
         # Headless mapping supplied via --project-mapping: apply directly, no TUI.
         project_id_map = dict(custom_project_mapping)
         _persist_project_id_map(orchestrator, config, project_id_map)
@@ -4345,20 +4347,23 @@ def charts(
         dest_projects_for_mapping = []
         project_name_mapping = None
 
-        ws_project_id_map = _workspace_scoped_project_id_map(orchestrator, ws_result, src_ws)
-        if ws_project_id_map:
-            chart_migrator._project_id_map = ws_project_id_map
-            _persist_project_id_map(orchestrator, config, ws_project_id_map)
-            if ws_result and src_ws:
-                project_name_mapping = ws_result.project_mappings.get(src_ws)
-
-        # Apply headless project mapping (no TUI) when provided via --project-mapping
-        if custom_mapping and not ws_project_id_map:
+        ws_project_id_map = None
+        # Apply headless project mapping (no TUI) when provided via --project-mapping.
+        # Explicit CLI mappings take precedence over workspace/TUI mappings.
+        if custom_mapping is not None:
             chart_migrator._project_id_map = dict(custom_mapping)
             _persist_project_id_map(orchestrator, config, custom_mapping)
             console.print(
                 f"Using custom project mapping with {len(custom_mapping)} source ID mapping(s)"
             )
+        else:
+            ws_project_id_map = _workspace_scoped_project_id_map(orchestrator, ws_result, src_ws)
+
+        if ws_project_id_map:
+            chart_migrator._project_id_map = ws_project_id_map
+            _persist_project_id_map(orchestrator, config, ws_project_id_map)
+            if ws_result and src_ws:
+                project_name_mapping = ws_result.project_mappings.get(src_ws)
 
         # Launch interactive TUI project mapper (inside loop for workspace-scoped projects)
         if map_projects and not ws_project_id_map:

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -272,6 +272,52 @@ def _persist_project_id_map(orchestrator, config, project_id_map: dict | None) -
     orchestrator.state_manager.save()
 
 
+# Sentinel returned by _load_project_mapping_arg when parsing/validation fails
+# (the error has already been printed). Distinct from None, which means "no
+# --project-mapping was supplied".
+_PROJECT_MAPPING_ERROR = object()
+
+
+def _load_project_mapping_arg(project_mapping: str | None):
+    """Parse a ``--project-mapping`` value into a source->destination ID dict.
+
+    Accepts either an inline JSON object string or a path to a JSON file, e.g.
+    ``'{"<source-project-id>": "<dest-project-id>"}'`` or ``./mapping.json``.
+
+    Returns the parsed dict on success, ``None`` when no mapping was supplied,
+    or ``_PROJECT_MAPPING_ERROR`` when parsing/validation failed (an error
+    message is printed before returning the sentinel). This enables fully
+    headless (non-interactive) project mapping for backend/CI migration jobs.
+    """
+    if not project_mapping:
+        return None
+
+    import json
+    import os
+
+    try:
+        if os.path.isfile(project_mapping):
+            with open(project_mapping, "r") as f:
+                custom_mapping = json.load(f)
+            console.print(f"Loaded project mapping from file: {project_mapping}")
+        else:
+            custom_mapping = json.loads(project_mapping)
+
+        if not isinstance(custom_mapping, dict):
+            console.print("[red]Error: Project mapping must be a JSON object/dict[/red]")
+            return _PROJECT_MAPPING_ERROR
+
+        console.print(f"Using custom project mapping with {len(custom_mapping)} project(s)")
+        return custom_mapping
+
+    except json.JSONDecodeError as e:
+        console.print(f"[red]Error parsing project mapping JSON: {e}[/red]")
+        return _PROJECT_MAPPING_ERROR
+    except Exception as e:
+        console.print(f"[red]Error loading project mapping: {e}[/red]")
+        return _PROJECT_MAPPING_ERROR
+
+
 def _ensure_chart_dependency_project_records(
     orchestrator,
     source_projects: list,
@@ -3148,31 +3194,10 @@ def rules(
         return
 
     # Parse custom project mapping once (outside loop, not workspace-scoped)
-    custom_mapping = None
-    if project_mapping:
-        import json
-        import os
-
-        try:
-            if os.path.isfile(project_mapping):
-                with open(project_mapping, "r") as f:
-                    custom_mapping = json.load(f)
-                console.print(f"Loaded project mapping from file: {project_mapping}")
-            else:
-                custom_mapping = json.loads(project_mapping)
-
-            if not isinstance(custom_mapping, dict):
-                console.print("[red]Error: Project mapping must be a JSON object/dict[/red]")
-                return
-
-            console.print(f"Using custom project mapping with {len(custom_mapping)} project(s)")
-
-        except json.JSONDecodeError as e:
-            console.print(f"[red]Error parsing project mapping JSON: {e}[/red]")
-            return
-        except Exception as e:
-            console.print(f"[red]Error loading project mapping: {e}[/red]")
-            return
+    custom_mapping = _load_project_mapping_arg(project_mapping)
+    if custom_mapping is _PROJECT_MAPPING_ERROR:
+        orchestrator.cleanup()
+        return
 
     for src_ws, dst_ws in ws_pairs:
         if src_ws and dst_ws:
@@ -3414,6 +3439,15 @@ def rules(
     help="Launch interactive TUI to map source projects to destination projects",
 )
 @click.option(
+    "--project-mapping",
+    type=str,
+    help=(
+        "JSON string or file path with source->destination project ID mapping "
+        '(e.g., \'{"<source-project-id>": "<dest-project-id>"}\'). Runs project '
+        "mapping headlessly with no TUI. Mutually exclusive with --map-projects."
+    ),
+)
+@click.option(
     "--rules-create-enabled",
     "rules_create_enabled",
     flag_value=True,
@@ -3434,6 +3468,7 @@ def migrate_all(
     include_all_commits,
     strip_projects,
     map_projects,
+    project_mapping,
     rules_create_enabled,
     source_workspace,
     dest_workspace,
@@ -3476,6 +3511,20 @@ def migrate_all(
         return
     if ws_result is _WS_CANCELLED:
         console.print("[yellow]Cancelled[/yellow]")
+        orchestrator.cleanup()
+        return
+
+    # --map-projects (TUI) and --project-mapping (headless JSON) are mutually exclusive
+    if map_projects and project_mapping:
+        console.print(
+            "[red]Error: --map-projects and --project-mapping are mutually exclusive[/red]"
+        )
+        orchestrator.cleanup()
+        return
+
+    # Parse headless project mapping once (shared across all workspace pairs)
+    custom_project_mapping = _load_project_mapping_arg(project_mapping)
+    if custom_project_mapping is _PROJECT_MAPPING_ERROR:
         orchestrator.cleanup()
         return
 
@@ -3577,6 +3626,7 @@ def migrate_all(
             ws_project_mapping,
             src_ws,
             dst_ws,
+            custom_project_mapping,
         )
 
     if ws_result:
@@ -3605,6 +3655,7 @@ def _migrate_all_for_workspace(
     ws_project_mapping=None,
     source_workspace_id=None,
     dest_workspace_id=None,
+    custom_project_mapping=None,
 ):
     """Run the full migrate_all flow for a single workspace pair (or no workspace).
 
@@ -3613,6 +3664,9 @@ def _migrate_all_for_workspace(
             (default prompt answer is No, i.e. rules disabled).
         ws_project_mapping: Optional name-based project mapping from workspace TUI.
             If provided, --map-projects is skipped (already done at workspace level).
+        custom_project_mapping: Optional explicit source->destination project ID dict
+            from the headless --project-mapping flag. If provided, the interactive
+            mapping flows are skipped entirely.
     """
 
     # Launch interactive TUI project mapper if requested (and not already done at workspace level)
@@ -3620,7 +3674,15 @@ def _migrate_all_for_workspace(
     source_projects_for_mapping = []
     dest_projects_for_mapping = []
     project_name_mapping = None
-    if ws_project_mapping:
+    if custom_project_mapping:
+        # Headless mapping supplied via --project-mapping: apply directly, no TUI.
+        project_id_map = dict(custom_project_mapping)
+        _persist_project_id_map(orchestrator, config, project_id_map)
+        console.print(
+            "Using custom project mapping with "
+            f"{len(project_id_map)} source ID mapping(s)\n"
+        )
+    elif ws_project_mapping:
         project_name_mapping = ws_project_mapping
         # Convert the name mapping from the workspace TUI to an ID mapping
         console.print("Fetching projects for project mapping... ", end="")
@@ -4185,10 +4247,26 @@ def _migrate_all_for_workspace(
     is_flag=True,
     help="Launch interactive TUI to map source projects to destination projects",
 )
+@click.option(
+    "--project-mapping",
+    type=str,
+    help=(
+        "JSON string or file path with source->destination project ID mapping "
+        '(e.g., \'{"<source-project-id>": "<dest-project-id>"}\'). Runs the '
+        "mapping headlessly with no TUI. Mutually exclusive with --map-projects."
+    ),
+)
 @workspace_options
 @click.pass_context
 def charts(
-    ctx, session, same_instance, map_projects, source_workspace, dest_workspace, map_workspaces
+    ctx,
+    session,
+    same_instance,
+    map_projects,
+    project_mapping,
+    source_workspace,
+    dest_workspace,
+    map_workspaces,
 ):
     """Migrate monitoring charts from sessions/projects."""
     config = ctx.obj["config"]
@@ -4231,6 +4309,20 @@ def charts(
 
     ws_pairs = list(ws_result.workspace_mapping.items()) if ws_result else [(None, None)]
 
+    # --map-projects (TUI) and --project-mapping (headless JSON) are mutually exclusive
+    if map_projects and project_mapping:
+        console.print(
+            "[red]Error: --map-projects and --project-mapping are mutually exclusive[/red]"
+        )
+        orchestrator.cleanup()
+        return
+
+    # Parse headless project mapping once (outside loop, not workspace-scoped)
+    custom_mapping = _load_project_mapping_arg(project_mapping)
+    if custom_mapping is _PROJECT_MAPPING_ERROR:
+        orchestrator.cleanup()
+        return
+
     for src_ws, dst_ws in ws_pairs:
         if src_ws and dst_ws:
             orchestrator.set_workspace_context(src_ws, dst_ws)
@@ -4259,6 +4351,14 @@ def charts(
             _persist_project_id_map(orchestrator, config, ws_project_id_map)
             if ws_result and src_ws:
                 project_name_mapping = ws_result.project_mappings.get(src_ws)
+
+        # Apply headless project mapping (no TUI) when provided via --project-mapping
+        if custom_mapping and not ws_project_id_map:
+            chart_migrator._project_id_map = dict(custom_mapping)
+            _persist_project_id_map(orchestrator, config, custom_mapping)
+            console.print(
+                f"Using custom project mapping with {len(custom_mapping)} source ID mapping(s)"
+            )
 
         # Launch interactive TUI project mapper (inside loop for workspace-scoped projects)
         if map_projects and not ws_project_id_map:

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -2467,6 +2467,90 @@ def test_charts_command_uses_workspace_project_mappings(cli_harness):
     assert "Using workspace-scoped project mapping" in cli_harness.console.text
 
 
+def test_charts_command_project_mapping_applies_headlessly(cli_harness):
+    """--project-mapping should apply an explicit ID map with no interactive TUI."""
+
+    cli_harness.migrators.chart.list_charts.return_value = [
+        {"id": "chart-1", "title": "Chart One", "session_id": "a3cee8e2"},
+    ]
+    cli_harness.migrators.chart.migrate_all_charts.return_value = {
+        "a3cee8e2": {"chart-1": "dest-chart-1"}
+    }
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(
+        ["charts", "--project-mapping", '{"a3cee8e2": "cc3ac580"}']
+    )
+
+    assert result.exit_code == 0
+    assert cli_harness.migrators.chart._project_id_map == {"a3cee8e2": "cc3ac580"}
+    assert "Using custom project mapping with 1 source ID mapping(s)" in cli_harness.console.text
+    # Headless: the interactive TUI project-fetch path must not run.
+    assert "Fetching projects from both instances" not in cli_harness.console.text
+    cli_harness.migrators.chart.migrate_all_charts.assert_called_once_with(same_instance=False)
+
+
+def test_charts_command_project_mapping_accepts_file_path(cli_harness, tmp_path):
+    """--project-mapping should also accept a path to a JSON file."""
+
+    mapping_file = tmp_path / "mapping.json"
+    mapping_file.write_text('{"a3cee8e2": "cc3ac580"}')
+    cli_harness.migrators.chart.migrate_all_charts.return_value = {}
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(["charts", "--project-mapping", str(mapping_file)])
+
+    assert result.exit_code == 0
+    assert cli_harness.migrators.chart._project_id_map == {"a3cee8e2": "cc3ac580"}
+    assert f"Loaded project mapping from file: {mapping_file}" in cli_harness.console.text
+
+
+def test_charts_command_rejects_map_projects_with_project_mapping(cli_harness):
+    """--map-projects and --project-mapping are mutually exclusive."""
+
+    result = cli_harness.invoke(
+        ["charts", "--map-projects", "--project-mapping", '{"a": "b"}']
+    )
+
+    assert result.exit_code == 0
+    assert "mutually exclusive" in cli_harness.console.text
+    cli_harness.migrators.chart.migrate_all_charts.assert_not_called()
+
+
+def test_charts_command_invalid_project_mapping_json_aborts(cli_harness):
+    """Malformed --project-mapping JSON should abort before migrating charts."""
+
+    result = cli_harness.invoke(["charts", "--project-mapping", "{not valid json"])
+
+    assert result.exit_code == 0
+    assert "Error parsing project mapping JSON" in cli_harness.console.text
+    cli_harness.migrators.chart.migrate_all_charts.assert_not_called()
+
+
+def test_migrate_all_project_mapping_applies_headlessly(cli_harness):
+    """migrate-all --project-mapping should feed the chart migrator without a TUI."""
+
+    cli_harness.controls.confirm_answers = [True, True, True]
+
+    result = cli_harness.invoke(
+        [
+            "migrate-all",
+            "--skip-users",
+            "--skip-datasets",
+            "--skip-prompts",
+            "--skip-queues",
+            "--skip-rules",
+            "--project-mapping",
+            '{"a3cee8e2": "cc3ac580"}',
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert "Using custom project mapping with 1 source ID mapping(s)" in cli_harness.console.text
+    assert cli_harness.migrators.chart._project_id_map == {"a3cee8e2": "cc3ac580"}
+    assert "Fetching projects from both instances" not in cli_harness.console.text
+
+
 def test_charts_command_workspace_project_mapping_filters_duplicate_project_names(cli_harness):
     """Workspace-scoped project mappings should resolve the project in the active pair."""
 

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -2172,6 +2172,33 @@ def test_rules_command_uses_workspace_project_mappings(cli_harness):
     assert "Using workspace-scoped project mapping" in cli_harness.console.text
 
 
+def test_rules_command_empty_project_mapping_overrides_workspace_project_mappings(cli_harness):
+    """rules --project-mapping {} should not fall back to workspace mappings."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={"src-ws": {"Source Project": "Destination Project"}},
+        workspaces_to_create=[],
+    )
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {"id": "source-project-id", "name": "Source Project"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {"id": "dest-project-id", "name": "Destination Project"},
+    ]
+    cli_harness.migrators.rules.list_rules.return_value = [
+        {"id": "rule-1", "display_name": "Rule One", "dataset_id": "dataset-1"},
+    ]
+    cli_harness.migrators.rules.create_rule.return_value = "dest-rule-1"
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(["rules", "--all", "--project-mapping", "{}"])
+
+    assert result.exit_code == 0
+    assert cli_harness.migrators.rules._project_id_map == {}
+    assert "Using workspace-scoped project mapping" not in cli_harness.console.text
+
+
 def test_migrate_all_runs_every_step_and_applies_workspace_project_mappings(cli_harness):
     """The all-in-one wizard should thread dataset and project mappings through later steps."""
 
@@ -2467,6 +2494,63 @@ def test_charts_command_uses_workspace_project_mappings(cli_harness):
     assert "Using workspace-scoped project mapping" in cli_harness.console.text
 
 
+def test_charts_command_project_mapping_overrides_workspace_project_mappings(cli_harness):
+    """Explicit --project-mapping should take precedence over workspace/TUI mappings."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={"src-ws": {"Workspace Source": "Workspace Destination"}},
+        workspaces_to_create=[],
+    )
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {"id": "workspace-source-id", "name": "Workspace Source"},
+        {"id": "explicit-source-id", "name": "Explicit Source"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {"id": "workspace-dest-id", "name": "Workspace Destination"},
+        {"id": "explicit-dest-id", "name": "Explicit Destination"},
+    ]
+    cli_harness.migrators.chart.list_charts.return_value = [
+        {"id": "chart-1", "title": "Chart One", "session_id": "explicit-source-id"},
+    ]
+    cli_harness.migrators.chart.migrate_all_charts.return_value = {
+        "explicit-source-id": {"chart-1": "dest-chart-1"}
+    }
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(
+        ["charts", "--project-mapping", '{"explicit-source-id": "explicit-dest-id"}']
+    )
+
+    assert result.exit_code == 0
+    assert cli_harness.migrators.chart._project_id_map == {
+        "explicit-source-id": "explicit-dest-id"
+    }
+
+
+def test_charts_command_empty_project_mapping_overrides_workspace_project_mappings(cli_harness):
+    """An explicitly supplied empty mapping should not fall back to workspace mappings."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={"src-ws": {"Workspace Source": "Workspace Destination"}},
+        workspaces_to_create=[],
+    )
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {"id": "workspace-source-id", "name": "Workspace Source"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {"id": "workspace-dest-id", "name": "Workspace Destination"},
+    ]
+
+    result = cli_harness.invoke(["charts", "--project-mapping", "{}"])
+
+    assert result.exit_code == 0
+    assert cli_harness.migrators.chart._project_id_map == {}
+    assert "Using custom project mapping with 0 source ID mapping(s)" in cli_harness.console.text
+    assert "Using workspace-scoped project mapping" not in cli_harness.console.text
+
+
 def test_charts_command_project_mapping_applies_headlessly(cli_harness):
     """--project-mapping should apply an explicit ID map with no interactive TUI."""
 
@@ -2549,6 +2633,44 @@ def test_migrate_all_project_mapping_applies_headlessly(cli_harness):
     assert "Using custom project mapping with 1 source ID mapping(s)" in cli_harness.console.text
     assert cli_harness.migrators.chart._project_id_map == {"a3cee8e2": "cc3ac580"}
     assert "Fetching projects from both instances" not in cli_harness.console.text
+
+
+def test_migrate_all_empty_project_mapping_overrides_workspace_project_mappings(cli_harness):
+    """migrate-all --project-mapping {} should not fall back to workspace mappings."""
+
+    cli_harness.controls.workspace_result = WorkspaceProjectResult(
+        workspace_mapping={"src-ws": "dst-ws"},
+        project_mappings={"src-ws": {"Workspace Source": "Workspace Destination"}},
+        workspaces_to_create=[],
+    )
+    cli_harness.orchestrator_factory.source_client.paginated_results = [
+        {"id": "workspace-source-id", "name": "Workspace Source"},
+    ]
+    cli_harness.orchestrator_factory.dest_client.paginated_results = [
+        {"id": "workspace-dest-id", "name": "Workspace Destination"},
+    ]
+    cli_harness.migrators.chart.list_charts.return_value = [
+        {"id": "chart-1", "title": "Chart One", "project_id": "workspace-source-id"},
+    ]
+    cli_harness.controls.confirm_answers = [True]
+
+    result = cli_harness.invoke(
+        [
+            "migrate-all",
+            "--skip-users",
+            "--skip-datasets",
+            "--skip-prompts",
+            "--skip-queues",
+            "--skip-rules",
+            "--project-mapping",
+            "{}",
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert "Using custom project mapping with 0 source ID mapping(s)" in cli_harness.console.text
+    assert "Using workspace-scoped project mapping" not in cli_harness.console.text
+    assert cli_harness.migrators.chart._project_id_map == {}
 
 
 def test_charts_command_workspace_project_mapping_filters_duplicate_project_names(cli_harness):


### PR DESCRIPTION
## Summary

The `charts` command previously only supported `--map-projects`, which always launches the interactive TUI and can't be scripted. This blocks running chart migration from a backend/CI onboarding job when source and destination project names differ between workspaces (e.g. one workspace per customer, projects named per environment/customer/agent).

This adds a headless **`--project-mapping`** flag (JSON string or file path) to **`charts`** and **`migrate-all`**, mirroring the existing `rules --project-mapping`. It applies an explicit source→destination project ID map with no TUI, so an entire migration can run non-interactively (`--non-interactive`).

## Changes

- `charts --project-mapping '{"<src-id>":"<dst-id>"}'` (or a file path) — applies the mapping directly, no TUI. Mutually exclusive with `--map-projects`.
- `migrate-all --project-mapping ...` — same headless mapping, feeding both rules and charts.
- Factored the JSON parse/validate logic into a shared `_load_project_mapping_arg` helper (also used by `rules`, no behavior change there).
- Functional tests: headless apply path, file-path input, mutual-exclusivity error, invalid JSON abort, and `migrate-all` pass-through.
- README / CLAUDE docs + CHANGELOG (under Unreleased).

## Testing

- `uv run pytest` — **412 passed**
- `ruff check` — clean
- End-to-end verified against real LangSmith (same instance, two workspaces, differing project names): `charts --non-interactive --project-mapping '{...}'` migrates the chart to the mapped destination project with no interactive input.