### PR TITLE
Fix four defects that turn a flaky network into permanent failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   selected agents with no extra flags. Default behavior with neither flag is
   unchanged.
 
+- **`resume --retry-exhausted`**: Also retry items that have used up their retry
+  budget. Previously the only way to get such an item moving again was to edit
+  the session state JSON by hand.
+
+### Fixed
+These four defects compounded on a self-hosted migration where a WAF in front of
+both instances intermittently refused requests: ~2,700 items failed permanently,
+583 experiments were left empty on the destination without any error saying so,
+and the summary misattributed the whole thing to feedback replay.
+
+- **Proxy/WAF 403s are retried instead of killing the item**: LangSmith always
+  returns JSON error bodies, so a 401/403 whose body is **not** JSON came from an
+  intermediary (proxy, load balancer, WAF) that refused the request before it
+  reached LangSmith. Those now raise a new retryable `UpstreamRejectionError`
+  and go through the normal exponential backoff, and the error message says the
+  response did not come from LangSmith. Genuine LangSmith permission failures
+  still raise `AuthenticationError` and still fail fast in a single request, so
+  a misconfigured key is not slowed down. The borrowed response body is
+  sanitized (control characters and escape sequences stripped, whitespace
+  collapsed, truncated) before it reaches the console or on-disk state, since it
+  comes from a source outside our control.
+- **A failed source run query no longer reports success**: when
+  `POST /runs/query` against the source failed, `migrate_runs_streaming` logged
+  it and broke out of the loop, leaving the failed-run counter at zero. The
+  caller concluded the run stage had succeeded and advanced to feedback, so the
+  experiment was created on the destination **containing no runs** and the only
+  visible symptom was `feedback replay incomplete (0/N migrated)`. The failure
+  now records a `run_query_failed` issue and propagates, so the item is marked
+  failed with the real error. Per-page `run_cursor` checkpointing is unchanged,
+  so `resume` continues from where it stopped.
+- **One failed pass no longer exhausts an item's retry budget**:
+  `update_item_status` incremented `attempts` on *every* status change,
+  including `pending -> in_progress` and `-> completed`. A single failing pass
+  through an experiment burned four increments against a cap of three, making
+  the item permanently unresumable. `attempts` now counts failures only.
+- **Complete experiments are no longer reported as failed**: feedback replay
+  counted every record it fetched as "found" but did not count records a
+  previous pass had already replayed (which are skipped by fingerprint) as
+  migrated. A fully migrated experiment therefore reported `0/N` and was marked
+  failed on every subsequent run, and could never reach a verified state.
+  Already-replayed records now count toward completion, and `feedback_verified`
+  is set only when every record is accounted for. Genuine gaps (unmapped runs,
+  failed creates) still report, now with a breakdown of each cause.
+
 ## [0.0.81] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,8 @@ and the summary misattributed the whole thing to feedback replay.
   experiment was created on the destination **containing no runs** and the only
   visible symptom was `feedback replay incomplete (0/N migrated)`. The failure
   now records a `run_query_failed` issue and propagates, so the item is marked
-  failed with the real error. Per-page `run_cursor` checkpointing is unchanged,
-  so `resume` continues from where it stopped.
+  failed with the real error. A page cursor advances only after its buffered runs
+  are written; failed writes retain the current cursor for a safe replay.
 - **One failed pass no longer exhausts an item's retry budget**:
   `update_item_status` incremented `attempts` on *every* status change,
   including `pending -> in_progress` and `-> completed`. A single failing pass
@@ -70,8 +70,9 @@ and the summary misattributed the whole thing to feedback replay.
   migrated. A fully migrated experiment therefore reported `0/N` and was marked
   failed on every subsequent run, and could never reach a verified state.
   Already-replayed records now count toward completion, and `feedback_verified`
-  is set only when every record is accounted for. Genuine gaps (unmapped runs,
-  failed creates) still report, now with a breakdown of each cause.
+  is set only when every record is accounted for. Source feedback query failures
+  propagate instead of verifying an empty or partial inventory. Genuine gaps
+  (unmapped runs, failed creates) still report with a per-cause breakdown.
 
 ## [0.0.81] - 2026-07-27
 

--- a/README.md
+++ b/README.md
@@ -536,6 +536,14 @@ Every migration session persists state and writes a remediation bundle when ther
 - org members
 - workspace members
 
