### PR TITLE
Release v0.0.83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,48 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.82] - 2026-07-29
+## [0.0.83] - 2026-07-31
 
 ### Added
-- **Selective Fleet agent migration (`fleet`)**: The `fleet` command could
-  previously migrate **all** agents in a workspace or **none**
-  (`--skip-agents`), with no way to target a subset. Two new options scope the
-  agents phase:
-  - **`--agent <name-or-id>`** (repeatable): migrate only the named agent(s),
-    matched against each source agent's name **or** ID, so the two forms can be
-    mixed in one invocation. Useful for relocating a handful of specific agents
-    into a team workspace without touching everyone else's.
-  - **`--agents-owned-only`**: restrict the listing to the Fleet `user`
-    audience (agents owned by or directly shared with the authenticated source
-    user), skipping workspace-shared agents owned by others. Without it, both
-    the `user` and `tenant` audiences are queried and merged with dedup by
-    agent ID.
-
-  `--skip-agents` is rejected when combined with either flag. Selectors that
-  match no source agent are reported as a warning under `--verbose`.
-  **Downstream cascade is automatic**: schedules, triggers, and usage limits
-  key off the agent map built in the agents phase, so they scope to the
-  selected agents with no extra flags. Default behavior with neither flag is
-  unchanged.
-- **Engine issue migration (`issues`)**: New `issues` command migrates
-  LangSmith Engine resources between instances: per-project issues-agent
-  configs (`/v1/platform/sessions/{id}/issues-agent`) and detected issues
-  (`/v1/platform/issues`).
-  - Only tracing projects that have Engine data (an issues-agent config or
-    detected issues) are mapped/created on the destination; projects are
-    matched by name, auto-created when missing, and restricted to real tracing
-    projects (experiment/test-run sessions are excluded).
-  - Issues-agent configs are recreated with source-instance-only fields
-    (`latest_thread_id`, `latest_run_id`, tenant, counters, timestamps)
-    stripped.
-  - Detected issues are migrated as metadata (including the Engine-authored
-    `proposed_fix` and `fix_prompt`); run links (`traces`), `actions`, and
-    `fix_branch`/`fix_pr_number` are not carried over.
-  - Idempotent: issues-agent configs and issues already present on the
-    destination are skipped (issues dedup by `session_id` + `name`).
-  - `--session <name-or-ID>` scopes the migration to a single tracing project.
-  - Adds `--session` and `--skip-issues` to `migrate-all` (Step 6, before Fleet).
-
 - **`resume --retry-exhausted`**: Also retry items that have used up their retry
   budget. Previously the only way to get such an item moving again was to edit
   the session state JSON by hand.
@@ -93,6 +54,48 @@ and the summary misattributed the whole thing to feedback replay.
   is set only when every record is accounted for. Source feedback query failures
   propagate instead of verifying an empty or partial inventory. Genuine gaps
   (unmapped runs, failed creates) still report with a per-cause breakdown.
