### PR TITLE
Add custom model pricing migration (model-pricing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Custom model pricing migration (`model-pricing`)**: New command to migrate
+  workspace-custom model price entries between instances/workspaces via
+  `/model-price-map`. Only workspace-custom entries are copied; the global
+  built-in prices (which already exist in every workspace) are skipped.
+  Migration is idempotent — an equivalent entry already on the destination is
+  updated in place (or skipped with `--skip-existing`), and a server-side
+  uniqueness conflict is treated as already-migrated. Also wired into
+  `migrate-all` (Step 8) with a `--skip-model-pricing` flag.
+
 ## [0.0.83] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ langsmith-migrator datasets
 - **Project Rules**: Copy automation rules with project mapping and optional project creation in interactive flows
 - **Prompts**: Migrate prompts (latest by default, full history with `--include-all-commits`)
 - **Charts**: Migrate monitoring charts with filter preservation
+- **Custom Model Pricing**: Migrate workspace-custom model price entries (`model-pricing`). Global built-in prices are skipped since they already exist in every workspace. Idempotent: an equivalent entry on the destination is updated in place, or skipped with `--skip-existing`
 - **Engine Issues**: Migrate per-project LangSmith Engine issues-agent configs and detected issues as metadata (`issues`). Run links and trace deep-links are not migrated (see Limitations)
 - **Fleet**: Migrate agents, shared skills, MCP servers, integrations, auth providers, schedules, triggers, webhooks, usage limits, sandbox policies, and workspace secrets (`fleet`)
 - **Context Hub**: Migrate Context Hub agents and skills (the versioned agent/skill repos in the LangSmith Context Hub), including files and repo metadata (description, readme, tags, is_public) (`contexts`). Replays the **full commit history** by default so the destination reproduces the source's commit chain; use `--latest-only` to copy just the latest commit. Also copies **commit tags**, including the `production` / `staging` environment tags behind the Context Hub promote feature, pointing each at the same commit on the destination (`--no-tags` to skip). Lists the same contexts the Context Hub UI shows (external-source repos are hidden by default; use `--include-external` to migrate them too). Scope with `--agents-only` / `--skills-only`; linked-repo commit pins are stripped and reported cross-instance, or preserved with `--same-instance`
@@ -49,6 +50,7 @@ This tool **does not support migrating trace data**. It migrates:
 - Project rules
 - Prompts
 - Charts
+- Custom model pricing (workspace-custom model-price-map entries)
 - LangSmith Engine issues-agent configs and detected issue metadata
 - Fleet resources (agents, skills, MCP servers, integrations, auth providers, schedules, triggers, webhooks, usage limits, sandbox policies, secrets)
 - Context Hub agents and skills (full commit history)
@@ -202,6 +204,9 @@ langsmith-migrator charts --project-mapping '{"old-project-id": "new-project-id"
 langsmith-migrator charts --project-mapping mapping.json   # Headless, from file
 langsmith-migrator charts --same-instance       # Reuse source IDs only when both sides share IDs
 
+# Custom model pricing (model-price-map)
+langsmith-migrator model-pricing                # Copy workspace-custom model prices (built-in prices are skipped)
+
 # Fleet resources (agents, skills, MCP servers, etc.)
 langsmith-migrator fleet                        # Migrate all Fleet resources
 langsmith-migrator fleet --skip-agents          # Skip agent migration
@@ -220,12 +225,13 @@ langsmith-migrator clean
 ### Command Overview
 
 - `test`: verify source and destination connectivity before running a migration
-- `migrate-all`: guided end-to-end wizard for users, datasets, prompts, queues, rules, charts, and Fleet resources
+- `migrate-all`: guided end-to-end wizard for users, datasets, prompts, queues, rules, charts, custom model pricing, and Fleet resources
 - `datasets`: migrate datasets; optionally include experiments, runs, and feedback
 - `queues`: migrate annotation queues
 - `prompts`: migrate prompts, optionally with full commit history
 - `rules`: migrate automation rules with project mapping controls
 - `charts`: migrate monitoring charts, either all sessions or one named session/project
+- `model-pricing`: migrate workspace-custom model price entries (global built-in prices are skipped; idempotent, with `--skip-existing`)
 - `fleet`: migrate Fleet resources (agents, skills, MCP servers, integrations, auth providers, schedules, triggers, webhooks, usage limits, sandbox policies, secrets) with `--skip-*` flags for each resource type, and `--agent <name-or-id>` / `--agents-owned-only` to scope which agents (and their schedules/triggers/usage limits) are migrated
 - `issues`: migrate Engine issues-agent configs and detected issues as metadata (`--session` to scope to one tracing project)
 - `contexts`: migrate Context Hub agents and skills, replaying full commit history and tags by default (`--latest-only`, `--no-tags`, `--agents-only`, `--skills-only`, `--include-external`, `--same-instance`)

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -22,6 +22,7 @@ from ..core.migrators import (
     DatasetMigrator,
     MigrationOrchestrator,
     IssueMigrator,
+    ModelPriceMapMigrator,
     PromptMigrator,
     RulesMigrator,
     UserRoleMigrator,
@@ -2325,6 +2326,129 @@ def queues(ctx, source_workspace, dest_workspace, map_workspaces):
     orchestrator.cleanup()
 
 
+@cli.command(name="model-pricing")
+@ssl_option
+@workspace_options
+@click.pass_context
+def model_pricing(ctx, source_workspace, dest_workspace, map_workspaces):
+    """Migrate custom model pricing (model-price-map) entries."""
+    config = ctx.obj["config"]
+    state_manager = ctx.obj["state_manager"]
+
+    display_banner()
+
+    if not ensure_config(config):
+        return
+
+    orchestrator = MigrationOrchestrator(config, state_manager)
+
+    # Test connections
+    if not orchestrator.test_connections():
+        console.print("\n[red]Cannot proceed without valid connections[/red]")
+        orchestrator.cleanup()
+        return
+
+    # Resolve workspace context
+    ws_result = _resolve_workspaces(
+        orchestrator,
+        source_workspace,
+        dest_workspace,
+        map_workspaces,
+        non_interactive=config.migration.non_interactive,
+    )
+    if ws_result is _WS_ABORTED:
+        ctx.exit(1)
+        return
+    if ws_result is _WS_CANCELLED:
+        console.print("[yellow]Cancelled[/yellow]")
+        orchestrator.cleanup()
+        return
+
+    ws_pairs = list(ws_result.workspace_mapping.items()) if ws_result else [(None, None)]
+
+    pricing_migrator = ModelPriceMapMigrator(
+        orchestrator.source_client, orchestrator.dest_client, None, config
+    )
+
+    for src_ws, dst_ws in ws_pairs:
+        if src_ws and dst_ws:
+            orchestrator.set_workspace_context(src_ws, dst_ws)
+            console.print(f"\n[bold cyan]Workspace: {src_ws} -> {dst_ws}[/bold cyan]")
+
+        # Get custom model pricing entries (built-in/global prices are excluded)
+        console.print("\n[bold]Fetching custom model pricing from source...[/bold]")
+
+        price_maps = pricing_migrator.list_price_maps()
+
+        if not price_maps:
+            console.print("[yellow]No custom model pricing found[/yellow]")
+            continue
+
+        selected_prices = _select_or_all(
+            config,
+            price_maps,
+            select_all=config.migration.non_interactive,
+            title="Select Model Pricing Entries to Migrate",
+            columns=[
+                {"key": "name", "title": "Name", "width": 40},
+                {"key": "provider", "title": "Provider", "width": 20},
+                {"key": "match_pattern", "title": "Match", "width": 30},
+                {"key": "prompt_cost", "title": "Prompt", "width": 14},
+                {"key": "completion_cost", "title": "Completion", "width": 14},
+            ],
+        )
+
+        if not selected_prices:
+            console.print("[yellow]No model pricing entries selected[/yellow]")
+            continue
+
+        console.print(
+            f"\n[bold]Migrating {len(selected_prices)} model pricing entry(ies)...[/bold]"
+        )
+        _ensure_migration_session(orchestrator, config)
+        pricing_migrator.state = orchestrator.state
+
+        # Perform migration
+        success_count = 0
+        failed_items = []
+
+        with Progress(console=console) as progress:
+            task = progress.add_task("Migrating model pricing...", total=len(selected_prices))
+            for entry in selected_prices:
+                name = entry.get("name", "unnamed")
+                item_id = _ensure_state_item(
+                    orchestrator,
+                    config,
+                    "model_price",
+                    entry.get("id", name),
+                    name,
+                    metadata={"model_price": entry},
+                )
+                try:
+                    _mark_state_item_started(orchestrator, item_id)
+                    new_id = pricing_migrator.create_price_map(entry)
+                    success_count += 1
+                    _mark_state_item_completed(orchestrator, item_id, destination_id=new_id)
+                except Exception as e:
+                    failed_items.append((name, str(e)))
+                    _mark_state_item_failed(orchestrator, item_id, e)
+                progress.advance(task)
+
+        console.print(
+            f"Model pricing: {success_count} migrated, {len(failed_items)} failed"
+        )
+        if failed_items and config.migration.verbose:
+            for name, err in failed_items:
+                console.print(f"  [red]✗[/red] {name}: {err}")
+
+    if ws_result:
+        orchestrator.clear_workspace_context()
+
+    _display_resolution_summary(orchestrator)
+    _exit_for_remediation_if_needed(ctx, config, orchestrator)
+    orchestrator.cleanup()
+
+
 @cli.command()
 @ssl_option
 @click.option(
@@ -3822,6 +3946,7 @@ def issues(
 @click.option("--skip-queues", is_flag=True, help="Skip annotation queue migration")
 @click.option("--skip-rules", is_flag=True, help="Skip rules migration")
 @click.option("--skip-charts", is_flag=True, help="Skip chart migration")
+@click.option("--skip-model-pricing", is_flag=True, help="Skip custom model pricing migration")
 @click.option("--skip-issues", is_flag=True, help="Skip LangSmith Engine issue migration")
 @click.option("--skip-fleet", is_flag=True, help="Skip Fleet resource migration")
 @click.option("--skip-contexts", is_flag=True, help="Skip Context Hub (agents & skills) migration")
@@ -3859,6 +3984,7 @@ def migrate_all(
     skip_queues,
     skip_rules,
     skip_charts,
+    skip_model_pricing,
     skip_issues,
     skip_fleet,
     skip_contexts,
@@ -4027,6 +4153,7 @@ def migrate_all(
             skip_issues=skip_issues,
             skip_fleet=skip_fleet,
             skip_contexts=skip_contexts,
+            skip_model_pricing=skip_model_pricing,
         )
 
     if ws_result:
@@ -4059,6 +4186,7 @@ def _migrate_all_for_workspace(
     skip_issues=True,
     skip_fleet=True,
     skip_contexts=True,
+    skip_model_pricing=True,
 ):
     """Run the full migrate_all flow for a single workspace pair (or no workspace).
 
@@ -4775,6 +4903,69 @@ def _migrate_all_for_workspace(
             console.print("[yellow]none found[/yellow]\n")
     else:
         console.print("[dim]Skipping contexts (--skip-contexts)[/dim]\n")
+
+    # 8. Custom Model Pricing (model-price-map)
+    if not skip_model_pricing:
+        console.print("[bold]Step 8: Custom Model Pricing[/bold]")
+        console.print("Fetching custom model pricing... ", end="")
+
+        pricing_migrator = ModelPriceMapMigrator(
+            orchestrator.source_client, orchestrator.dest_client, None, config
+        )
+        price_maps = pricing_migrator.list_price_maps()
+
+        if price_maps:
+            console.print(f"found {len(price_maps)}")
+            if _confirm_action(
+                config,
+                f"Migrate {len(price_maps)} model pricing entry(ies)?",
+                default=True,
+                non_interactive_value=True,
+            ):
+                _ensure_migration_session(orchestrator, config)
+                pricing_migrator.state = orchestrator.state
+                success_count = 0
+                failed_items = []
+
+                with Progress(console=console) as progress:
+                    task = progress.add_task(
+                        "Migrating model pricing...", total=len(price_maps)
+                    )
+                    for entry in price_maps:
+                        name = entry.get("name", "unnamed")
+                        item_id = _ensure_state_item(
+                            orchestrator,
+                            config,
+                            "model_price",
+                            entry.get("id", name),
+                            name,
+                            metadata={"model_price": entry},
+                        )
+                        try:
+                            _mark_state_item_started(orchestrator, item_id)
+                            new_id = pricing_migrator.create_price_map(entry)
+                            success_count += 1
+                            _mark_state_item_completed(
+                                orchestrator, item_id, destination_id=new_id
+                            )
+                        except Exception as e:
+                            failed_items.append((name, str(e)))
+                            _mark_state_item_failed(orchestrator, item_id, e)
+                        progress.advance(task)
+
+                console.print(
+                    f"Model pricing: {success_count} migrated, {len(failed_items)} failed"
+                )
+                if failed_items and config.migration.verbose:
+                    for name, err in failed_items:
+                        console.print(f"  [red]✗[/red] {name}: {err}")
+                console.print()
+            else:
+                console.print("[yellow]Skipped model pricing[/yellow]\n")
+        else:
+            console.print("[yellow]none found[/yellow]\n")
+    else:
+        console.print("[dim]Skipping model pricing (--skip-model-pricing)[/dim]\n")
 
 
 @cli.command()

--- a/langsmith_migrator/core/api_client.py
+++ b/langsmith_migrator/core/api_client.py
@@ -397,31 +397,6 @@ class EnhancedAPIClient:
 
     @retry_upstream_rejections(max_retries=3)
     @retry_on_failure(max_retries=1)
-    def put(self, endpoint: str, data: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Make a PUT request.
-
-        Args:
-            endpoint: API endpoint
-            data: JSON data to send
-
-        Returns:
-            JSON response as dictionary
-        """
-        url = self._prepare_url(endpoint)
-
-        if self.verbose:
-            self.console.print(f"[dim]PUT {url}[/dim]")
-
-        # Add rate limiting delay
-        if self.rate_limit_delay > 0:
-            time.sleep(self.rate_limit_delay)
-
-        response = self.session.put(url, json=data, timeout=self.timeout)
-        return self._handle_response(response, endpoint)
-
-    @retry_upstream_rejections(max_retries=3)
-    @retry_on_failure(max_retries=1)
     def delete(self, endpoint: str) -> Dict[str, Any]:
         """
         Make a DELETE request.

--- a/langsmith_migrator/core/api_client.py
+++ b/langsmith_migrator/core/api_client.py
@@ -397,6 +397,31 @@ class EnhancedAPIClient:
 
     @retry_upstream_rejections(max_retries=3)
     @retry_on_failure(max_retries=1)
+    def put(self, endpoint: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Make a PUT request.
+
+        Args:
+            endpoint: API endpoint
+            data: JSON data to send
+
+        Returns:
+            JSON response as dictionary
+        """
+        url = self._prepare_url(endpoint)
+
+        if self.verbose:
+            self.console.print(f"[dim]PUT {url}[/dim]")
+
+        # Add rate limiting delay
+        if self.rate_limit_delay > 0:
+            time.sleep(self.rate_limit_delay)
+
+        response = self.session.put(url, json=data, timeout=self.timeout)
+        return self._handle_response(response, endpoint)
+
+    @retry_upstream_rejections(max_retries=3)
+    @retry_on_failure(max_retries=1)
     def delete(self, endpoint: str) -> Dict[str, Any]:
         """
         Make a DELETE request.

--- a/langsmith_migrator/core/migrators/__init__.py
+++ b/langsmith_migrator/core/migrators/__init__.py
@@ -10,6 +10,7 @@ from .prompt import PromptMigrator
 from .rules import RulesMigrator
 from .issue import IssueMigrator
 from .chart import ChartMigrator
+from .model_price_map import ModelPriceMapMigrator
 from .user_role import UserRoleMigrator
 from .orchestrator import MigrationOrchestrator
 from .fleet_skill import FleetSkillMigrator
@@ -34,6 +35,7 @@ __all__ = [
     "RulesMigrator",
     "IssueMigrator",
     "ChartMigrator",
+    "ModelPriceMapMigrator",
     "UserRoleMigrator",
     "MigrationOrchestrator",
     "FleetSkillMigrator",

--- a/langsmith_migrator/core/migrators/model_price_map.py
+++ b/langsmith_migrator/core/migrators/model_price_map.py
@@ -1,0 +1,144 @@
+"""Custom model pricing (model-price-map) migration logic."""
+
+from typing import Any, Dict, List, Optional
+
+from .base import BaseMigrator
+
+# Fields accepted by the destination create endpoint (ModelPriceMapCreateSchema).
+# id / tenant_id / priority_order are assigned server-side and must not be sent.
+_CREATE_FIELDS = (
+    "name",
+    "start_time",
+    "match_path",
+    "match_pattern",
+    "prompt_cost",
+    "completion_cost",
+    "prompt_cost_details",
+    "completion_cost_details",
+    "provider",
+)
+
+
+def _match_identity(entry: Dict[str, Any]) -> tuple:
+    """Identity used to detect an equivalent entry already on the destination.
+
+    Mirrors the server's uniqueness on match conditions (match_pattern +
+    match_path + provider).
+    """
+    match_path = entry.get("match_path") or []
+    return (
+        entry.get("match_pattern"),
+        tuple(match_path),
+        entry.get("provider"),
+    )
+
+
+class ModelPriceMapMigrator(BaseMigrator):
+    """Handles custom model pricing (model-price-map) migration."""
+
+    def list_price_maps(self) -> List[Dict[str, Any]]:
+        """List workspace-custom model price entries from the source.
+
+        ``GET /model-price-map`` returns both the workspace's custom entries
+        (``tenant_id`` set) and the global built-ins (``tenant_id`` is null).
+        Only the custom entries are migratable, so the built-ins are dropped -
+        recreating them would be redundant and would 409 against the
+        destination's own built-ins.
+        """
+        try:
+            response = self.source.get("/model-price-map")
+        except Exception as e:
+            self.log(f"Failed to list model price maps: {e}", "warning")
+            return []
+
+        if not isinstance(response, list):
+            self.log(
+                f"Unexpected model-price-map response type: {type(response)}", "warning"
+            )
+            return []
+
+        return [
+            entry
+            for entry in response
+            if isinstance(entry, dict) and entry.get("tenant_id") is not None
+        ]
+
+    def find_existing(self, entry: Dict[str, Any]) -> Optional[str]:
+        """Return the id of an equivalent entry on the destination, if any."""
+        try:
+            response = self.dest.get("/model-price-map")
+        except Exception as e:
+            self.log(f"Failed to check for existing model price map: {e}", "warning")
+            return None
+
+        if not isinstance(response, list):
+            return None
+
+        target = _match_identity(entry)
+        for existing in response:
+            if not isinstance(existing, dict):
+                continue
+            # Only match the destination's own custom entries. Global built-ins
+            # (tenant_id is null) share match conditions with custom entries but
+            # are not updatable per-tenant - matching one would yield its id and a
+            # PUT against a row that doesn't exist in this tenant (500).
+            if existing.get("tenant_id") is None:
+                continue
+            if _match_identity(existing) == target:
+                return existing.get("id")
+        return None
+
+    def _build_payload(self, entry: Dict[str, Any]) -> Dict[str, Any]:
+        """Build the create/update payload, copying only server-accepted fields."""
+        return {field: entry[field] for field in _CREATE_FIELDS if field in entry}
+
+    def update_price_map(self, price_map_id: str, entry: Dict[str, Any]) -> None:
+        """Update an existing model price entry on the destination."""
+        if self.config.migration.dry_run:
+            self.log(
+                f"[DRY RUN] Would update model price: {entry.get('name')} ({price_map_id})"
+            )
+            return
+
+        self.dest.put(f"/model-price-map/{price_map_id}", self._build_payload(entry))
+        self.log(
+            f"Updated model price: {entry.get('name')} ({price_map_id})", "success"
+        )
+
+    def create_price_map(self, entry: Dict[str, Any]) -> str:
+        """Create (or update) a model price entry on the destination."""
+        name = entry.get("name") or "unnamed"
+
+        existing_id = self.find_existing(entry)
+        if existing_id:
+            if self.config.migration.skip_existing:
+                self.log(f"Model price '{name}' already exists, skipping", "warning")
+                return existing_id
+            self.log(f"Model price '{name}' exists, updating...", "info")
+            self.update_price_map(existing_id, entry)
+            return existing_id
+
+        if self.config.migration.dry_run:
+            self.log(f"[DRY RUN] Would create model price: {name}")
+            return f"dry-run-{entry.get('id', name)}"
+
+        from ..api_client import APIError, ConflictError
+
+        try:
+            response = self.dest.post("/model-price-map", self._build_payload(entry))
+        except ConflictError:
+            # Server enforces uniqueness on match conditions. A conflict means an
+            # equivalent entry already exists on the destination, so the migration
+            # goal is already satisfied - treat as idempotent success.
+            self.log(
+                f"Model price '{name}' already exists on destination, skipping",
+                "warning",
+            )
+            return self.find_existing(entry) or ""
+
+        if not isinstance(response, dict) or "id" not in response:
+            raise APIError(
+                f"Invalid response creating model price '{name}': {response}"
+            )
+
+        return response["id"]

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -56,6 +56,7 @@ def test_registered_command_names_match_public_cli_surface():
         "list-projects",
         "list_workspaces",
         "migrate-all",
+        "model-pricing",
         "prompts",
         "queues",
         "resume",

--- a/tests/test_model_price_map_migrator.py
+++ b/tests/test_model_price_map_migrator.py
@@ -1,0 +1,187 @@
+"""Unit tests for ModelPriceMapMigrator."""
+
+import pytest
+
+from langsmith_migrator.core.api_client import ConflictError
+from langsmith_migrator.core.migrators import ModelPriceMapMigrator
+
+
+class TestModelPriceMapMigrator:
+    """Test cases for ModelPriceMapMigrator."""
+
+    @pytest.fixture
+    def pricing_migrator(self, mock_api_client, sample_config, migration_state):
+        """Create a ModelPriceMapMigrator instance (same mock for source and dest)."""
+        return ModelPriceMapMigrator(
+            mock_api_client, mock_api_client, migration_state, sample_config
+        )
+
+    @pytest.fixture
+    def custom_entry(self):
+        """A workspace-custom pricing entry (tenant_id set)."""
+        return {
+            "id": "price-src-1",
+            "tenant_id": "ws-source",
+            "name": "amazon_bedrock_claude-sonnet-4-5 (fuel50)",
+            "start_time": None,
+            "match_path": ["model", "model_name"],
+            "match_pattern": "claude-sonnet-4-5",
+            "prompt_cost": "0.000003",
+            "completion_cost": "0.000015",
+            "prompt_cost_details": None,
+            "completion_cost_details": None,
+            "provider": "amazon_bedrock",
+        }
+
+    @pytest.fixture
+    def global_entry(self):
+        """A global/built-in pricing entry (tenant_id is null) - should be skipped."""
+        return {
+            "id": "price-global-1",
+            "tenant_id": None,
+            "name": "gpt-4o",
+            "match_path": ["model"],
+            "match_pattern": "gpt-4o",
+            "prompt_cost": "0.0000025",
+            "completion_cost": "0.00001",
+            "provider": "openai",
+        }
+
+    def test_list_price_maps_filters_global_entries(
+        self, pricing_migrator, mock_api_client, custom_entry, global_entry
+    ):
+        """Only workspace-custom entries (tenant_id set) are returned."""
+        mock_api_client.get.return_value = [custom_entry, global_entry]
+
+        result = pricing_migrator.list_price_maps()
+
+        assert len(result) == 1
+        assert result[0]["id"] == "price-src-1"
+        mock_api_client.get.assert_called_once_with("/model-price-map")
+
+    def test_list_price_maps_non_list_response(self, pricing_migrator, mock_api_client):
+        """A non-list response degrades gracefully to an empty list."""
+        mock_api_client.get.return_value = {"detail": "unexpected"}
+
+        assert pricing_migrator.list_price_maps() == []
+
+    def test_create_price_map_strips_server_assigned_fields(
+        self, pricing_migrator, mock_api_client, sample_config, custom_entry
+    ):
+        """Payload must omit id/tenant_id/priority_order (server-assigned)."""
+        sample_config.migration.dry_run = False
+        # find_existing -> none; create -> success
+        mock_api_client.get.return_value = []
+        mock_api_client.post.return_value = {"id": "price-dest-1"}
+
+        result = pricing_migrator.create_price_map(custom_entry)
+
+        assert result == "price-dest-1"
+        endpoint, payload = mock_api_client.post.call_args[0]
+        assert endpoint == "/model-price-map"
+        assert "id" not in payload
+        assert "tenant_id" not in payload
+        assert "priority_order" not in payload
+        assert payload["name"] == custom_entry["name"]
+        assert payload["match_pattern"] == "claude-sonnet-4-5"
+        assert payload["prompt_cost"] == "0.000003"
+
+    def test_create_price_map_dry_run(
+        self, pricing_migrator, mock_api_client, sample_config, custom_entry
+    ):
+        """Dry-run makes no POST and returns a dry-run sentinel id."""
+        sample_config.migration.dry_run = True
+        mock_api_client.get.return_value = []
+
+        result = pricing_migrator.create_price_map(custom_entry)
+
+        assert result.startswith("dry-run-")
+        mock_api_client.post.assert_not_called()
+
+    def test_create_price_map_skip_existing(
+        self, pricing_migrator, mock_api_client, sample_config, custom_entry
+    ):
+        """When an equivalent entry exists and skip_existing is on, skip the POST."""
+        sample_config.migration.dry_run = False
+        sample_config.migration.skip_existing = True
+        existing = {**custom_entry, "id": "price-dest-existing", "tenant_id": "ws-dest"}
+        mock_api_client.get.return_value = [existing]
+
+        result = pricing_migrator.create_price_map(custom_entry)
+
+        assert result == "price-dest-existing"
+        mock_api_client.post.assert_not_called()
+
+    def test_create_price_map_updates_when_not_skipping(
+        self, pricing_migrator, mock_api_client, sample_config, custom_entry
+    ):
+        """When an equivalent entry exists and skip_existing is off, PUT-update it."""
+        sample_config.migration.dry_run = False
+        sample_config.migration.skip_existing = False
+        existing = {**custom_entry, "id": "price-dest-existing", "tenant_id": "ws-dest"}
+        mock_api_client.get.return_value = [existing]
+        mock_api_client.put.return_value = {"id": "price-dest-existing"}
+
+        result = pricing_migrator.create_price_map(custom_entry)
+
+        assert result == "price-dest-existing"
+        endpoint, _ = mock_api_client.put.call_args[0]
+        assert endpoint == "/model-price-map/price-dest-existing"
+        mock_api_client.post.assert_not_called()
+
+    def test_find_existing_ignores_global_builtin_entries(
+        self, pricing_migrator, mock_api_client, custom_entry
+    ):
+        """A global built-in (tenant_id null) with matching conditions must NOT
+        be treated as an existing destination entry. Otherwise the migrator would
+        PUT against a row that doesn't exist in the tenant and get a 500."""
+        global_match = {
+            "id": "global-builtin-id",
+            "tenant_id": None,
+            "match_path": custom_entry["match_path"],
+            "match_pattern": custom_entry["match_pattern"],
+            "provider": custom_entry["provider"],
+        }
+        mock_api_client.get.return_value = [global_match]
+
+        assert pricing_migrator.find_existing(custom_entry) is None
+
+    def test_create_price_map_creates_when_only_global_matches(
+        self, pricing_migrator, mock_api_client, sample_config, custom_entry
+    ):
+        """When the destination has only a matching global built-in (no custom
+        entry), the migrator should CREATE a new custom entry, not update."""
+        sample_config.migration.dry_run = False
+        global_match = {
+            "id": "global-builtin-id",
+            "tenant_id": None,
+            "match_path": custom_entry["match_path"],
+            "match_pattern": custom_entry["match_pattern"],
+            "provider": custom_entry["provider"],
+        }
+        mock_api_client.get.return_value = [global_match]
+        mock_api_client.post.return_value = {"id": "price-dest-new"}
+
+        result = pricing_migrator.create_price_map(custom_entry)
+
+        assert result == "price-dest-new"
+        mock_api_client.post.assert_called_once()
+        mock_api_client.put.assert_not_called()
+
+    def test_create_price_map_conflict_is_idempotent(
+        self, pricing_migrator, mock_api_client, sample_config, custom_entry
+    ):
+        """A 409 from POST is swallowed and treated as already-exists."""
+        sample_config.migration.dry_run = False
+        sample_config.migration.skip_existing = False
+        existing = {**custom_entry, "id": "price-dest-existing", "tenant_id": "ws-dest"}
+        # First find_existing (pre-POST) returns nothing; post 409s; second
+        # find_existing (post-conflict) resolves the id.
+        mock_api_client.get.side_effect = [[], [existing]]
+        mock_api_client.post.side_effect = ConflictError(
+            "Resource conflict", request_info={}
+        )
+
+        result = pricing_migrator.create_price_map(custom_entry)
+
+        assert result == "price-dest-existing"


### PR DESCRIPTION
## Summary

Adds a new `model-pricing` command to migrate **workspace-custom model price entries** between LangSmith instances/workspaces via `/model-price-map`.

- Only workspace-custom entries (those with a `tenant_id`) are copied; the global built-in prices — which already exist in every workspace — are skipped.
- Migration is **idempotent**: an equivalent entry already on the destination is updated in place (matched on `match_pattern` + `match_path` + `provider`), or skipped with `--skip-existing`. A server-side uniqueness conflict (409) on create is treated as already-migrated.
- Wired into `migrate-all` as **Step 8**, with a `--skip-model-pricing` flag.
- Adds a `put()` helper to `EnhancedAPIClient` for in-place updates (`PUT /model-price-map/{id}`), wrapped in the same retry/upstream-rejection handling as the other write methods.

## Changes

- `core/migrators/model_price_map.py` — new `ModelPriceMapMigrator` (list / find-existing / create / update)
- `core/migrators/__init__.py` — export `ModelPriceMapMigrator`
- `core/api_client.py` — new `put()` method
- `cli/main.py` — new `model-pricing` command + `migrate-all` integration (`--skip-model-pricing`, Step 8)
- `tests/test_model_price_map_migrator.py` — 8 unit tests (global-entry filtering, server-field stripping, dry-run, skip-existing, update-vs-create, conflict idempotency)
- `tests/functional/test_cli_functional.py` — add `model-pricing` to the CLI command registry assertion
- `CHANGELOG.md`, `README.md` — document the new command

## Test plan

- `pytest` — all 615 tests pass
- `langsmith-migrator model-pricing --help` and `langsmith-migrator migrate-all --help` (shows `--skip-model-pricing`) both work
