### PR TITLE
Add explicit permissions to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test (3.12)


### PR DESCRIPTION
## Summary
- add an explicit `permissions: contents: read` block to the test workflow
- resolves CodeQL alert #55 (`actions/missing-workflow-permissions`)

## Validation
- inspected the resulting workflow diff
- confirmed only `.github/workflows/test.yml` changed

## Notes
- Trivy alerts #51 and #52 for `pygments` are stale: `main` already has `pygments==2.20.0` in both `requirements.txt` and `uv.lock`.