+
+## [0.0.82] - 2026-07-29
+
+### Added
+- **Selective Fleet agent migration (`fleet`)**: The `fleet` command could
+  previously migrate **all** agents in a workspace or **none**
+  (`--skip-agents`), with no way to target a subset. Two new options scope the
+  agents phase:
+  - **`--agent <name-or-id>`** (repeatable): migrate only the named agent(s),
+    matched against each source agent's name **or** ID, so the two forms can be
+    mixed in one invocation. Useful for relocating a handful of specific agents
+    into a team workspace without touching everyone else's.
+  - **`--agents-owned-only`**: restrict the listing to the Fleet `user`
+    audience (agents owned by or directly shared with the authenticated source
+    user), skipping workspace-shared agents owned by others. Without it, both
+    the `user` and `tenant` audiences are queried and merged with dedup by
+    agent ID.
+
+  `--skip-agents` is rejected when combined with either flag. Selectors that
+  match no source agent are reported as a warning under `--verbose`.
+  **Downstream cascade is automatic**: schedules, triggers, and usage limits
+  key off the agent map built in the agents phase, so they scope to the
+  selected agents with no extra flags. Default behavior with neither flag is
+  unchanged.
+- **Engine issue migration (`issues`)**: New `issues` command migrates
+  LangSmith Engine resources between instances: per-project issues-agent
+  configs (`/v1/platform/sessions/{id}/issues-agent`) and detected issues
+  (`/v1/platform/issues`).
+  - Only tracing projects that have Engine data (an issues-agent config or
+    detected issues) are mapped/created on the destination; projects are
+    matched by name, auto-created when missing, and restricted to real tracing
+    projects (experiment/test-run sessions are excluded).
+  - Issues-agent configs are recreated with source-instance-only fields
+    (`latest_thread_id`, `latest_run_id`, tenant, counters, timestamps)
+    stripped.
+  - Detected issues are migrated as metadata (including the Engine-authored
+    `proposed_fix` and `fix_prompt`); run links (`traces`), `actions`, and
+    `fix_branch`/`fix_pr_number` are not carried over.
+  - Idempotent: issues-agent configs and issues already present on the
+    destination are skipped (issues dedup by `session_id` + `name`).
+  - `--session <name-or-ID>` scopes the migration to a single tracing project.
+  - Adds `--session` and `--skip-issues` to `migrate-all` (Step 6, before Fleet).
 
 ## [0.0.81] - 2026-07-27
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Python CLI for migrating users and roles, datasets, experiments, annotation qu
 
 ```bash
 # Install (requires uv: https://docs.astral.sh/uv/)
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.82-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.83-py3-none-any.whl"
 
 # Set up environment variables
 export LANGSMITH_OLD_API_KEY="your_source_api_key"
@@ -115,20 +115,20 @@ The destination's `POST /runs/batch` endpoint rejects runs with timestamps outsi
 
 ### Option 1: uv tool install (Recommended)
 ```bash
-uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.82-py3-none-any.whl"
+uv tool install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.83-py3-none-any.whl"
 
 # To update an existing installation, use --force:
-uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.82-py3-none-any.whl"
+uv tool install --force "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.83-py3-none-any.whl"
 ```
 
 ### Option 2: uvx (One-off execution, no install)
 ```bash
-uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.82-py3-none-any.whl" langsmith-migrator test
+uvx --from "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.83-py3-none-any.whl" langsmith-migrator test
 ```
 
 ### Option 3: pip
 ```bash
-pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.82-py3-none-any.whl"
+pip install "langsmith-data-migration-tool @ https://github.com/langchain-ai/langsmith-data-migration-tool/releases/latest/download/langsmith_data_migration_tool-0.0.83-py3-none-any.whl"
 ```
 
 ### Option 4: From source (Development/Contributing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.82"
+version = "0.0.83"
 description = "A tool for migrating datasets, experiments, prompts, rules, annotation queues, charts, and Fleet resources between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1141,7 +1141,7 @@ wheels = [
 
 [[package]]
 name = "langsmith-data-migration-tool"
-version = "0.0.82"
+version = "0.0.83"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
The four-defect `Fixed` block and the `resume --retry-exhausted` entry from #132 were written into the `[0.0.82]` changelog section, but #132 merged on 2026-07-31 - two days after `v0.0.82` was tagged (`a4125a6`, 2026-07-29 14:11) and its artifacts were built. Those five entries were never in the 0.0.82 release.

This cuts them as 0.0.83:
- Bump version to `0.0.83` (`pyproject.toml`, `uv.lock`)
- Move the `Fixed` block and `resume --retry-exhausted` from `[0.0.82]` into a new `[0.0.83] - 2026-07-31` section
- Restore `[0.0.82]` to exactly what shipped at the tag (selective Fleet agent migration + the `issues` command) - verified byte-identical to `git show v0.0.82:CHANGELOG.md`
- Bump the five README install pins to `0.0.83` (they interpolate the filename into a `releases/latest/download/` URL, so they break if left at the old version)

No source changes - `--retry-exhausted` was already documented in the README by 9c30e93.

## Test plan
- [x] `uv run pytest` - 606 passed
- [x] `uv build --wheel` - builds cleanly at 0.0.83
- [x] `python3 .github/scripts/check_wheel_contents.py dist/*0.0.83*.whl` - PASS
- [x] `ruff check langsmith_migrator .github/scripts/check_wheel_contents.py` - all checks passed
- [x] README-sync check satisfied (README.md changed alongside CHANGELOG.md/version)