### PR TITLE
Release v0.0.82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.82] - 2026-07-29
+
 ### Added
 - **Selective Fleet agent migration (`fleet`)**: The `fleet` command could
   previously migrate **all** agents in a workspace or **none**
@@ -28,10 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   key off the agent map built in the agents phase, so they scope to the
   selected agents with no extra flags. Default behavior with neither flag is
   unchanged.
-
-## [0.0.82] - 2026-07-27
-
-### Added
 - **Engine issue migration (`issues`)**: New `issues` command migrates
   LangSmith Engine resources between instances: per-project issues-agent
   configs (`/v1/platform/sessions/{id}/issues-agent`) and detected issues

--- a/README.md
+++ b/README.md
@@ -226,7 +226,8 @@ langsmith-migrator clean
 - `prompts`: migrate prompts, optionally with full commit history
 - `rules`: migrate automation rules with project mapping controls
 - `charts`: migrate monitoring charts, either all sessions or one named session/project
-- `fleet`: migrate Fleet resources (agents, skills, MCP servers, integrations, auth providers, schedules, triggers, webhooks, usage limits, sandbox policies, secrets) with `--skip-*` flags for each resource type
+- `fleet`: migrate Fleet resources (agents, skills, MCP servers, integrations, auth providers, schedules, triggers, webhooks, usage limits, sandbox policies, secrets) with `--skip-*` flags for each resource type, and `--agent <name-or-id>` / `--agents-owned-only` to scope which agents (and their schedules/triggers/usage limits) are migrated
+- `issues`: migrate Engine issues-agent configs and detected issues as metadata (`--session` to scope to one tracing project)
 - `contexts`: migrate Context Hub agents and skills, replaying full commit history and tags by default (`--latest-only`, `--no-tags`, `--agents-only`, `--skills-only`, `--include-external`, `--same-instance`)
 - `users`: migrate users/roles between instances, or run single-instance CSV access sync
 - `export-users`: export active org and workspace members to a members CSV for import via `users --members-csv`


### PR DESCRIPTION
## Summary
- Folds the selective Fleet agent migration changelog entry into the `[0.0.82]` release section alongside the Engine issue migration work, since v0.0.82 was never actually tagged.

## Test plan
- [x] `uv run pytest` — 564 passed
- [x] `uv build` — wheel/sdist build cleanly at 0.0.82