### PR TITLE
fix: send bounded end_time in chart discovery reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Chart discovery `422 end_time must be set`**: Chart read/list requests
+  (`POST /charts`) now send a bounded, non-null `end_time` (a 1-day window) in
+  all three discovery paths (`_list_charts`, `_build_dest_section_map`, and the
+  `_enrich_chart` fallback) instead of `end_time: None`. The server's list
+  endpoint runs its stats fan-out even for metadata-only (`omit_data`) reads,
+  and that path rejects a null `end_time` with a 422, which caused source chart
+  discovery to fail so that no charts were migrated. Sending a bounded window
+  keeps the request well under the server's data-point cap and lets discovery
+  succeed while the server-side fix is pending.
+
 ## [0.0.78] - 2026-06-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.79] - 2026-07-06
+
 ### Fixed
 - **Chart discovery `422 end_time must be set`**: Chart read/list requests
   (`POST /charts`) now send a bounded, non-null `end_time` (a 1-day window) in

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python CLI for migrating users and roles, datasets, experiments, annotation qu
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.78-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.79-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -59,20 +59,20 @@ The destination's `POST /runs/batch` endpoint rejects runs with timestamps outsi
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.78-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.79-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.78-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.79-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.78-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.79-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.78-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.79-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)

--- a/langsmith_migrator/__init__.py
+++ b/langsmith_migrator/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("langsmith-data-migration-tool")
 except PackageNotFoundError:
-    __version__ = "0.0.78"
+    __version__ = "0.0.79"

--- a/langsmith_migrator/core/migrators/chart.py
+++ b/langsmith_migrator/core/migrators/chart.py
@@ -195,14 +195,18 @@ class ChartMigrator(BaseMigrator):
             return chart
 
         try:
-            start_time = (
-                datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
-            ).isoformat()
+            now = datetime.datetime.now(datetime.UTC)
+            start_time = (now - datetime.timedelta(days=1)).isoformat()
+            # end_time must be non-null: the list-charts endpoint still runs its
+            # stats fan-out even with omit_data, and that path rejects a null
+            # end_time with 422 "end_time must be set". A bounded 1-day window at
+            # the 15-min stride is ~96 buckets, well under the server point cap.
+            end_time = now.isoformat()
             payload = {
                 "timezone": "UTC",
                 "omit_data": False,
                 "start_time": start_time,
-                "end_time": None,
+                "end_time": end_time,
                 "stride": {"days": 0, "hours": 0, "minutes": 15},
                 "after_index": None,
                 "tag_value_id": None,
@@ -596,17 +600,21 @@ class ChartMigrator(BaseMigrator):
     ) -> List[Dict[str, Any]]:
         """List charts from the requested instance using POST /api/v1/charts."""
         try:
