### PR TITLE
feat(fleet): scope agent migration to specific or owned agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Selective Fleet agent migration (`fleet`)**: The `fleet` command could
+  previously migrate **all** agents in a workspace or **none**
+  (`--skip-agents`), with no way to target a subset. Two new options scope the
+  agents phase:
+  - **`--agent <name-or-id>`** (repeatable): migrate only the named agent(s),
+    matched against each source agent's name **or** ID, so the two forms can be
+    mixed in one invocation. Useful for relocating a handful of specific agents
+    into a team workspace without touching everyone else's.
+  - **`--agents-owned-only`**: restrict the listing to the Fleet `user`
+    audience (agents owned by or directly shared with the authenticated source
+    user), skipping workspace-shared agents owned by others. Without it, both
+    the `user` and `tenant` audiences are queried and merged with dedup by
+    agent ID.
+
+  `--skip-agents` is rejected when combined with either flag. Selectors that
+  match no source agent are reported as a warning under `--verbose`.
+  **Downstream cascade is automatic**: schedules, triggers, and usage limits
+  key off the agent map built in the agents phase, so they scope to the
+  selected agents with no extra flags. Default behavior with neither flag is
+  unchanged.
+
 ## [0.0.81] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ langsmith-migrator charts --same-instance       # Reuse source IDs only when bot
 langsmith-migrator fleet                        # Migrate all Fleet resources
 langsmith-migrator fleet --skip-agents          # Skip agent migration
 langsmith-migrator fleet --skip-skills --skip-mcp-servers  # Skip specific resources
+langsmith-migrator fleet --agent "My Agent" --agent agent-abc123  # Only these agents (by name or ID)
+langsmith-migrator fleet --agents-owned-only    # Only agents you own or are directly shared
 
 # Utilities
 langsmith-migrator export-users --source -o users.csv  # Export active members to a members CSV

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -4839,12 +4839,19 @@ def _migrate_fleet_for_workspace(
     skip_webhooks=False,
     skip_usage_limits=False,
     skip_sandbox_policies=False,
+    agents_selected=None,
+    agents_owned_only=False,
 ):
     """Run the Fleet migration flow for a single workspace pair.
 
     Resources are migrated in dependency order. ID mappings from earlier
     phases are stored in ``state.id_mappings`` and consumed by later
     phases for cross-reference remapping.
+
+    ``agents_selected`` (a set of agent names or IDs) and
+    ``agents_owned_only`` scope Phase 6 to a subset of source agents.
+    Because schedules, triggers, and usage limits key off the resulting
+    ``agent_id_map``, they automatically scope to the selected agents too.
     """
     _ensure_migration_session(orchestrator, config)
     state = orchestrator.state