+Each item gets a budget of three failed attempts before `resume` stops picking it up automatically. Failures are what consume the budget, so an item that failed once still has two retries left. If an item does use up its budget and you want to try again anyway (for example once a network or permissions problem has been resolved), pass `--retry-exhausted`:
+
+```bash
+langsmith-migrator resume --retry-exhausted
+```
+
+Items that are *blocked* rather than failed (a missing dataset dependency, say) are not retried by `resume` at all, since retrying cannot resolve them. Those are listed separately under "Items requiring manual attention" along with the action needed.
+
 For chart items, `resume` revalidates saved `--same-instance` metadata against the current source/destination and workspace context. If the mode changed, it re-resolves the destination project/session before retrying; if that cannot be resolved safely, the item is checkpointed with guidance to rerun `charts` with project mapping. A later successful `charts --map-projects` run marks the prior chart dependency blocker resolved so `resume` does not keep looping on stale blocked state. Global or dataset-only charts that have no project/session dependency can resume with `dest_session_id=None`.
 
 Use `langsmith-migrator clean` to remove saved sessions once you no longer need their state or remediation bundles.

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -5612,8 +5612,13 @@ def contexts(
 
 @cli.command()
 @ssl_option
+@click.option(
+    "--retry-exhausted",
+    is_flag=True,
+    help="Also retry items that have used up their retry budget",
+)
 @click.pass_context
-def resume(ctx):
+def resume(ctx, retry_exhausted):
     """Resume a previous migration session (retry pending/failed items)."""
     config = ctx.obj["config"]
     state_manager = ctx.obj["state_manager"]
@@ -5659,7 +5664,11 @@ def resume(ctx):
         config.state_manager = state_manager
 
         # Get resumable items
-        resume_items = state.get_resume_items()
+        resume_items = state.get_resume_items(
+            max_attempts=None if retry_exhausted else 3
+        )
+        if retry_exhausted:
+            console.print("[dim]Including items that used up their retry budget[/dim]")
         actionable_groups = state.get_actionable_groups()
 
         console.print(f"\nResumable items: {len(resume_items)}")

--- a/langsmith_migrator/core/api_client.py
+++ b/langsmith_migrator/core/api_client.py
@@ -9,6 +9,7 @@ from rich.console import Console
 
 from ..utils.retry import (
     retry_on_failure,
+    retry_upstream_rejections,
     APIError,
     RateLimitError,
     AuthenticationError,
@@ -368,7 +369,8 @@ class EnhancedAPIClient:
         response = self.session.post(url, json=data, timeout=self.timeout)
         return self._handle_response(response, endpoint)
 
-    @retry_on_failure(max_retries=1)  # Reduce retries for PATCH - if it fails once, likely to keep failing
+    @retry_upstream_rejections(max_retries=3)
+    @retry_on_failure(max_retries=1)
     def patch(self, endpoint: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Make a PATCH request.
@@ -393,6 +395,7 @@ class EnhancedAPIClient:
         response = self.session.patch(url, json=data, timeout=15)
         return self._handle_response(response, endpoint)
 
+    @retry_upstream_rejections(max_retries=3)
     @retry_on_failure(max_retries=1)
     def delete(self, endpoint: str) -> Dict[str, Any]:
         """
@@ -415,6 +418,7 @@ class EnhancedAPIClient:
         response = self.session.delete(url, timeout=15)
         return self._handle_response(response, endpoint)
 
+    @retry_upstream_rejections(max_retries=3)
     @retry_on_failure(max_retries=1)
     def put(self, endpoint: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/langsmith_migrator/core/api_client.py
+++ b/langsmith_migrator/core/api_client.py
@@ -1,5 +1,6 @@
 """Simplified API client with improved separation of concerns."""
 
+import re
 import time
 import requests
 from typing import Dict, Any, Optional, List, Generator, Tuple
@@ -12,6 +13,7 @@ from ..utils.retry import (
     RateLimitError,
     AuthenticationError,
     ConflictError,
+    UpstreamRejectionError,
 )
 from ..utils.pagination import CursorPaginationHelper, PaginationHelper
 
@@ -19,6 +21,26 @@ from ..utils.pagination import CursorPaginationHelper, PaginationHelper
 class NotFoundError(APIError):
     """Resource not found error."""
     pass
+
+
+# C0/C1 control characters, which covers ANSI escape sequence introducers.
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
+
+def sanitize_upstream_text(text: Optional[str], limit: int = 200) -> str:
+    """Make an untrusted intermediary's response body safe to log and persist.
+
+    A body produced by a proxy or WAF is outside our control, and it lands both on
+    an ANSI-capable console and in on-disk session state and remediation bundles.
+    Strip control characters (so it cannot emit escape sequences), collapse
+    whitespace (HTML error pages are newline-heavy), and truncate.
+    """
+    if not text:
+        return "no response body"
+    cleaned = " ".join(_CONTROL_CHARS.sub("", text).split())
+    if not cleaned:
+        return "no response body"
+    return cleaned[:limit] + "..." if len(cleaned) > limit else cleaned
 
 
 @dataclass
@@ -189,6 +211,27 @@ class EnhancedAPIClient:
             except (ValueError, AttributeError):
                 return response.text[:500] if response.text else "No response body"
 
+        def body_is_json() -> bool:
+            try:
+                response.json()
+                return True
+            except (ValueError, AttributeError):
+                return False
+
+        # An auth-shaped status with a non-JSON body did not come from LangSmith,
+        # which always answers in JSON. Something in front of it refused the
+        # request, so treat it as retryable rather than as a bad API key.
+        if response.status_code in (401, 403) and not body_is_json():
+            self.error_count += 1
+            raise UpstreamRejectionError(
+                f"{response.status_code} for {endpoint} came from an intermediary, not from "
+                f"LangSmith (the response body was not JSON): "
+                f"{sanitize_upstream_text(response.text)}. A proxy, load balancer, or WAF in "
+                "front of LangSmith is refusing these requests. This is often transient.",
+                status_code=response.status_code,
+                request_info=request_info
+            )
+
         # 401 Unauthorized - invalid API key
         if response.status_code == 401:
             self.error_count += 1
@@ -269,8 +312,11 @@ class EnhancedAPIClient:
                 return {}
             return json_response
         except ValueError as e:
+            # Carry the status code so retry_on_failure can judge this. Without it
+            # the status check reads as falsy and even a 5xx becomes terminal.
             raise APIError(
                 f"Invalid JSON response from {endpoint}: {e}",
+                status_code=response.status_code,
                 request_info=request_info
             )
 

--- a/langsmith_migrator/core/migrators/experiment.py
+++ b/langsmith_migrator/core/migrators/experiment.py
@@ -409,8 +409,36 @@ class ExperimentMigrator(BaseMigrator):
                 try:
                     response = self.source.post("/runs/query", payload)
                 except Exception as e:
+                    # Do not swallow this. Breaking out leaves the failure counter at
+                    # zero, so the caller concludes the run stage succeeded and moves
+                    # on to feedback - producing an empty experiment on the destination
+                    # that gets reported as a feedback problem. Raise so the caller
+                    # marks the item failed with the real error. The per-page
+                    # run_cursor checkpoint above means resume picks up where we
+                    # stopped rather than re-walking the experiment.
                     self.log(f"Error querying runs for experiment {experiment_id}: {e}", "error")
-                    break
+                    if experiment_item:
+                        issue = self.record_issue(
+                            "transient",
+                            "run_query_failed",
+                            f"Could not query source runs for experiment {experiment_id}",
+                            item_id=experiment_item_id,
+                            next_action="Re-run `langsmith-migrator resume` to continue from the last cursor.",
+                            evidence={
+                                "error": str(e),
+                                "page": page_num,
+                                "cursor": payload.get("cursor"),
+                                "runs_migrated_before_failure": experiment_runs_created,
+                            },
+                        )
+                        if issue:
+                            self.queue_remediation(
+                                issue_id=issue.id,
+                                next_action=issue.next_action or "Retry the source run query.",
+                                item_id=experiment_item_id,
+                                command="langsmith-migrator resume",
+                            )
+                    raise
 
                 runs = response.get("runs", [])
 

--- a/langsmith_migrator/core/migrators/experiment.py
+++ b/langsmith_migrator/core/migrators/experiment.py
@@ -387,6 +387,57 @@ class ExperimentMigrator(BaseMigrator):
             experiment_runs_created = 0
             experiment_failed_runs = 0
 
+            def flush_batch() -> int:
+                nonlocal total_runs, total_failed
+                nonlocal experiment_runs_created, experiment_failed_runs
+
+                if not batch:
+                    return 0
+
+                created_mapping, failed_runs = self._create_runs_batch(batch)
+                total_runs += len(created_mapping)
+                total_failed += len(failed_runs)
+                experiment_runs_created += len(created_mapping)
+                experiment_failed_runs += len(failed_runs)
+
+                if created_mapping:
+                    run_id_mapping.update(created_mapping)
+                    if self.state:
+                        for old_id, new_id in created_mapping.items():
+                            self.state.set_mapped_id("run", old_id, new_id)
+                        self.persist_state()
+                    self.log(
+                        f"Created batch of {len(created_mapping)} runs (total: {total_runs})",
+                        "info",
+                    )
+
+                if failed_runs:
+                    failed_ids = {entry["source_run_id"] for entry in failed_runs}
+                    for failed_id in failed_ids:
+                        pending_run_mapping.pop(failed_id, None)
+                    self.log(f"Failed to create {len(failed_runs)} run(s) in batch", "error")
+                    if experiment_item:
+                        issue = self.record_issue(
+                            "transient",
+                            "run_batch_failed",
+                            f"Run batch creation failed for experiment {experiment_id}",
+                            item_id=experiment_item_id,
+                            next_action="Re-run `langsmith-migrator resume` to replay the failed runs.",
+                            evidence={"failed_runs": failed_runs[:10], "failed_count": len(failed_runs)},
+                        )
+                        if issue:
+                            self.queue_remediation(
+                                issue_id=issue.id,
+                                next_action=issue.next_action or "Resume experiment runs.",
+                                item_id=experiment_item_id,
+                                command="langsmith-migrator resume",
+                            )
+
+                for created_id in created_mapping:
+                    pending_run_mapping.pop(created_id, None)
+                batch.clear()
+                return len(failed_runs)
+
             self.log(f"Fetching runs for experiment {exp_idx}/{len(experiment_ids)}: {experiment_id}", "info")
 
             payload = {
@@ -455,6 +506,9 @@ class ExperimentMigrator(BaseMigrator):
                     if page_num == 1:
                         self.log(f"No runs found for experiment {experiment_id}", "info")
                     break
+
+                failures_before_page = experiment_failed_runs
+                current_cursor = payload.get("cursor")
 
                 for run in runs:
                     source_session_id = run.get("session_id")
@@ -542,110 +596,32 @@ class ExperimentMigrator(BaseMigrator):
 
                     batch.append(migrated_run)
 
-                    # Process batch
                     if len(batch) >= self.config.migration.batch_size:
-                        created_mapping, failed_runs = self._create_runs_batch(batch)
-                        total_runs += len(created_mapping)
-                        total_failed += len(failed_runs)
-                        experiment_runs_created += len(created_mapping)
-                        experiment_failed_runs += len(failed_runs)
-                        if created_mapping:
-                            run_id_mapping.update(created_mapping)
-                            if self.state:
-                                for old_id, new_id in created_mapping.items():
-                                    self.state.set_mapped_id("run", old_id, new_id)
-                                self.persist_state()
-                            self.log(
-                                f"Created batch of {len(created_mapping)} runs (total: {total_runs})",
-                                "info",
-                            )
-                        if failed_runs:
-                            failed_ids = {entry["source_run_id"] for entry in failed_runs}
-                            for failed_id in failed_ids:
-                                pending_run_mapping.pop(failed_id, None)
-                            self.log(f"Failed to create {len(failed_runs)} run(s) in batch", "error")
-                            if experiment_item:
-                                issue = self.record_issue(
-                                    "transient",
-                                    "run_batch_failed",
-                                    f"Run batch creation failed for experiment {experiment_id}",
-                                    item_id=experiment_item_id,
-                                    next_action="Re-run `langsmith-migrator resume` to replay the failed runs.",
-                                    evidence={"failed_runs": failed_runs[:10], "failed_count": len(failed_runs)},
-                                )
-                                if issue:
-                                    self.queue_remediation(
-                                        issue_id=issue.id,
-                                        next_action=issue.next_action or "Resume experiment runs.",
-                                        item_id=experiment_item_id,
-                                        command="langsmith-migrator resume",
-                                    )
-                        for created_id in created_mapping:
-                            pending_run_mapping.pop(created_id, None)
-                        batch.clear()
+                        flush_batch()
 
-                # Check for next page
+                flush_batch()
+                page_had_failures = experiment_failed_runs > failures_before_page
+
                 cursors = response.get("cursors")
                 next_cursor = cursors.get("next") if cursors else None
+                checkpoint_cursor = current_cursor if page_had_failures else next_cursor
 
                 if experiment_item:
                     self.checkpoint_item(
                         experiment_item_id,
                         stage="migrate_runs",
                         metadata={
-                            "run_cursor": next_cursor,
+                            "run_cursor": checkpoint_cursor,
                             "run_failures": experiment_failed_runs,
                             "runs_migrated": experiment_runs_created,
                         },
                     )
-                if not next_cursor:
+
+                if page_had_failures or not next_cursor:
                     break
 
                 payload["cursor"] = next_cursor
                 self.log(f"Fetching next page with cursor: {next_cursor}", "info")
-
-            if batch:
-                created_mapping, failed_runs = self._create_runs_batch(batch)
-                total_runs += len(created_mapping)
-                total_failed += len(failed_runs)
-                experiment_runs_created += len(created_mapping)
-                experiment_failed_runs += len(failed_runs)
-                if created_mapping:
-                    run_id_mapping.update(created_mapping)
-                    if self.state:
-                        for old_id, new_id in created_mapping.items():
-                            self.state.set_mapped_id("run", old_id, new_id)
-                        self.persist_state()
-                    self.log(f"Created final batch of {len(created_mapping)} runs", "info")
-                if failed_runs:
-                    self.log(f"Failed to create {len(failed_runs)} run(s) in final batch", "error")
-                    if experiment_item:
-                        issue = self.record_issue(
-                            "transient",
-                            "run_batch_failed",
-                            f"Final run batch creation failed for experiment {experiment_id}",
-                            item_id=experiment_item_id,
-                            next_action="Re-run `langsmith-migrator resume` to replay the failed runs.",
-                            evidence={"failed_runs": failed_runs[:10], "failed_count": len(failed_runs)},
-                        )
-                        if issue:
-                            self.queue_remediation(
-                                issue_id=issue.id,
-                                next_action=issue.next_action or "Resume experiment runs.",
-                                item_id=experiment_item_id,
-                                command="langsmith-migrator resume",
-                            )
-                if experiment_item:
-                    next_stage = "migrate_feedback" if experiment_failed_runs == 0 else "migrate_runs"
-                    self.checkpoint_item(
-                        experiment_item_id,
-                        stage=next_stage,
-                        metadata={
-                            "run_cursor": None,
-                            "run_failures": experiment_failed_runs,
-                            "runs_migrated": experiment_runs_created,
-                        },
-                    )
 
         self.log(f"Run migration complete: {total_runs} migrated, {total_skipped} skipped", "success")
         return total_runs, run_id_mapping, total_failed

--- a/langsmith_migrator/core/migrators/feedback.py
+++ b/langsmith_migrator/core/migrators/feedback.py
@@ -186,7 +186,13 @@ class FeedbackMigrator(BaseMigrator):
             run_id_mapping: Mapping of source run IDs to destination IDs
 
         Returns:
-            Tuple of (total_feedback_found, total_feedback_migrated)
+            Tuple of (total_feedback_found, total_feedback_accounted_for).
+
+            The second element counts every record now present on the destination,
+            which is the records created on this pass plus those a previous pass
+            already replayed. Callers compare the two to decide whether an
+            experiment's feedback is complete, so counting only this pass would
+            report an already-complete experiment as failed.
         """
         if not experiment_id_mapping:
             self.log("No experiments to migrate feedback for", "info")
@@ -213,14 +219,16 @@ class FeedbackMigrator(BaseMigrator):
 
             # Transform feedback for destination
             migrated_feedbacks = []
-            skipped = 0
+            unmapped_runs = 0
+            already_replayed = 0
 
             for fb in feedbacks:
                 fingerprint = self._feedback_fingerprint(source_exp_id, fb)
                 if self.state and self.state.get_mapped_id("feedback_fingerprint", fingerprint):
+                    already_replayed += 1
                     self.log(
                         f"Skipping feedback '{fb.get('key')}' - already replayed in a prior attempt",
-                        "warning",
+                        "info",
                     )
                     continue
 
@@ -235,7 +243,7 @@ class FeedbackMigrator(BaseMigrator):
                             f"Skipping feedback '{fb.get('key')}' - run {source_run_id} not in mapping",
                             "warning"
                         )
-                        skipped += 1
+                        unmapped_runs += 1
                         continue
                 else:
                     dest_run_id = None
@@ -261,53 +269,70 @@ class FeedbackMigrator(BaseMigrator):
                 migrated_fb["_fingerprint"] = fingerprint
                 migrated_feedbacks.append(migrated_fb)
 
-            if skipped > 0:
-                self.log(f"Skipped {skipped} feedback records due to unmapped runs", "warning")
+            if unmapped_runs > 0:
+                self.log(f"Skipped {unmapped_runs} feedback records due to unmapped runs", "warning")
+            if already_replayed > 0:
+                self.log(
+                    f"{already_replayed} feedback record(s) were already replayed on an earlier pass",
+                    "info",
+                )
 
             # Create feedback in destination
+            created = 0
+            created_feedbacks: List[Dict[str, Any]] = []
             if migrated_feedbacks:
                 created, created_feedbacks = self.create_feedback_batch(migrated_feedbacks)
-                total_migrated += created
                 self.log(
                     f"Migrated {created}/{len(migrated_feedbacks)} feedback for experiment {source_exp_id}",
                     "success"
                 )
-                if self.state:
-                    for migrated_fb in created_feedbacks:
-                        fingerprint = migrated_fb.get("_fingerprint")
-                        if fingerprint:
-                            self.state.set_mapped_id(
-                                "feedback_fingerprint", fingerprint, fingerprint
-                            )
-                    if created == len(migrated_feedbacks):
-                        self.checkpoint_item(
-                            experiment_item_id,
-                            stage="completed",
-                            metadata={
-                                "feedback_found": len(feedbacks),
-                                "feedback_migrated": created,
-                                "feedback_verified": True,
-                            },
+
+            # Records replayed on an earlier pass are already on the destination, so
+            # they count toward this experiment being complete. Counting only the
+            # records created on *this* pass makes a fully-migrated experiment look
+            # like a failure on every subsequent run, and one that can never recover.
+            accounted = created + already_replayed
+            total_migrated += accounted
+
+            if self.state:
+                for migrated_fb in created_feedbacks:
+                    fingerprint = migrated_fb.get("_fingerprint")
+                    if fingerprint:
+                        self.state.set_mapped_id(
+                            "feedback_fingerprint", fingerprint, fingerprint
                         )
-                    elif created < len(migrated_feedbacks):
-                        issue = self.record_issue(
-                            "transient",
-                            "feedback_partial_replay",
-                            f"Some feedback could not be replayed for experiment {source_exp_id}",
+                if accounted == len(feedbacks):
+                    self.checkpoint_item(
+                        experiment_item_id,
+                        stage="completed",
+                        metadata={
+                            "feedback_found": len(feedbacks),
+                            "feedback_migrated": accounted,
+                            "feedback_verified": True,
+                        },
+                    )
+                else:
+                    issue = self.record_issue(
+                        "transient",
+                        "feedback_partial_replay",
+                        f"Some feedback could not be replayed for experiment {source_exp_id}",
+                        item_id=experiment_item_id,
+                        next_action="Re-run `langsmith-migrator resume` to retry feedback creation.",
+                        evidence={
+                            "feedback_found": len(feedbacks),
+                            "feedback_migrated": accounted,
+                            "already_replayed": already_replayed,
+                            "unmapped_runs": unmapped_runs,
+                            "create_failures": len(migrated_feedbacks) - created,
+                        },
+                    )
+                    if issue:
+                        self.queue_remediation(
+                            issue_id=issue.id,
+                            next_action=issue.next_action or "Retry feedback replay.",
                             item_id=experiment_item_id,
-                            next_action="Re-run `langsmith-migrator resume` to retry feedback creation.",
-                            evidence={
-                                "feedback_found": len(feedbacks),
-                                "feedback_migrated": created,
-                            },
+                            command="langsmith-migrator resume",
                         )
-                        if issue:
-                            self.queue_remediation(
-                                issue_id=issue.id,
-                                next_action=issue.next_action or "Retry feedback replay.",
-                                item_id=experiment_item_id,
-                                command="langsmith-migrator resume",
-                            )
-                    self.persist_state()
+                self.persist_state()
 
         return total_found, total_migrated

--- a/langsmith_migrator/core/migrators/feedback.py
+++ b/langsmith_migrator/core/migrators/feedback.py
@@ -70,8 +70,8 @@ class FeedbackMigrator(BaseMigrator):
                 offset += limit
 
             except Exception as e:
-                self.log(f"Error fetching feedback for session {session_id}: {e}", "warning")
-                break
+                self.log(f"Error fetching feedback for session {session_id}: {e}", "error")
+                raise
 
         return all_feedback
 
@@ -120,8 +120,8 @@ class FeedbackMigrator(BaseMigrator):
                     offset += limit
 
                 except Exception as e:
-                    self.log(f"Error fetching feedback for runs: {e}", "warning")
-                    break
+                    self.log(f"Error fetching feedback for runs: {e}", "error")
+                    raise
 
         return all_feedback
 
@@ -207,8 +207,26 @@ class FeedbackMigrator(BaseMigrator):
             if self.state:
                 self.checkpoint_item(experiment_item_id, stage="migrate_feedback")
 
-            # Fetch feedback for this experiment session
-            feedbacks = self.list_feedback_for_session(source_exp_id)
+            try:
+                feedbacks = self.list_feedback_for_session(source_exp_id)
+            except Exception as e:
+                if self.state:
+                    issue = self.record_issue(
+                        "transient",
+                        "feedback_query_failed",
+                        f"Could not query source feedback for experiment {source_exp_id}",
+                        item_id=experiment_item_id,
+                        next_action="Re-run `langsmith-migrator resume` to retry the feedback query.",
+                        evidence={"error": str(e)},
+                    )
+                    if issue:
+                        self.queue_remediation(
+                            issue_id=issue.id,
+                            next_action=issue.next_action or "Retry the source feedback query.",
+                            item_id=experiment_item_id,
+                            command="langsmith-migrator resume",
+                        )
+                raise
 
             if not feedbacks:
                 self.log(f"No feedback found for experiment {source_exp_id}", "info")
@@ -304,11 +322,10 @@ class FeedbackMigrator(BaseMigrator):
                 if accounted == len(feedbacks):
                     self.checkpoint_item(
                         experiment_item_id,
-                        stage="completed",
+                        stage="migrate_feedback",
                         metadata={
                             "feedback_found": len(feedbacks),
                             "feedback_migrated": accounted,
-                            "feedback_verified": True,
                         },
                     )
                 else:

--- a/langsmith_migrator/core/migrators/orchestrator.py
+++ b/langsmith_migrator/core/migrators/orchestrator.py
@@ -500,6 +500,26 @@ class MigrationOrchestrator:
                 self.state_manager.save()
 
             current_item = self.state.get_item(item_id)
+            if (
+                current_item
+                and current_item.stage == "completed"
+                and current_item.metadata.get("feedback_verified")
+                and not current_item.terminal_state
+            ):
+                self.state.mark_terminal(
+                    item_id,
+                    ResolutionOutcome.MIGRATED,
+                    "experiment_migrated",
+                    verification_state=VerificationState.VERIFIED,
+                    evidence={
+                        "destination_experiment_id": dest_experiment_id,
+                        "feedback_found": current_item.metadata.get("feedback_found", 0),
+                        "feedback_migrated": current_item.metadata.get("feedback_migrated", 0),
+                    },
+                )
+                self.state_manager.save()
+                return True, "migrated"
+
             if current_item and (
                 current_item.stage in {"migrate_feedback", "completed"}
                 and not current_item.metadata.get("feedback_verified")

--- a/langsmith_migrator/core/migrators/orchestrator.py
+++ b/langsmith_migrator/core/migrators/orchestrator.py
@@ -500,6 +500,8 @@ class MigrationOrchestrator:
                 self.state_manager.save()
 
             current_item = self.state.get_item(item_id)
+            # Pre-fix feedback migration persisted completed+verified before the
+            # orchestrator persisted terminal_state. Repair those legacy sessions.
             if (
                 current_item
                 and current_item.stage == "completed"

--- a/langsmith_migrator/utils/retry.py
+++ b/langsmith_migrator/utils/retry.py
@@ -54,6 +54,20 @@ class ConflictError(APIError):
         super().__init__(message, 409, request_info)
 
 
+class UpstreamRejectionError(APIError):
+    """An auth-shaped rejection (401/403) that did not come from LangSmith.
+
+    LangSmith always returns JSON error bodies, so a non-JSON body on a 401/403
+    means an intermediary - a proxy, load balancer, or WAF - refused the request
+    before it reached LangSmith. Those rejections are frequently transient
+    (rate-based rules, a dropped VPN, a changed egress IP), so unlike
+    AuthenticationError this is retryable.
+    """
+
+    def __init__(self, message: str, status_code: int, request_info: dict = None):
+        super().__init__(message, status_code, request_info)
+
+
 def retry_on_failure(max_retries: int = 3, delay: float = 1.0, backoff: float = 2.0):
     """
     Decorator to retry failed API calls with exponential backoff.
@@ -84,6 +98,16 @@ def retry_on_failure(max_retries: int = 3, delay: float = 1.0, backoff: float = 
                         wait_time = min(current_delay * 2, MAX_BACKOFF_SECONDS)
                     time.sleep(wait_time)
                     current_delay = min(current_delay * backoff, MAX_BACKOFF_SECONDS)
+                except UpstreamRejectionError as e:
+                    # An intermediary refused this before LangSmith saw it. Often
+                    # transient, so retry rather than killing the caller's work item.
+                    # Must precede the APIError clause below, which would re-raise it.
+                    last_exception = e
+                    if attempt < max_retries - 1:
+                        wait_time = min(current_delay, MAX_BACKOFF_SECONDS)
+                        time.sleep(wait_time)
+                        current_delay = min(current_delay * backoff, MAX_BACKOFF_SECONDS)
+                    continue
                 except AuthenticationError:
                     # Never retry auth errors - they won't succeed without user intervention
                     raise

--- a/langsmith_migrator/utils/retry.py
+++ b/langsmith_migrator/utils/retry.py
@@ -68,6 +68,25 @@ class UpstreamRejectionError(APIError):
         super().__init__(message, status_code, request_info)
 
 
+def retry_upstream_rejections(max_retries: int = 3, delay: float = 1.0, backoff: float = 2.0):
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            current_delay = delay
+            for attempt in range(max_retries):
+                try:
+                    return func(*args, **kwargs)
+                except UpstreamRejectionError:
+                    if attempt >= max_retries - 1:
+                        raise
+                    time.sleep(min(current_delay, MAX_BACKOFF_SECONDS))
+                    current_delay = min(current_delay * backoff, MAX_BACKOFF_SECONDS)
+
+        return wrapper
+
+    return decorator
+
+
 def retry_on_failure(max_retries: int = 3, delay: float = 1.0, backoff: float = 2.0):
     """
     Decorator to retry failed API calls with exponential backoff.

--- a/langsmith_migrator/utils/state.py
+++ b/langsmith_migrator/utils/state.py
@@ -418,7 +418,12 @@ class MigrationState:
         item = self.items[item_id]
         item.status = status
         item.last_attempt = _now()
-        item.attempts += 1
+        # Count failures only. This is the budget `get_failed_items` gates resume
+        # on, and a single pass through an item can move it through several
+        # non-failure states (in_progress -> in_progress -> completed), which
+        # would exhaust the budget before the item had failed even once.
+        if status == MigrationStatus.FAILED:
+            item.attempts += 1
 
         if destination_id:
             item.destination_id = destination_id
@@ -521,16 +526,24 @@ class MigrationState:
                     items.append(item)
         return items
 
-    def get_failed_items(self, max_attempts: int = 3) -> List[MigrationItem]:
-        """Get failed items that haven't exceeded max attempts."""
+    def get_failed_items(self, max_attempts: Optional[int] = 3) -> List[MigrationItem]:
+        """Get failed items that haven't exceeded max attempts.
+
+        Pass max_attempts=None to include items that have used up their budget.
+        """
         items = []
         for item in self.items.values():
-            if item.status == MigrationStatus.FAILED and item.attempts < max_attempts:
+            if item.status != MigrationStatus.FAILED:
+                continue
+            if max_attempts is None or item.attempts < max_attempts:
                 items.append(item)
         return items
 
-    def get_resume_items(self, max_attempts: int = 3) -> List[MigrationItem]:
-        """Return items that should be reconsidered by resume."""
+    def get_resume_items(self, max_attempts: Optional[int] = 3) -> List[MigrationItem]:
+        """Return items that should be reconsidered by resume.
+
+        Pass max_attempts=None to also retry items that have used up their budget.
+        """
         items = self.get_pending_items(include_in_progress=True)
         items.extend(self.get_failed_items(max_attempts=max_attempts))
         return items

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -150,6 +150,52 @@ def test_html_bodied_403_is_an_upstream_rejection_and_is_retried(monkeypatch):
     assert post_mock.call_count == 3
 
 
+@pytest.mark.parametrize(
+    ("method_name", "payload"),
+    [
+        ("patch", {"name": "updated"}),
+        ("put", {"name": "updated"}),
+        ("delete", None),
+    ],
+)
+def test_idempotent_write_methods_retry_upstream_rejections(
+    monkeypatch,
+    method_name,
+    payload,
+):
+    client = _client()
+    endpoint = "/resources/resource-1"
+    url = f"https://langsmith.example.com/api/v1{endpoint}"
+    request_method = method_name.upper()
+    request_mock = Mock(
+        side_effect=[
+            _response(request_method, url, 403, text_body=EDGE_403_BODY),
+            _response(request_method, url, 204),
+        ]
+    )
+    monkeypatch.setattr(client.session, method_name, request_mock)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    if payload is None:
+        result = getattr(client, method_name)(endpoint)
+    else:
+        result = getattr(client, method_name)(endpoint, payload)
+
+    assert result == {}
+    assert request_mock.call_count == 2
+
+
+def test_patch_does_not_retry_ambiguous_network_failures(monkeypatch):
+    client = _client()
+    patch_mock = Mock(side_effect=requests.exceptions.ConnectionError("response lost"))
+    monkeypatch.setattr(client.session, "patch", patch_mock)
+
+    with pytest.raises(requests.exceptions.ConnectionError, match="response lost"):
+        client.patch("/resources/resource-1", {"name": "updated"})
+
+    assert patch_mock.call_count == 1
+
+
 def test_html_bodied_401_is_an_upstream_rejection(monkeypatch):
     client = _client()
     url = "https://langsmith.example.com/api/v1/sessions/abc"

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -12,8 +12,22 @@ from langsmith_migrator.core.api_client import (
     ConflictError,
     EnhancedAPIClient,
     NotFoundError,
+    sanitize_upstream_text,
 )
-from langsmith_migrator.utils.retry import APIError, AuthenticationError, RateLimitError
+from langsmith_migrator.utils.retry import (
+    APIError,
+    AuthenticationError,
+    RateLimitError,
+    UpstreamRejectionError,
+)
+
+# The verbatim body a Google Cloud Armor policy returned in front of a customer's
+# self-hosted LangSmith. LangSmith itself never answers in HTML.
+EDGE_403_BODY = (
+    '<!doctype html><meta charset="utf-8">'
+    '<meta name=viewport content="width=device-width, initial-scale=1">'
+    "<title>403</title>403 Forbidden"
+)
 
 
 def _response(
@@ -115,6 +129,99 @@ def test_get_translates_authentication_error_without_retry(monkeypatch):
         client.get("/orgs/current/members")
 
     assert get_mock.call_count == 1
+
+
+def test_html_bodied_403_is_an_upstream_rejection_and_is_retried(monkeypatch):
+    """A 403 whose body is not JSON came from a proxy/WAF, not from LangSmith."""
+    client = _client()
+    url = "https://langsmith.example.com/api/v1/sessions"
+    post_mock = Mock(
+        return_value=_response(
+            "POST", url, 403, text_body=EDGE_403_BODY, headers={"Content-Type": "text/html"}
+        )
+    )
+    monkeypatch.setattr(client.session, "post", post_mock)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    with pytest.raises(UpstreamRejectionError, match="came from an intermediary"):
+        client.post("/sessions", {"name": "experiment-1"})
+
+    # Retried rather than killing the caller's work item on the first refusal.
+    assert post_mock.call_count == 3
+
+
+def test_html_bodied_401_is_an_upstream_rejection(monkeypatch):
+    client = _client()
+    url = "https://langsmith.example.com/api/v1/sessions/abc"
+    get_mock = Mock(return_value=_response("GET", url, 401, text_body="<html>401</html>"))
+    monkeypatch.setattr(client.session, "get", get_mock)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    with pytest.raises(UpstreamRejectionError) as excinfo:
+        client.get("/sessions/abc")
+
+    assert excinfo.value.status_code == 401
+    assert get_mock.call_count == 3
+
+
+def test_json_bodied_403_stays_a_permission_error_without_retry(monkeypatch):
+    """A real LangSmith permission failure must still fail fast, in one request."""
+    client = _client()
+    url = "https://langsmith.example.com/api/v1/orgs/current/scim/tokens"
+    post_mock = Mock(
+        return_value=_response(
+            "POST",
+            url,
+            403,
+            json_body={"detail": "missing permission organization:manage"},
+        )
+    )
+    monkeypatch.setattr(client.session, "post", post_mock)
+
+    with pytest.raises(AuthenticationError, match="Access denied"):
+        client.post("/orgs/current/scim/tokens", {})
+
+    assert post_mock.call_count == 1
+
+
+def test_upstream_rejection_message_is_sanitized(monkeypatch):
+    """The borrowed body is untrusted, so it must not carry escape sequences through."""
+    client = _client()
+    url = "https://langsmith.example.com/api/v1/sessions"
+    hostile = "<html>\x1b[31mdenied\x1b[0m\n\n\tby   policy\x00</html>"
+    post_mock = Mock(return_value=_response("POST", url, 403, text_body=hostile))
+    monkeypatch.setattr(client.session, "post", post_mock)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    with pytest.raises(UpstreamRejectionError) as excinfo:
+        client.post("/sessions", {})
+
+    message = str(excinfo.value)
+    assert "\x1b" not in message
+    assert "\x00" not in message
+    assert "<html>[31mdenied[0m by policy</html>" in message
+
+
+def test_sanitize_upstream_text_truncates_and_handles_empty():
+    assert sanitize_upstream_text("") == "no response body"
+    assert sanitize_upstream_text(None) == "no response body"
+    assert sanitize_upstream_text("\x00\x01") == "no response body"
+    long_body = "a" * 500
+    sanitized = sanitize_upstream_text(long_body, limit=200)
+    assert sanitized == "a" * 200 + "..."
+
+
+def test_invalid_json_response_carries_status_code(monkeypatch):
+    """Without a status code the retry layer treats even a 5xx as terminal."""
+    client = _client()
+    url = "https://langsmith.example.com/api/v1/sessions"
+    get_mock = Mock(return_value=_response("GET", url, 200, text_body="not-json"))
+    monkeypatch.setattr(client.session, "get", get_mock)
+
+    with pytest.raises(APIError) as excinfo:
+        client.get("/sessions")
+
+    assert excinfo.value.status_code == 200
 
 
 def test_patch_uses_fixed_timeout_and_handles_no_content(monkeypatch):

--- a/tests/test_experiment_migrator.py
+++ b/tests/test_experiment_migrator.py
@@ -160,8 +160,8 @@ def _orchestrator(tmp_path: Path):
 
 
 class TestOrchestratorDeltaPersistence:
-    def test_resume_finalizes_a_verified_completed_checkpoint(self, tmp_path):
-        orchestrator, _ = _orchestrator(tmp_path)
+    def test_resume_repairs_legacy_verified_checkpoint_without_terminal_state(self, tmp_path):
+        orchestrator, state_manager = _orchestrator(tmp_path)
         state = orchestrator.ensure_state()
         item = state.ensure_item(
             "experiment_src-exp",
@@ -180,6 +180,15 @@ class TestOrchestratorDeltaPersistence:
             },
         )
         item.destination_id = "dest-exp"
+        item.status = MigrationStatus.IN_PROGRESS
+        state_manager.save()
+
+        loaded_state = state_manager.load_session(state.session_id)
+        assert loaded_state is not None
+        orchestrator.state = loaded_state
+        loaded_item = loaded_state.get_item(item.id)
+        assert loaded_item is not None
+        assert loaded_item.terminal_state is None
 
         experiment_payload = {"id": "src-exp", "name": "exp"}
         exp_mig = Mock()
@@ -190,8 +199,8 @@ class TestOrchestratorDeltaPersistence:
         )
 
         assert ok is True
-        assert item.status == MigrationStatus.COMPLETED
-        assert item.terminal_state == ResolutionOutcome.MIGRATED.value
+        assert loaded_item.status == MigrationStatus.COMPLETED
+        assert loaded_item.terminal_state == ResolutionOutcome.MIGRATED.value
         fb_mig.migrate_feedback_for_experiments.assert_not_called()
 
     def test_computes_and_persists_delta_on_first_attempt(self, tmp_path):

--- a/tests/test_experiment_migrator.py
+++ b/tests/test_experiment_migrator.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 from langsmith_migrator.core.migrators.experiment import ExperimentMigrator
 from langsmith_migrator.core.migrators.orchestrator import MigrationOrchestrator
 from langsmith_migrator.utils.config import Config
-from langsmith_migrator.utils.state import StateManager
+from langsmith_migrator.utils.state import MigrationStatus, ResolutionOutcome, StateManager
 
 
 def _make_migrator():
@@ -160,6 +160,40 @@ def _orchestrator(tmp_path: Path):
 
 
 class TestOrchestratorDeltaPersistence:
+    def test_resume_finalizes_a_verified_completed_checkpoint(self, tmp_path):
+        orchestrator, _ = _orchestrator(tmp_path)
+        state = orchestrator.ensure_state()
+        item = state.ensure_item(
+            "experiment_src-exp",
+            "experiment",
+            "exp",
+            "src-exp",
+            stage="completed",
+            workspace_pair={"source": None, "dest": None},
+            metadata={
+                "source_dataset_id": "src-ds",
+                "dest_dataset_id": "dst-ds",
+                "destination_experiment_id": "dest-exp",
+                "feedback_found": 2,
+                "feedback_migrated": 2,
+                "feedback_verified": True,
+            },
+        )
+        item.destination_id = "dest-exp"
+
+        experiment_payload = {"id": "src-exp", "name": "exp"}
+        exp_mig = Mock()
+        fb_mig = Mock()
+
+        ok, _ = orchestrator._resolve_experiment_item(
+            experiment_payload, "src-ds", "dst-ds", exp_mig, fb_mig,
+        )
+
+        assert ok is True
+        assert item.status == MigrationStatus.COMPLETED
+        assert item.terminal_state == ResolutionOutcome.MIGRATED.value
+        fb_mig.migrate_feedback_for_experiments.assert_not_called()
+
     def test_computes_and_persists_delta_on_first_attempt(self, tmp_path):
         orchestrator, _ = _orchestrator(tmp_path)
         state = orchestrator.ensure_state()

--- a/tests/test_experiment_run_query_failure.py
+++ b/tests/test_experiment_run_query_failure.py
@@ -1,0 +1,103 @@
+"""A failed source run query must not look like a successful run stage."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from langsmith_migrator.core.api_client import EnhancedAPIClient
+from langsmith_migrator.core.migrators import ExperimentMigrator, FeedbackMigrator
+from langsmith_migrator.utils.retry import UpstreamRejectionError
+
+
+def _clients():
+    source = Mock(spec=EnhancedAPIClient)
+    source.base_url = "https://source.example/api/v1"
+    source.session = Mock()
+    source.session.headers = {}
+
+    dest = Mock(spec=EnhancedAPIClient)
+    dest.base_url = "https://dest.example/api/v1"
+    dest.session = Mock()
+    dest.session.headers = {}
+    return source, dest
+
+
+def test_failed_run_query_raises_instead_of_reporting_zero_runs(
+    sample_config,
+    migration_state,
+):
+    """Silently returning zero runs left empty experiments on the destination."""
+    source, dest = _clients()
+    source.post.side_effect = UpstreamRejectionError(
+        "403 for /runs/query came from an intermediary", status_code=403
+    )
+    migration_state.ensure_item(
+        "experiment_exp-src", "experiment", "exp-1", "exp-src", stage="migrate_runs"
+    )
+
+    migrator = ExperimentMigrator(source, dest, migration_state, sample_config)
+
+    with pytest.raises(UpstreamRejectionError):
+        migrator.migrate_runs_streaming(
+            ["exp-src"],
+            {"experiments": {"exp-src": "exp-dst"}, "examples": {}},
+        )
+
+    # Nothing was written to the destination.
+    dest.post.assert_not_called()
+
+
+def test_failed_run_query_records_a_run_query_issue(sample_config, migration_state):
+    """The operator needs the real error, not a downstream feedback symptom."""
+    source, dest = _clients()
+    source.post.side_effect = RuntimeError("connection reset")
+    migration_state.ensure_item(
+        "experiment_exp-src", "experiment", "exp-1", "exp-src", stage="migrate_runs"
+    )
+
+    migrator = ExperimentMigrator(source, dest, migration_state, sample_config)
+
+    with pytest.raises(RuntimeError):
+        migrator.migrate_runs_streaming(
+            ["exp-src"],
+            {"experiments": {"exp-src": "exp-dst"}, "examples": {}},
+        )
+
+    codes = [issue.code for issue in migration_state.issue_log]
+    assert "run_query_failed" in codes
+    issue = next(i for i in migration_state.issue_log if i.code == "run_query_failed")
+    assert "connection reset" in issue.evidence["error"]
+    assert issue.item_id == "experiment_exp-src"
+
+
+def test_feedback_is_not_attempted_after_a_failed_run_query(
+    sample_config,
+    migration_state,
+):
+    """Regression guard for the misleading `feedback replay incomplete (0/N)` report.
+
+    Runs never made it over, so feedback has no runs to attach to. Previously the
+    run failure was swallowed and this surfaced as a feedback problem instead.
+    """
+    source, dest = _clients()
+    source.post.side_effect = RuntimeError("connection reset")
+    migration_state.ensure_item(
+        "experiment_exp-src", "experiment", "exp-1", "exp-src", stage="migrate_runs"
+    )
+
+    migrator = ExperimentMigrator(source, dest, migration_state, sample_config)
+    with pytest.raises(RuntimeError):
+        migrator.migrate_runs_streaming(
+            ["exp-src"],
+            {"experiments": {"exp-src": "exp-dst"}, "examples": {}},
+        )
+
+    item = migration_state.get_item("experiment_exp-src")
+    assert item.metadata.get("runs_migrated", 0) == 0
+    assert item.stage != "migrate_feedback"
+
+    # And the feedback migrator would have had no run mapping to work with.
+    feedback = FeedbackMigrator(source, dest, migration_state, sample_config)
+    assert feedback.state.id_mappings.get("run", {}) == {}

--- a/tests/test_experiment_run_query_failure.py
+++ b/tests/test_experiment_run_query_failure.py
@@ -49,6 +49,40 @@ def test_failed_run_query_raises_instead_of_reporting_zero_runs(
     dest.post.assert_not_called()
 
 
+def test_later_query_failure_does_not_skip_a_buffered_page(
+    sample_config,
+    migration_state,
+):
+    source, dest = _clients()
+    source_run = {
+        "id": "run-1",
+        "name": "run-1",
+        "run_type": "chain",
+        "session_id": "exp-src",
+        "dotted_order": "20260101T000000000000Z11111111-1111-1111-1111-111111111111",
+    }
+    source.post.side_effect = [
+        {"runs": [source_run], "cursors": {"next": "cursor-2"}},
+        RuntimeError("connection reset"),
+    ]
+    dest.post.return_value = {"errors": []}
+    migration_state.ensure_item(
+        "experiment_exp-src", "experiment", "exp-1", "exp-src", stage="migrate_runs"
+    )
+
+    migrator = ExperimentMigrator(source, dest, migration_state, sample_config)
+
+    with pytest.raises(RuntimeError, match="connection reset"):
+        migrator.migrate_runs_streaming(
+            ["exp-src"],
+            {"experiments": {"exp-src": "exp-dst"}, "examples": {}},
+        )
+
+    assert dest.post.call_count == 1
+    assert migration_state.get_mapped_id("run", "run-1") is not None
+    assert migration_state.get_item("experiment_exp-src").metadata["run_cursor"] == "cursor-2"
+
+
 def test_failed_run_query_records_a_run_query_issue(sample_config, migration_state):
     """The operator needs the real error, not a downstream feedback symptom."""
     source, dest = _clients()

--- a/tests/test_feedback_accounting.py
+++ b/tests/test_feedback_accounting.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
+import pytest
+
 from langsmith_migrator.core.api_client import EnhancedAPIClient
 from langsmith_migrator.core.migrators import FeedbackMigrator
 
@@ -56,7 +58,8 @@ def test_first_pass_reports_everything_migrated(sample_config, migration_state):
 
     assert (found, accounted) == (3, 3)
     item = migration_state.get_item("experiment_exp-src")
-    assert item.metadata["feedback_verified"] is True
+    assert item.metadata["feedback_migrated"] == 3
+    assert item.metadata.get("feedback_verified") is not True
 
 
 def test_second_pass_counts_already_replayed_records(sample_config, migration_state):
@@ -86,7 +89,9 @@ def test_second_pass_counts_already_replayed_records(sample_config, migration_st
     assert first_pass_posts == 3
     assert dest.post.call_count == 0, "already-replayed feedback must not be re-posted"
     assert (found, accounted) == (3, 3), "an already-complete experiment is not a failure"
-    assert migration_state.get_item("experiment_exp-src").metadata["feedback_verified"] is True
+    item = migration_state.get_item("experiment_exp-src")
+    assert item.metadata["feedback_migrated"] == 3
+    assert item.metadata.get("feedback_verified") is not True
 
 
 def test_partial_pass_still_reports_a_shortfall(sample_config, migration_state):
@@ -108,6 +113,30 @@ def test_partial_pass_still_reports_a_shortfall(sample_config, migration_state):
     assert item.metadata.get("feedback_verified") is not True
     issue = next(i for i in migration_state.issue_log if i.code == "feedback_partial_replay")
     assert issue.evidence["unmapped_runs"] == 2
+
+
+def test_source_query_failure_does_not_verify_a_partial_inventory(
+    sample_config,
+    migration_state,
+):
+    feedbacks = [_feedback(i) for i in range(100)]
+    source, dest = _clients(feedbacks)
+    source.get.side_effect = [feedbacks, RuntimeError("connection reset")]
+    migration_state.ensure_item(
+        "experiment_exp-src", "experiment", "exp-1", "exp-src", stage="migrate_feedback"
+    )
+    run_mapping = {f"run-{i}": f"dest-run-{i}" for i in range(100)}
+
+    with pytest.raises(RuntimeError, match="connection reset"):
+        _migrator(source, dest, sample_config, migration_state).migrate_feedback_for_experiments(
+            {"exp-src": "exp-dst"}, run_mapping
+        )
+
+    dest.post.assert_not_called()
+    item = migration_state.get_item("experiment_exp-src")
+    assert item.metadata.get("feedback_verified") is not True
+    issue = next(i for i in migration_state.issue_log if i.code == "feedback_query_failed")
+    assert issue.item_id == "experiment_exp-src"
 
 
 def test_create_failures_are_reported_and_retried_next_pass(sample_config, migration_state):
@@ -143,4 +172,6 @@ def test_create_failures_are_reported_and_retried_next_pass(sample_config, migra
 
     assert dest.post.call_count == 1
     assert (found, accounted) == (2, 2)
-    assert migration_state.get_item("experiment_exp-src").metadata["feedback_verified"] is True
+    item = migration_state.get_item("experiment_exp-src")
+    assert item.metadata["feedback_migrated"] == 2
+    assert item.metadata.get("feedback_verified") is not True

--- a/tests/test_feedback_accounting.py
+++ b/tests/test_feedback_accounting.py
@@ -1,0 +1,146 @@
+"""Feedback replay accounting across repeated passes."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from langsmith_migrator.core.api_client import EnhancedAPIClient
+from langsmith_migrator.core.migrators import FeedbackMigrator
+
+
+def _clients(feedbacks: list[dict]):
+    source = Mock(spec=EnhancedAPIClient)
+    source.base_url = "https://source.example/api/v1"
+    source.session = Mock()
+    source.session.headers = {}
+
+    def _source_get(endpoint: str, params: dict | None = None):
+        if endpoint == "/feedback":
+            # One page, then an empty page to end pagination.
+            return feedbacks if (params or {}).get("offset", 0) == 0 else []
+        raise AssertionError(f"Unexpected source endpoint: {endpoint}")
+
+    source.get.side_effect = _source_get
+
+    dest = Mock(spec=EnhancedAPIClient)
+    dest.base_url = "https://dest.example/api/v1"
+    dest.session = Mock()
+    dest.session.headers = {}
+    dest.post.return_value = {}
+    return source, dest
+
+
+def _feedback(idx: int) -> dict:
+    return {
+        "id": f"fb-{idx}",
+        "run_id": f"run-{idx}",
+        "key": "correctness",
+        "score": 1,
+    }
+
+
+def _migrator(source, dest, sample_config, migration_state):
+    return FeedbackMigrator(source, dest, migration_state, sample_config)
+
+
+def test_first_pass_reports_everything_migrated(sample_config, migration_state):
+    feedbacks = [_feedback(1), _feedback(2), _feedback(3)]
+    source, dest = _clients(feedbacks)
+    migration_state.ensure_item(
+        "experiment_exp-src", "experiment", "exp-1", "exp-src", stage="migrate_feedback"
+    )
+    run_mapping = {f"run-{i}": f"dest-run-{i}" for i in (1, 2, 3)}
+
+    found, accounted = _migrator(source, dest, sample_config, migration_state).\
+        migrate_feedback_for_experiments({"exp-src": "exp-dst"}, run_mapping)
+
+    assert (found, accounted) == (3, 3)
+    item = migration_state.get_item("experiment_exp-src")
+    assert item.metadata["feedback_verified"] is True
+
+
+def test_second_pass_counts_already_replayed_records(sample_config, migration_state):
+    """The false-failure bug: a fully migrated experiment reported as incomplete.
+
+    On a re-run every record is fingerprint-skipped, so counting only records
+    created on this pass yielded 0/N and the caller marked the experiment failed
+    forever, with no way to recover.
+    """
+    feedbacks = [_feedback(1), _feedback(2), _feedback(3)]
+    run_mapping = {f"run-{i}": f"dest-run-{i}" for i in (1, 2, 3)}
+    migration_state.ensure_item(
+        "experiment_exp-src", "experiment", "exp-1", "exp-src", stage="migrate_feedback"
+    )
+
+    source, dest = _clients(feedbacks)
+    _migrator(source, dest, sample_config, migration_state).migrate_feedback_for_experiments(
+        {"exp-src": "exp-dst"}, run_mapping
+    )
+    first_pass_posts = dest.post.call_count
+
+    # Second pass over the same state: nothing new to create.
+    source, dest = _clients(feedbacks)
+    found, accounted = _migrator(source, dest, sample_config, migration_state).\
+        migrate_feedback_for_experiments({"exp-src": "exp-dst"}, run_mapping)
+
+    assert first_pass_posts == 3
+    assert dest.post.call_count == 0, "already-replayed feedback must not be re-posted"
+    assert (found, accounted) == (3, 3), "an already-complete experiment is not a failure"
+    assert migration_state.get_item("experiment_exp-src").metadata["feedback_verified"] is True
+
+
+def test_partial_pass_still_reports_a_shortfall(sample_config, migration_state):
+    """A genuine gap must keep reporting, so the fix cannot mask real failures."""
+    feedbacks = [_feedback(1), _feedback(2), _feedback(3)]
+    source, dest = _clients(feedbacks)
+    migration_state.ensure_item(
+        "experiment_exp-src", "experiment", "exp-1", "exp-src", stage="migrate_feedback"
+    )
+    # Only run-1 made it over, so the other two records have nothing to attach to.
+    run_mapping = {"run-1": "dest-run-1"}
+
+    found, accounted = _migrator(source, dest, sample_config, migration_state).\
+        migrate_feedback_for_experiments({"exp-src": "exp-dst"}, run_mapping)
+
+    assert found == 3
+    assert accounted == 1
+    item = migration_state.get_item("experiment_exp-src")
+    assert item.metadata.get("feedback_verified") is not True
+    issue = next(i for i in migration_state.issue_log if i.code == "feedback_partial_replay")
+    assert issue.evidence["unmapped_runs"] == 2
+
+
+def test_create_failures_are_reported_and_retried_next_pass(sample_config, migration_state):
+    """A record whose POST fails stays unfingerprinted, so a later pass retries it."""
+    feedbacks = [_feedback(1), _feedback(2)]
+    run_mapping = {"run-1": "dest-run-1", "run-2": "dest-run-2"}
+    migration_state.ensure_item(
+        "experiment_exp-src", "experiment", "exp-1", "exp-src", stage="migrate_feedback"
+    )
+
+    source, dest = _clients(feedbacks)
+    calls = {"count": 0}
+
+    def _flaky_post(endpoint: str, payload: dict):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise RuntimeError("403 from a proxy")
+        return {}
+
+    dest.post.side_effect = _flaky_post
+
+    found, accounted = _migrator(source, dest, sample_config, migration_state).\
+        migrate_feedback_for_experiments({"exp-src": "exp-dst"}, run_mapping)
+
+    assert (found, accounted) == (2, 1)
+    issue = next(i for i in migration_state.issue_log if i.code == "feedback_partial_replay")
+    assert issue.evidence["create_failures"] == 1
+
+    # Next pass: the one that succeeded is skipped, the failed one is retried.
+    source, dest = _clients(feedbacks)
+    found, accounted = _migrator(source, dest, sample_config, migration_state).\
+        migrate_feedback_for_experiments({"exp-src": "exp-dst"}, run_mapping)
+
+    assert dest.post.call_count == 1
+    assert (found, accounted) == (2, 2)
+    assert migration_state.get_item("experiment_exp-src").metadata["feedback_verified"] is True

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,115 @@
+"""Tests for the retry_on_failure decorator's retry policy."""
+
+from __future__ import annotations
+
+import pytest
+import requests
+
+from langsmith_migrator.utils.retry import (
+    APIError,
+    AuthenticationError,
+    ConflictError,
+    RateLimitError,
+    UpstreamRejectionError,
+    retry_on_failure,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Keep backoff from actually sleeping."""
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+
+def _counting_raiser(exc: Exception):
+    """Return a decorated callable that always raises, plus its call counter."""
+    calls = {"count": 0}
+
+    @retry_on_failure(max_retries=3)
+    def call():
+        calls["count"] += 1
+        raise exc
+
+    return call, calls
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        UpstreamRejectionError("proxy said no", status_code=403),
+        UpstreamRejectionError("proxy said no", status_code=401),
+        RateLimitError("slow down"),
+        APIError("server blew up", status_code=503),
+        requests.exceptions.ConnectionError("dns failed"),
+        requests.exceptions.ReadTimeout("too slow"),
+    ],
+)
+def test_transient_failures_are_retried(exc):
+    call, calls = _counting_raiser(exc)
+
+    with pytest.raises(type(exc)):
+        call()
+
+    assert calls["count"] == 3
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        AuthenticationError("bad key", status_code=401),
+        AuthenticationError("no permission", status_code=403),
+        ConflictError("already exists"),
+        APIError("bad request", status_code=400),
+        APIError("no status code at all"),
+    ],
+)
+def test_terminal_failures_are_not_retried(exc):
+    call, calls = _counting_raiser(exc)
+
+    with pytest.raises(type(exc)):
+        call()
+
+    assert calls["count"] == 1
+
+
+def test_upstream_rejection_succeeds_on_a_later_attempt():
+    """The whole point: a transient edge refusal should not lose the work."""
+    calls = {"count": 0}
+
+    @retry_on_failure(max_retries=3)
+    def call():
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise UpstreamRejectionError("proxy said no", status_code=403)
+        return {"ok": True}
+
+    assert call() == {"ok": True}
+    assert calls["count"] == 3
+
+
+def test_upstream_rejection_is_not_caught_by_the_auth_clause():
+    """Guards the subclassing: it must derive from APIError, not AuthenticationError."""
+    assert issubclass(UpstreamRejectionError, APIError)
+    assert not issubclass(UpstreamRejectionError, AuthenticationError)
+
+
+def test_rate_limit_honors_retry_after(monkeypatch):
+    slept: list[float] = []
+    monkeypatch.setattr("time.sleep", slept.append)
+    call, _calls = _counting_raiser(RateLimitError("slow down", retry_after=7.0))
+
+    with pytest.raises(RateLimitError):
+        call()
+
+    assert slept[0] == 7.0
+
+
+def test_backoff_is_capped(monkeypatch):
+    slept: list[float] = []
+    monkeypatch.setattr("time.sleep", slept.append)
+    call, _calls = _counting_raiser(RateLimitError("slow down", retry_after=9999.0))
+
+    with pytest.raises(RateLimitError):
+        call()
+
+    assert all(delay <= 60.0 for delay in slept)

--- a/tests/test_state_attempts.py
+++ b/tests/test_state_attempts.py
@@ -1,0 +1,116 @@
+"""Retry-budget accounting on migration items."""
+
+from __future__ import annotations
+
+import time
+
+from langsmith_migrator.utils.state import (
+    MigrationState,
+    MigrationStatus,
+    ResolutionOutcome,
+    VerificationState,
+)
+
+
+def _state() -> MigrationState:
+    return MigrationState(
+        session_id="test-session",
+        started_at=time.time(),
+        updated_at=time.time(),
+        source_url="https://source.example",
+        destination_url="https://dest.example",
+    )
+
+
+def _item(state: MigrationState, item_id: str = "experiment_exp-1"):
+    return state.ensure_item(item_id, "experiment", "exp-1", "exp-1", stage="create_experiment")
+
+
+def test_non_failure_transitions_do_not_consume_the_budget():
+    """A single pass moves an item through several states; only failures should count."""
+    state = _state()
+    item = _item(state)
+
+    state.update_item_status(item.id, MigrationStatus.IN_PROGRESS, stage="create_experiment")
+    state.update_item_status(item.id, MigrationStatus.IN_PROGRESS, stage="migrate_runs")
+    state.update_item_status(item.id, MigrationStatus.IN_PROGRESS, stage="migrate_feedback")
+
+    assert item.attempts == 0
+
+    state.update_item_status(item.id, MigrationStatus.FAILED, error="boom")
+
+    assert item.attempts == 1
+
+
+def test_an_item_that_failed_once_is_still_resumable():
+    """The bug this guards: one failing pass used to exhaust a budget of three."""
+    state = _state()
+    item = _item(state)
+
+    # A realistic failing pass: create, run replay, feedback, then fail.
+    state.update_item_status(item.id, MigrationStatus.IN_PROGRESS, stage="create_experiment")
+    state.update_item_status(item.id, MigrationStatus.IN_PROGRESS, stage="migrate_runs")
+    state.update_item_status(item.id, MigrationStatus.IN_PROGRESS, stage="migrate_feedback")
+    state.update_item_status(item.id, MigrationStatus.FAILED, error="feedback replay incomplete")
+
+    assert [i.id for i in state.get_resume_items()] == [item.id]
+
+
+def test_budget_is_exhausted_after_three_real_failures():
+    state = _state()
+    item = _item(state)
+
+    for _ in range(3):
+        state.update_item_status(item.id, MigrationStatus.FAILED, error="boom")
+
+    assert item.attempts == 3
+    assert state.get_resume_items() == []
+
+
+def test_retry_exhausted_override_includes_spent_items():
+    """`resume --retry-exhausted` must work without hand-editing state."""
+    state = _state()
+    item = _item(state)
+
+    for _ in range(5):
+        state.update_item_status(item.id, MigrationStatus.FAILED, error="boom")
+
+    assert state.get_resume_items() == []
+    assert [i.id for i in state.get_resume_items(max_attempts=None)] == [item.id]
+
+
+def test_completed_items_are_never_resumed():
+    state = _state()
+    item = _item(state)
+
+    state.update_item_status(item.id, MigrationStatus.FAILED, error="boom")
+    state.update_item_status(item.id, MigrationStatus.COMPLETED, destination_id="dest-1")
+
+    assert item.attempts == 1
+    assert state.get_resume_items() == []
+
+
+def test_attempts_survives_a_round_trip():
+    state = _state()
+    item = _item(state)
+    state.update_item_status(item.id, MigrationStatus.FAILED, error="boom")
+
+    restored = MigrationState.from_dict(state.to_dict())
+
+    assert restored.items[item.id].attempts == 1
+
+
+def test_blocked_items_are_not_resumed_but_are_actionable():
+    """Blocked items stay out of the automatic retry set by design."""
+    state = _state()
+    item = _item(state)
+    state.mark_terminal(
+        item.id,
+        ResolutionOutcome.BLOCKED_WITH_CHECKPOINT,
+        "missing_dataset_dependency",
+        verification_state=VerificationState.BLOCKED,
+        next_action="Migrate the referenced dataset, then resume.",
+    )
+
+    assert state.get_resume_items() == []
+    assert [i.id for i in state.get_checkpoint_items()] == [item.id]


### PR DESCRIPTION
## Summary

Fixes migration failures and misleading resume state exposed by transient proxy/WAF rejections:

- Retry non-JSON 401/403 responses as intermediary rejections while genuine LangSmith JSON auth errors still fail fast.
- Propagate failed source run and feedback queries instead of treating partial data as success.
- Flush each run page before advancing its cursor, retaining the current cursor when destination writes fail.
- Count only failed item attempts and add `resume --retry-exhausted` for manual recovery.
- Count previously replayed feedback toward completion and persist verified/terminal experiment state together.

## Why

A self-hosted migration behind an intermittent WAF permanently failed thousands of items, created empty experiments, and reported the failures as feedback problems. Retry classification, swallowed source-query errors, cursor checkpoint ordering, attempt accounting, and feedback accounting compounded the incident.

## Validation

- 590 tests pass
- Changed Python files pass Ruff
- Regression coverage includes transient intermediary responses, later-page query failures, partial feedback reads, cursor replay safety, retry budgets, and interrupted experiment finalization