-            # Prepare request body for listing charts according to schema
-            # Note: Some versions require start_time even if omit_data is True
-            start_time = (
-                datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
-            ).isoformat()
+            # Prepare request body for listing charts according to schema.
+            # We only want metadata (omit_data=True), but the list-charts
+            # endpoint still runs its stats fan-out and rejects a null end_time
+            # with 422 "end_time must be set", so we send a bounded window.
+            # A 1-day range at the 15-min stride is ~96 buckets, well under the
+            # server point cap.
+            now = datetime.datetime.now(datetime.UTC)
+            start_time = (now - datetime.timedelta(days=1)).isoformat()
+            end_time = now.isoformat()
 
             payload = {
                 "timezone": "UTC",
                 "omit_data": True,  # Only fetch metadata, not full data
                 "start_time": start_time,
-                "end_time": None,
+                "end_time": end_time,
                 "stride": {"days": 0, "hours": 0, "minutes": 15},
                 "after_index": None,
                 "tag_value_id": None,
@@ -768,14 +776,17 @@ class ChartMigrator(BaseMigrator):
         """Fetch destination charts/sections and build a name->id map."""
         self._dest_section_map = {}
         try:
-            # We use the same payload as list_charts but against destination
-            start_time = (
-                datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
-            ).isoformat()
+            # We use the same payload as list_charts but against destination.
+            # end_time must be non-null (see _list_charts): the endpoint runs
+            # its stats fan-out even with omit_data and 422s on a null end_time.
+            now = datetime.datetime.now(datetime.UTC)
+            start_time = (now - datetime.timedelta(days=1)).isoformat()
+            end_time = now.isoformat()
             payload = {
                 "timezone": "UTC",
                 "omit_data": True,
                 "start_time": start_time,
+                "end_time": end_time,
                 "stride": {"days": 0, "hours": 0, "minutes": 15},
             }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.78"
+version = "0.0.79"
 description = "A tool for migrating datasets, experiments, prompts, rules, and annotation queues between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_chart_migrator.py
+++ b/tests/test_chart_migrator.py
@@ -1,5 +1,6 @@
 """Unit tests for ChartMigrator."""
 
+import datetime
 from unittest.mock import Mock
 
 import pytest
@@ -13,6 +14,15 @@ def _mock_client() -> Mock:
     client.session = Mock()
     client.session.headers = {}
     return client
+
+
+def _charts_payload(client: Mock) -> dict:
+    """Return the request body from the client's POST /charts (list) call."""
+    for call in client.post.call_args_list:
+        args = call.args
+        if args and args[0] == "/charts":
+            return args[1]
+    raise AssertionError("expected a POST /charts call")
 
 
 def test_find_existing_chart_checks_destination_not_source(sample_config, migration_state):
@@ -1129,3 +1139,75 @@ def test_migrate_session_charts_forwards_same_instance(
         "dest-session",
         same_instance=True,
     )
+
+
+def _assert_bounded_window(payload: dict) -> None:
+    """Chart-read payloads must send a non-null, bounded time window.
+
+    Regression guard for Pylon 16029 / LSO-3080: the POST /charts list endpoint
+    runs its stats fan-out even with omit_data=True, and that path rejects a
+    null end_time with 422 "end_time must be set". Sending end_time=None (the
+    prior behavior) made source chart discovery fail so 0 charts migrated.
+    """
+    assert payload.get("end_time") is not None, "end_time must be sent (non-null)"
+    assert payload.get("start_time") is not None
+    start = datetime.datetime.fromisoformat(payload["start_time"])
+    end = datetime.datetime.fromisoformat(payload["end_time"])
+    assert start <= end, "start_time must not be after end_time"
+
+
+def test_list_charts_sends_bounded_end_time(sample_config, migration_state):
+    """_list_charts must send a non-null bounded end_time (metadata-only read)."""
+
+    source_client = _mock_client()
+    source_client.post.return_value = []
+
+    migrator = ChartMigrator(
+        source_client,
+        _mock_client(),
+        migration_state,
+        sample_config,
+    )
+    migrator._list_charts(source_client, side="source")
+
+    payload = _charts_payload(source_client)
+    assert payload["omit_data"] is True
+    _assert_bounded_window(payload)
+
+
+def test_build_dest_section_map_sends_bounded_end_time(sample_config, migration_state):
+    """_build_dest_section_map must send a non-null bounded end_time on destination."""
+
+    dest_client = _mock_client()
+    dest_client.post.return_value = {"sections": []}
+
+    migrator = ChartMigrator(
+        _mock_client(),
+        dest_client,
+        migration_state,
+        sample_config,
+    )
+    migrator._build_dest_section_map()
+
+    payload = _charts_payload(dest_client)
+    assert payload["omit_data"] is True
+    _assert_bounded_window(payload)
+
+
+def test_enrich_chart_sends_bounded_end_time(sample_config, migration_state):
+    """_enrich_chart's fallback source fetch must send a non-null bounded end_time."""
+
+    source_client = _mock_client()
+    source_client.post.return_value = []
+
+    migrator = ChartMigrator(
+        source_client,
+        _mock_client(),
+        migration_state,
+        sample_config,
+    )
+    # A chart with no series triggers the enrichment fetch.
+    migrator._enrich_chart({"id": "chart-1", "title": "Latency"})
+
+    payload = _charts_payload(source_client)
+    _assert_bounded_window(payload)

--- a/uv.lock
+++ b/uv.lock
@@ -1295,7 +1295,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.78"
+version = "0.0.79"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Description

Chart read/list requests (`POST /charts`) were sent with `end_time: None`. The
server's list endpoint runs its stats fan-out even for metadata-only
(`omit_data=True`) reads, and that path rejects a null `end_time` with
`422 "end_time must be set"`. As a result, **source chart discovery failed and
no charts were migrated** (`No charts found in source` → `Migrated: 0`), most
visibly when the migration ran headlessly (e.g. from a backend/Lambda
onboarding job).

This sends a bounded, non-null time window (`start_time = now - 1 day`,
`end_time = now`) in all three chart discovery paths:

- `_list_charts` (source + destination list/dedupe reads)
- `_build_dest_section_map` (destination section map)
- `_enrich_chart` (fallback source fetch)

The 1-day window at the existing 15-minute stride is ~96 buckets, well under the
server's data-point cap, so discovery succeeds. This is a client-side workaround
that unblocks migration while the underlying server-side fix (list endpoint
honoring `omit_data`) is pending; it stays correct after that fix ships, since
the server will simply ignore `end_time` for `omit_data` reads.

## Test Plan

- [x] `uv run pytest tests/test_chart_migrator.py` — 35 passed (3 new regression
  tests asserting each discovery path sends a non-null, bounded window)
- [x] Confirmed the new tests **fail** on the pre-fix payload (`end_time: None`)
- [x] Reproduced end-to-end against live SaaS via the CLI: unpatched →
  `422 end_time must be set` / 0 charts; patched → `Found N charts` /
  charts migrated (dry-run)