@@ -5088,7 +5095,11 @@ def _migrate_fleet_for_workspace(
         agent_migrator = FleetAgentMigrator(
             orchestrator.source_client, orchestrator.dest_client, state, config
         )
-        agents = agent_migrator.list_agents()
+        audiences = ("user",) if agents_owned_only else ("user", "tenant")
+        agents = agent_migrator.list_agents(
+            audiences=audiences,
+            select=agents_selected or None,
+        )
         if agents:
             console.print(f"  Found {len(agents)} agent(s)")
             console.print("  Fetching destination model catalog... ", end="")
@@ -5260,6 +5271,26 @@ def _migrate_fleet_for_workspace(
 @click.option("--skip-webhooks", is_flag=True, help="Skip webhooks")
 @click.option("--skip-usage-limits", is_flag=True, help="Skip spend limits")
 @click.option("--skip-sandbox-policies", is_flag=True, help="Skip sandbox policies")
+@click.option(
+    "--agent",
+    "agents_selected",
+    multiple=True,
+    help=(
+        "Only migrate the agent(s) with this name or ID. Repeat the flag to "
+        "select several. When omitted, all agents in scope are migrated. "
+        "Schedules, triggers, and usage limits are scoped to the selected "
+        "agents automatically."
+    ),
+)
+@click.option(
+    "--agents-owned-only",
+    is_flag=True,
+    help=(
+        "Only migrate agents owned by or directly shared with the "
+        "authenticated source user (Fleet 'user' audience), skipping "
+        "workspace-shared agents owned by others."
+    ),
+)
 @workspace_options
 @click.pass_context
 def fleet(
@@ -5274,6 +5305,8 @@ def fleet(
     skip_webhooks,
     skip_usage_limits,
     skip_sandbox_policies,
+    agents_selected,
+    agents_owned_only,
     source_workspace,
     dest_workspace,
     map_workspaces,
@@ -5283,6 +5316,14 @@ def fleet(
     state_manager = ctx.obj["state_manager"]
 
     display_banner()
+
+    agents_selected = set(agents_selected)
+    if skip_agents and (agents_selected or agents_owned_only):
+        console.print(
+            "[red]Error: --skip-agents cannot be combined with --agent or "
+            "--agents-owned-only[/red]"
+        )
+        return
 
     if not ensure_config(config):
         return
@@ -5344,6 +5385,8 @@ def fleet(
             skip_webhooks=skip_webhooks,
             skip_usage_limits=skip_usage_limits,
             skip_sandbox_policies=skip_sandbox_policies,
+            agents_selected=agents_selected,
+            agents_owned_only=agents_owned_only,
         )
 
     if ws_result:

--- a/langsmith_migrator/core/migrators/fleet_agent.py
+++ b/langsmith_migrator/core/migrators/fleet_agent.py
@@ -1,6 +1,6 @@
 """Fleet agent migration logic."""
 
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Iterable, Optional
 import copy
 
 from .base import BaseMigrator
@@ -10,18 +10,33 @@ from ..api_client import NotFoundError
 class FleetAgentMigrator(BaseMigrator):
     """Handles migration of Fleet agents with cross-reference remapping."""
 
-    def list_agents(self) -> List[Dict[str, Any]]:
-        """List all agent summaries from the source workspace.
+    def list_agents(
+        self,
+        *,
+        audiences: Iterable[str] = ("user", "tenant"),
+        select: Optional[set] = None,
+    ) -> List[Dict[str, Any]]:
+        """List agent summaries from the source workspace.
 
         The Fleet API splits agent listing into two audiences: ``user``
         (owned + directly-shared, the default) and ``tenant``
         (workspace-shared). There is no single call that returns both,
         so we issue both and merge with dedup by agent ID.
+
+        Args:
+            audiences: Which Fleet audiences to query. Defaults to both
+                (``user`` and ``tenant``). Pass ``("user",)`` to restrict to
+                agents owned by or directly shared with the authenticated
+                user ("owned-only").
+            select: If provided, keep only agents whose ``id`` or ``name``
+                is in this set. Selectors that match nothing are logged as a
+                warning so typos surface instead of silently migrating
+                nothing.
         """
         agents: List[Dict[str, Any]] = []
         seen_ids: set = set()
 
-        for audience in ("user", "tenant"):
+        for audience in audiences:
             try:
                 for agent in self.source.get_cursor_paginated(
                     "/v1/fleet/agents", params={"audience": audience}
@@ -38,7 +53,40 @@ class FleetAgentMigrator(BaseMigrator):
             except Exception as e:
                 self.log(f"Failed to list Fleet agents (audience={audience}): {e}", "warning")
 
+        if select:
+            agents = self._filter_selected(agents, select)
+
         return agents
+
+    def _filter_selected(
+        self, agents: List[Dict[str, Any]], select: set
+    ) -> List[Dict[str, Any]]:
+        """Keep only agents whose id or name is in ``select``.
+
+        Warns about any selector value that matched no source agent, which
+        makes name typos visible rather than silently migrating nothing.
+        """
+        selected: List[Dict[str, Any]] = []
+        matched: set = set()
+        for agent in agents:
+            agent_id = agent.get("id")
+            name = agent.get("name")
+            if agent_id in select or name in select:
+                selected.append(agent)
+                if agent_id in select:
+                    matched.add(agent_id)
+                if name in select:
+                    matched.add(name)
+
+        unmatched = set(select) - matched
+        if unmatched:
+            self.log(
+                "No source agent matched selector(s): "
+                + ", ".join(sorted(unmatched)),
+                "warning",
+            )
+
+        return selected
 
     def list_dest_models(self) -> List[str]:
         """List available model IDs on the destination instance."""

--- a/tests/cli_fleet_test.py
+++ b/tests/cli_fleet_test.py
@@ -118,12 +118,23 @@ class _FakeFleetSkillMigrator:
 class _FakeFleetAgentMigrator:
     create_calls: list = []
     id_mappings_received: dict = {}
+    list_calls: list = []
+    catalog: list = [{"id": "agent-1", "name": "Test Agent"}]
 
     def __init__(self, source_client, dest_client, state, config):
         pass
 
-    def list_agents(self):
-        return [{"id": "agent-1", "name": "Test Agent"}]
+    def list_agents(self, *, audiences=("user", "tenant"), select=None):
+        _FakeFleetAgentMigrator.list_calls.append(
+            {"audiences": tuple(audiences), "select": set(select) if select else None}
+        )
+        agents = list(_FakeFleetAgentMigrator.catalog)
+        if select:
+            agents = [
+                a for a in agents
+                if a.get("id") in select or a.get("name") in select
+            ]
+        return agents
 
     def list_dest_models(self):
         return ["anthropic:claude-sonnet-4-6"]
@@ -330,6 +341,8 @@ def _reset_fake_calls():
     _FakeFleetSkillMigrator.create_calls = []
     _FakeFleetAgentMigrator.create_calls = []
     _FakeFleetAgentMigrator.id_mappings_received = {}
+    _FakeFleetAgentMigrator.list_calls = []
+    _FakeFleetAgentMigrator.catalog = [{"id": "agent-1", "name": "Test Agent"}]
     _FakeFleetScheduleMigrator.create_calls = []
     _FakeFleetTriggerMigrator.create_calls = []
     _FakeFleetWebhookMigrator.create_calls = []
@@ -642,3 +655,82 @@ def test_fleet_usage_limit_receives_agent_id_map():
     limit_id, agent_id_map = _FakeFleetUsageLimitMigrator.create_calls[0]
     assert limit_id == "limit-1"
     assert agent_id_map.get("agent-1") == "dest-agent-1"
+
+
+def test_fleet_agent_selection_migrates_only_selected():
+    """--agent selection should migrate only the chosen agent(s)."""
+    _reset_fake_calls()
+    _FakeFleetAgentMigrator.catalog = [
+        {"id": "agent-1", "name": "Test Agent"},
+        {"id": "agent-2", "name": "Other Agent"},
+    ]
+
+    with _patch_all():
+        cli_main._migrate_fleet_for_workspace(
+            orchestrator=_make_orchestrator(),
+            config=_make_config(),
+            skip_secrets=True,
+            skip_auth_providers=True,
+            skip_mcp_servers=True,
+            skip_skills=True,
+            skip_agents=False,
+            skip_schedules=True,
+            skip_triggers=True,
+            skip_webhooks=True,
+            skip_usage_limits=True,
+            skip_sandbox_policies=True,
+            agents_selected={"Test Agent"},
+        )
+
+    # Only the selected agent is created, even though two exist on the source.
+    assert _FakeFleetAgentMigrator.create_calls == ["agent-1"]
+    # The selection set is passed through to the migrator.
+    assert _FakeFleetAgentMigrator.list_calls[0]["select"] == {"Test Agent"}
+
+
+def test_fleet_agents_owned_only_restricts_audience():
+    """--agents-owned-only should query only the 'user' audience."""
+    _reset_fake_calls()
+
+    with _patch_all():
+        cli_main._migrate_fleet_for_workspace(
+            orchestrator=_make_orchestrator(),
+            config=_make_config(),
+            skip_secrets=True,
+            skip_auth_providers=True,
+            skip_mcp_servers=True,
+            skip_skills=True,
+            skip_agents=False,
+            skip_schedules=True,
+            skip_triggers=True,
+            skip_webhooks=True,
+            skip_usage_limits=True,
+            skip_sandbox_policies=True,
+            agents_owned_only=True,
+        )
+
+    assert _FakeFleetAgentMigrator.list_calls[0]["audiences"] == ("user",)
+
+
+def test_fleet_default_queries_both_audiences():
+    """Without owned-only, both 'user' and 'tenant' audiences are queried."""
+    _reset_fake_calls()
+
+    with _patch_all():
+        cli_main._migrate_fleet_for_workspace(
+            orchestrator=_make_orchestrator(),
+            config=_make_config(),
+            skip_secrets=True,
+            skip_auth_providers=True,
+            skip_mcp_servers=True,
+            skip_skills=True,
+            skip_agents=False,
+            skip_schedules=True,
+            skip_triggers=True,
+            skip_webhooks=True,
+            skip_usage_limits=True,
+            skip_sandbox_policies=True,
+        )
+
+    assert _FakeFleetAgentMigrator.list_calls[0]["audiences"] == ("user", "tenant")
+    assert _FakeFleetAgentMigrator.list_calls[0]["select"] is None

--- a/tests/test_fleet_agent_migrator.py
+++ b/tests/test_fleet_agent_migrator.py
@@ -80,6 +80,60 @@ class TestFleetAgentMigrator:
         assert len(result) == 1
         assert result[0]["id"] == "agent-1"
 
+    def test_list_agents_select_by_name(self, agent_migrator):
+        """select should keep only agents whose name matches."""
+        agent_migrator.source.get_cursor_paginated.side_effect = [
+            [{"id": "agent-1", "name": "Keep Me"}],
+            [{"id": "agent-2", "name": "Drop Me"}],
+        ]
+
+        result = agent_migrator.list_agents(select={"Keep Me"})
+
+        assert len(result) == 1
+        assert result[0]["id"] == "agent-1"
+
+    def test_list_agents_select_by_id(self, agent_migrator):
+        """select should keep only agents whose id matches."""
+        agent_migrator.source.get_cursor_paginated.side_effect = [
+            [{"id": "agent-1", "name": "Keep Me"}],
+            [{"id": "agent-2", "name": "Drop Me"}],
+        ]
+
+        result = agent_migrator.list_agents(select={"agent-2"})
+
+        assert len(result) == 1
+        assert result[0]["id"] == "agent-2"
+
+    def test_list_agents_owned_only_queries_user_audience(self, agent_migrator):
+        """Passing audiences=('user',) should issue exactly one list call."""
+        agent_migrator.source.get_cursor_paginated.side_effect = [
+            [{"id": "agent-1", "name": "Owned Agent"}],
+        ]
+
+        result = agent_migrator.list_agents(audiences=("user",))
+
+        assert len(result) == 1
+        assert agent_migrator.source.get_cursor_paginated.call_count == 1
+        called_params = agent_migrator.source.get_cursor_paginated.call_args.kwargs["params"]
+        assert called_params == {"audience": "user"}
+
+    def test_list_agents_unmatched_selector_warns(self, agent_migrator):
+        """A selector matching nothing should log a warning and return empty."""
+        agent_migrator.source.get_cursor_paginated.side_effect = [
+            [{"id": "agent-1", "name": "Keep Me"}],
+            [],
+        ]
+        agent_migrator.log = Mock()
+
+        result = agent_migrator.list_agents(select={"Nonexistent"})
+
+        assert result == []
+        warned = any(
+            "Nonexistent" in call.args[0]
+            for call in agent_migrator.log.call_args_list
+        )
+        assert warned
+
     def test_list_agents_user_audience_error(self, agent_migrator):
         """If user audience fails, tenant agents should still be returned."""
         from langsmith_migrator.core.api_client import NotFoundError


### PR DESCRIPTION
## Summary

The `fleet` command could previously migrate **all** agents in a workspace or **none** (`--skip-agents`) — there was no way to target a subset. This adds selective agent migration.

### New options on `langsmith-migrator fleet`
- **`--agent <name-or-id>`** (repeatable): migrate only the named agent(s), matched by name or ID. Selectors that match nothing are logged as a warning so typos surface instead of silently migrating nothing.
- **`--agents-owned-only`**: restrict to the Fleet `user` audience (agents owned by or directly shared with the authenticated user), skipping workspace-shared agents owned by others.

`--skip-agents` is now rejected when combined with either flag.

## Why
Teams frequently need to move a handful of specific agents between workspaces (e.g. relocating 4 agents from a shared workspace to a team workspace) without touching everyone else's agents. The all-or-nothing behavior made that impossible.

## Implementation
- `FleetAgentMigrator.list_agents` gains `audiences` and `select` parameters. Default behavior (both `user` + `tenant` audiences, no filter) is **unchanged**, so existing callers/flows are unaffected.
- The `fleet` command threads the selection into the agents phase.
- **Downstream cascade is automatic**: schedules, triggers, and usage limits key off the agent map built in the agents phase, so they naturally scope to the selected agents with no extra logic.

---
🤖 Generated with [Oz](https://app.warp.dev/conversation/39523675-b3a8-4757-bc01-bfea085e0406)
