### PR TITLE
Release v0.0.81: set CHANGELOG date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.81]
+## [0.0.81] - 2026-07-27
 
 ### Added
 - **Context Hub migration (`contexts`)**: New command to migrate Context Hub

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ langsmith-migrator clean
 - `rules`: migrate automation rules with project mapping controls
 - `charts`: migrate monitoring charts, either all sessions or one named session/project
 - `fleet`: migrate Fleet resources (agents, skills, MCP servers, integrations, auth providers, schedules, triggers, webhooks, usage limits, sandbox policies, secrets) with `--skip-*` flags for each resource type
+- `contexts`: migrate Context Hub agents and skills, replaying full commit history and tags by default (`--latest-only`, `--no-tags`, `--agents-only`, `--skills-only`, `--include-external`, `--same-instance`)
 - `users`: migrate users/roles between instances, or run single-instance CSV access sync
 - `export-users`: export active org and workspace members to a members CSV for import via `users --members-csv`
 - `resume`: retry resumable items from a prior session and show grouped manual blockers


### PR DESCRIPTION
## Summary

Sets the release date for the `0.0.81` section in `CHANGELOG.md` to `2026-07-27`, matching the dated-heading format used by prior releases (e.g. `## [0.0.80] - 2026-07-15`).

This is the release-prep commit for **v0.0.81**. The version is already set to `0.0.81` in `pyproject.toml` and `langsmith_migrator/__init__.py`, and the 0.0.81 CHANGELOG entry (Context Hub `contexts` migration) is already present.

## Test plan

- `uv run pytest -q` -> 544 passed
- `uv build` -> builds wheel + sdist for 0.0.81 successfully

After merge: tag `v0.0.81`, create the GitHub release, and upload the wheel + sdist per the release process in `CLAUDE.md`.
