### PR TITLE
Add subcommand for migrating long-lived traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Long-lived trace migration (`traces`)**: New command that migrates traces
+  whose `trace_tier` is `longlived` between deployments. Run `id`, `trace_id`,
+  `parent_run_id`, `dotted_order` and all timestamps are preserved verbatim
+  (there is no time-shifting option); tracing projects are mapped rather than
+  assumed equal. Attachments and offloaded `inputs`/`outputs` are fetched
+  through the tool's own configured HTTP session — with the blob host validated
+  and redirects refused — and re-inlined, so a failed fetch is reported rather
+  than migrating a run with a placeholder. Writes go through
+  `multipart_ingest` in trace-boundary batches sized to the destination's
+  advertised limits, with binary-split isolation on failure.
+
+  The command is **stateless**: for each `(project, time window)` slice it
+  ingests `source_ids - dest_ids` and re-queries to confirm the difference is
+  empty, so the diff is the work-list, the skip-list and the completeness proof
+  at once. A run the destination already holds is never re-sent: a fully
+  ingested run is immutable (its `end_time` is persisted), so it cannot be
+  repaired in place — repair means re-migrating that window into a fresh
+  destination project. There is no checkpoint and no resume — re-run instead,
+  and `resume` says so. A pre-flight canary verifies the destination still
+  accepts historical timestamps before anything is written, and destination
+  projects are created with an explicit long-lived trace tier,
+  scoped one project at a time. Run `model-pricing` before `traces`: token and
+  cost rollups are recomputed by the destination, not replayed. Deliberately
+  not wired into `migrate-all`.
+
 - **Custom model pricing migration (`model-pricing`)**: New command to migrate
   workspace-custom model price entries between instances/workspaces via
   `/model-price-map`. Only workspace-custom entries are copied; the global

--- a/README.md
+++ b/README.md
@@ -70,7 +70,13 @@ What `traces` guarantees:
 window, not from a checkpoint. If a run is interrupted, just re-run the same command —
 finished windows produce an empty difference. `--max-age-days` sets the range to walk
 (default 180, the retention ceiling) and `--window` the size of one slice of it
-(default 1 day); widen `--window` when migrating many projects. `langsmith-migrator
+(default 1 day); widen `--window` when migrating many projects. `--max-age-days` is
+the easy way to *start* a migration; to **resume** one, prefer `--max-age-stamp` with
+an absolute instant, because a relative age denotes a different point in time every
+time it is evaluated — over a multi-hour run the same float silently slides forward.
+Each project reports a `verified complete from … to …` watermark and a ready-to-paste
+`--max-age-stamp` that redoes about one ingest batch, so no boundary run is skipped.
+Passing both bounds is an error rather than a silent preference. `langsmith-migrator
 resume` does not apply and will say so.
 
 **Ordering dependency: run `model-pricing` before `traces`.** Token and cost rollups are
@@ -525,6 +531,8 @@ The prompt default is `No` (rules are created disabled).
 --project TEXT                  Tracing project (session) name or ID; repeatable
 --all                           Migrate all tracing projects without prompting
 --max-age-days FLOAT            How far back to walk, the range (default: 180, the retention ceiling)
+--max-age-stamp TEXT            Absolute lower bound instead of --max-age-days, e.g. 2026-08-27T18:00:00Z
+                                (mutually exclusive with --max-age-days; prefer it for long runs and resuming)
 --window FLOAT                  Size in days of one slice of the range (default: 1)
 --max-field-bytes INTEGER       Destination MAX_FIELD_SIZE_BYTES; not advertised, so it must be supplied (default: 25 MB)
 --no-verify                     Skip the confirming re-query after ingest (the pre-diff still runs)

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ langsmith-migrator clean
 - `fleet`: migrate Fleet resources (agents, skills, MCP servers, integrations, auth providers, schedules, triggers, webhooks, usage limits, sandbox policies, secrets) with `--skip-*` flags for each resource type, and `--agent <name-or-id>` / `--agents-owned-only` to scope which agents (and their schedules/triggers/usage limits) are migrated
 - `issues`: migrate Engine issues-agent configs and detected issues as metadata (`--session` to scope to one tracing project)
 - `contexts`: migrate Context Hub agents and skills, replaying full commit history and tags by default (`--latest-only`, `--no-tags`, `--agents-only`, `--skills-only`, `--include-external`, `--same-instance`)
-- `traces`: migrate long-lived traces (`trace_tier == "longlived"`) with run IDs and timestamps preserved; stateless, so re-run rather than resume (`--max-age-days`, `--window`, `--skip-attachments`, `--emit-upgrade-list`). Not part of `migrate-all`
+- `traces`: migrate long-lived traces (`trace_tier == "longlived"`) with run IDs and timestamps preserved; stateless, so re-run rather than resume (`--max-age-days`, `--window`, `--prefetch-windows`, `--compress-level`, `--skip-attachments`, `--emit-upgrade-list`). Not part of `migrate-all`
 - `users`: migrate users/roles between instances, or run single-instance CSV access sync
 - `export-users`: export active org and workspace members to a members CSV for import via `users --members-csv`
 - `resume`: retry resumable items from a prior session and show grouped manual blockers
@@ -538,6 +538,9 @@ The prompt default is `No` (rules are created disabled).
 --no-verify                     Skip the confirming re-query after ingest (the pre-diff still runs)
 --verify-content-sample INTEGER Runs per window to content-check (default: 100)
 --skip-attachments              Migrate runs without their attachments (recorded as degraded)
+--compress-level INTEGER        zstd level for the ingest body, 1-22 (default: 3)
+--no-compress-upload            Send the ingest body uncompressed
+--prefetch-windows INTEGER      Windows to retrieve concurrently, 1-32 (default: 4); ingest stays serial
 --map-projects                  Launch interactive TUI to map source projects to destination projects
 --project-mapping TEXT          JSON string or file path with project ID mapping (headless, no TUI)
 --restore-session-tier/--no-restore-session-tier
@@ -548,6 +551,33 @@ The prompt default is `No` (rules are created disabled).
 ```
 
 There are deliberately **no timestamp options**: run timestamps are copied verbatim.
+
+#### Throughput
+
+Three settings govern speed, and only one of them trades anything away:
+
+- `--prefetch-windows` (default 4) retrieves several windows at once. **Ingest
+  stays serial and strictly oldest-first whatever this is set to**, so a failure
+  leaves every earlier window complete rather than a hole in the middle. Peak
+  memory is this many windows of payloads plus the one being written — shrink
+  `--window` if that is too much.
+- `--compress-level` (default 3) sets the zstd level for the ingest body.
+  Measured per assembled request on real payloads: level 1 (what the SDK uses
+  on its own) 5.9x, level 3 with long-distance matching 68.5x at 1755 MB/s,
+  level 19 79.7x at 58 MB/s. Level 3 is effectively free; raise it only when
+  genuinely bandwidth-bound, since the frame is built by the retrieval workers
+  and higher levels start costing real CPU.
+- Page size is not an option: `/runs/query` is asked for 1000 runs per page and
+  lowers itself if a deployment advertises a smaller cap. Payload fetches are
+  likewise self-tuning — they start at 500 run IDs per request and halve on a
+  413/502/503, because for a project with large payloads that many IDs makes a
+  response the gateway refuses to serve. A line like `500 IDs per request was
+  refused (502); continuing at 250` is that adjustment, not an error.
+
+`--no-compress-upload` falls back to the SDK's own uncompressed multipart path.
+Compression is also skipped automatically if the destination does not advertise
+`zstd_compression_enabled` or the SDK internals it needs have moved; the
+pre-flight table says which.
 
 ### Users Options
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ langsmith-migrator datasets
 - **Custom Model Pricing**: Migrate workspace-custom model price entries (`model-pricing`). Global built-in prices are skipped since they already exist in every workspace. Idempotent: an equivalent entry on the destination is updated in place, or skipped with `--skip-existing`
 - **Engine Issues**: Migrate per-project LangSmith Engine issues-agent configs and detected issues as metadata (`issues`). Run links and trace deep-links are not migrated (see Limitations)
 - **Fleet**: Migrate agents, shared skills, MCP servers, integrations, auth providers, schedules, triggers, webhooks, usage limits, sandbox policies, and workspace secrets (`fleet`)
+- **Long-lived traces**: Migrate traces whose tier is `longlived` between deployments (`traces`), preserving run IDs, `dotted_order` and timestamps verbatim, carrying attachments and re-inlining offloaded payloads. Stateless — work is a destination diff per time window, so re-run instead of resuming. Not part of `migrate-all`
 - **Context Hub**: Migrate Context Hub agents and skills (the versioned agent/skill repos in the LangSmith Context Hub), including files and repo metadata (description, readme, tags, is_public) (`contexts`). Replays the **full commit history** by default so the destination reproduces the source's commit chain; use `--latest-only` to copy just the latest commit. Also copies **commit tags**, including the `production` / `staging` environment tags behind the Context Hub promote feature, pointing each at the same commit on the destination (`--no-tags` to skip). Lists the same contexts the Context Hub UI shows (external-source repos are hidden by default; use `--include-external` to migrate them too). Scope with `--agents-only` / `--skills-only`; linked-repo commit pins are stripped and reported cross-instance, or preserved with `--same-instance`
 - **Workspace Scoping**: Run resource migrations per workspace pair with explicit IDs or interactive workspace mapping
 - **Remediation & Resume**: Persist migration state, write remediation bundles, print grouped actionable next steps, and retry pending/failed work with `resume`
@@ -41,27 +42,91 @@ langsmith-migrator datasets
 
 ## Limitations
 
-### Trace Data Not Supported
+### Long-Lived Traces Only
 
-This tool **does not support migrating trace data**. It migrates:
-- Datasets and examples (including file attachments)
-- Experiments, runs, and feedback
-- Annotation queues
-- Project rules
-- Prompts
-- Charts
-- Custom model pricing (workspace-custom model-price-map entries)
-- LangSmith Engine issues-agent configs and detected issue metadata
-- Fleet resources (agents, skills, MCP servers, integrations, auth providers, schedules, triggers, webhooks, usage limits, sandbox policies, secrets)
-- Context Hub agents and skills (full commit history)
+The `traces` command migrates **long-lived traces only** (`trace_tier == "longlived"`)
+— the ones deliberately retained for up to 180 days. Short-lived traces are out of
+scope.
 
-For trace data, use LangSmith's **Bulk Export** functionality: [LangSmith Bulk Export Documentation](https://docs.langchain.com/langsmith/data-export#bulk-exporting-trace-data)
+What `traces` guarantees:
+
+- **Run IDs are preserved.** `id`, `trace_id`, `parent_run_id` and `dotted_order` are
+  copied verbatim, so run references keep meaning across the move.
+- **Timestamps are preserved.** There is no time-shifting option, flag, or fallback.
+  (Contrast `datasets --include-experiments`, which *does* shift experiment run
+  timestamps — see "Experiment Timestamps Are Rewritten on Migration".)
+- **Tracing projects are mapped, not preserved.** Creating a destination project
+  attempts the source's UUID because a match is convenient, but a rejection is normal
+  progress — nothing depends on the two being equal. Resolution order is
+  `--project-mapping` / `--map-projects` → destination name match → create.
+- **Completeness is verified per project.** For each `(project, time window)` slice the
+  tool compares the source's long-lived run IDs against the destination's and reports
+  `source = ingested + already present + degraded + blocked`.
+- **Attachments and offloaded payloads are carried.** Blobs are fetched through the
+  tool's own configured HTTP session (SSL settings, CA bundles, proxies) and re-inlined;
+  a failed fetch is reported, never silently replaced with a placeholder.
+
+**Statelessness: there is no resume.** Work is derived from a destination diff per time
+window, not from a checkpoint. If a run is interrupted, just re-run the same command —
+finished windows produce an empty difference. `--max-age-days` sets the range to walk
+(default 180, the retention ceiling) and `--window` the size of one slice of it
+(default 1 day); widen `--window` when migrating many projects. `langsmith-migrator
+resume` does not apply and will say so.
+
+**Ordering dependency: run `model-pricing` before `traces`.** Token and cost rollups are
+not replayed — the destination recomputes them from each run's `usage_metadata` against
+its own price map, so the custom prices must be in place first.
+
+**Same-workspace refusal.** The destination's run identity is
+`(tenant, project, start_time, run id)`, so re-ingesting runs under their original IDs
+into the *same* deployment and workspace duplicates or overwrites the source rather than
+replacing it. The command refuses, regardless of how projects map. Cross-workspace on one
+deployment is fine.
+
+**Retention tier.** The ingest contract has no per-run tier field, so the destination
+*project's* tier is the only lever — and it must be right at ingest time, because the row
+TTL and the blob key prefix are both baked in at insert. Destination projects are
+therefore created with an explicit long-lived tier, and an existing short-lived project is
+raised (and re-read until the raise is observable) before anything is written into it.
+Exposure is scoped to one project at a time: raise → migrate → verify → restore.
+`--restore-session-tier` defaults on when the source project was not itself long-lived.
+
+**Fidelity repair means a new project, not a re-send.** A run is immutable once fully
+ingested so re-sending a run the destination already holds cannot repair it.
+
+#### Destination configuration checklist
+
+The tool reports rather than requires: the pre-flight prints the destination's advertised
+limits, runs a historical-ingest canary, and names the setting behind any value that will
+hurt. Fixing the destination and re-running costs nothing.
+
+| Setting | Default | Why it matters |
+| --- | --- | --- |
+| `V1_INGEST_ENFORCE_TIME_WINDOW_EXCLUDED_ORGS` | `["*"]` | Historical timestamps are rejected outright when the ±24h ingest window is enforced, and the *whole* multipart request fails. Keep `*` or add the org. The pre-flight canary — one run stamped at the far end of the requested range, read back by ID — enforces this before anything is migrated, and stops with `historical_ingest_rejected` if it fails. |
+| `MAX_FIELD_SIZE_BYTES` | 25 MB | An oversized `inputs`/`outputs` is **silently replaced with a placeholder**, not rejected, and the limit is not advertised. Tell the tool via `--max-field-bytes`; a larger re-inlined payload is then reported as `payload_oversized_for_destination` instead of quietly stubbed. |
+| `MAX_ATTACHMENT_SIZE_BYTES` | 200 MB | Attachments above this are refused. |
+| `TRACE_TIER_TTL_DURATION_SEC_MAP`, `S3_TRACE_TIER_PREFIX_MAP` | `""` | Both need a `longlived` entry or tier handling errors. |
+| `FF_BLOB_STORAGE_ENABLED` | false (auto-true with S3) | Gates the blob side of tier handling. |
+| `DEFAULT_TRACE_TIER` | `shortlived` | Decides whether the explicit long-lived create counts as a tier *increase*. |
+| Destination key's role | — | Needs `PROJECTS_INCREASE_TRACE_TIER`, plus `PROJECTS_DECREASE_TRACE_TIER` when restoring. A 403 stops the pre-flight with `trace_tier_permission_denied`. |
+| Tenant long-lived usage limit | — | Checked once per multipart request; a breach fails the whole request. Confirm headroom for the expected volume. |
+
+Worth tuning for the transfer and reverting afterwards: `BATCH_INGEST_SIZE_LIMIT_BYTES`
+(20 MB default, binding for trace payloads with inlined blobs), `BATCH_INGEST_SIZE_LIMIT`
+(100 runs), `BATCH_INGEST_SCALE_UP_NTHREADS_LIMIT` (16),
+`BATCH_INGEST_SCALE_UP_QSIZE_TRIGGER` (1000, lower it so workers scale before a backlog
+builds), and `TRACER_SESSION_CACHE_SOFT_TTL_SEC` (60, only relevant when raising an
+existing project's tier).
+
+Not migrated by `traces`: short-lived traces, threads, and run-level sharing links.
+`migrate-all` deliberately does not run it — trace volume makes it a separately scoped
+operation.
 
 ### Engine Issue Run Links and Trace Deep-Links Are Not Migrated
 
 The `issues` command migrates two LangSmith Engine resource types: per-project issues-agent configs and the detected issues themselves. Detected issues are migrated as **metadata only** (name, description, severity, status, tags, plus the Engine-authored `proposed_fix` and `fix_prompt`).
 
-An issue's linked runs are **not** migrated. Issues reference runs by `run_id`/`trace_id`, and trace data is not portable across instances (see "Trace Data Not Supported" above). The destination validates every `run_id` against its own run store, so links pointing at source runs would be rejected. The tool never sends the linked-run list when recreating an issue. To repopulate run links, run Engine on the destination so it re-detects issues against the destination's own traces. For the same reason, `fix_branch`/`fix_pr_number` (source-instance GitHub references) and Engine-generated advisory `actions` are also not sent on create.
+An issue's linked runs are **not** migrated. Issues reference runs by `run_id`/`trace_id`, and the destination validates every `run_id` against its own run store, so links pointing at source runs would be rejected. Migrating traces first with the `traces` command preserves run IDs (see "Long-Lived Traces Only" above), but re-pointing issue run links is not yet automated. The tool never sends the linked-run list when recreating an issue. To repopulate run links, run Engine on the destination so it re-detects issues against the destination's own traces. For the same reason, `fix_branch`/`fix_pr_number` (source-instance GitHub references) and Engine-generated advisory `actions` are also not sent on create.
 
 Issues-agent configs are recreated with source-instance-only fields stripped (`latest_thread_id`, `latest_run_id`, issue counts, tenant, timestamps). GitHub/Context-Hub linkage (`github_repo_url`, `context_hub_repo_handle`, etc.) is carried over but only works if the destination has the corresponding integrations configured. Engine-generated advisory `actions` on an issue (e.g. suggested evaluators) are not migrated: the destination re-validates them strictly on create and regenerates them when Engine runs there. Tip: migrate datasets/projects first (or use `migrate-all`) so issues map onto existing projects instead of freshly-created empty ones.
 
@@ -214,6 +279,12 @@ langsmith-migrator fleet --skip-skills --skip-mcp-servers  # Skip specific resou
 langsmith-migrator fleet --agent "My Agent" --agent agent-abc123  # Only these agents (by name or ID)
 langsmith-migrator fleet --agents-owned-only    # Only agents you own or are directly shared
 
+# Long-lived traces (run model-pricing first)
+langsmith-migrator traces                       # Interactive project selection
+langsmith-migrator traces --all                 # All tracing projects
+langsmith-migrator traces --project "my-project" --max-age-days 90 --window 7
+langsmith-migrator traces --emit-upgrade-list upgrade.csv  # Leave tiers alone, hand the list to an operator
+
 # Utilities
 langsmith-migrator export-users --source -o users.csv  # Export active members to a members CSV
 langsmith-migrator list-projects --source
@@ -235,6 +306,7 @@ langsmith-migrator clean
 - `fleet`: migrate Fleet resources (agents, skills, MCP servers, integrations, auth providers, schedules, triggers, webhooks, usage limits, sandbox policies, secrets) with `--skip-*` flags for each resource type, and `--agent <name-or-id>` / `--agents-owned-only` to scope which agents (and their schedules/triggers/usage limits) are migrated
 - `issues`: migrate Engine issues-agent configs and detected issues as metadata (`--session` to scope to one tracing project)
 - `contexts`: migrate Context Hub agents and skills, replaying full commit history and tags by default (`--latest-only`, `--no-tags`, `--agents-only`, `--skills-only`, `--include-external`, `--same-instance`)
+- `traces`: migrate long-lived traces (`trace_tier == "longlived"`) with run IDs and timestamps preserved; stateless, so re-run rather than resume (`--max-age-days`, `--window`, `--skip-attachments`, `--emit-upgrade-list`). Not part of `migrate-all`
 - `users`: migrate users/roles between instances, or run single-instance CSV access sync
 - `export-users`: export active org and workspace members to a members CSV for import via `users --members-csv`
 - `resume`: retry resumable items from a prior session and show grouped manual blockers
@@ -446,6 +518,28 @@ The prompt default is `No` (rules are created disabled).
 --project-mapping TEXT  JSON string or file path with project ID mapping (headless, no TUI; mutually exclusive with --map-projects)
 --same-instance         Reuse source project/session IDs on destination only when both sides truly share IDs
 ```
+
+### Trace Options
+
+```bash
+--project TEXT                  Tracing project (session) name or ID; repeatable
+--all                           Migrate all tracing projects without prompting
+--max-age-days FLOAT            How far back to walk, the range (default: 180, the retention ceiling)
+--window FLOAT                  Size in days of one slice of the range (default: 1)
+--max-field-bytes INTEGER       Destination MAX_FIELD_SIZE_BYTES; not advertised, so it must be supplied (default: 25 MB)
+--no-verify                     Skip the confirming re-query after ingest (the pre-diff still runs)
+--verify-content-sample INTEGER Runs per window to content-check (default: 100)
+--skip-attachments              Migrate runs without their attachments (recorded as degraded)
+--map-projects                  Launch interactive TUI to map source projects to destination projects
+--project-mapping TEXT          JSON string or file path with project ID mapping (headless, no TUI)
+--restore-session-tier/--no-restore-session-tier
+                                Restore each destination project's trace tier after verifying it
+                                (defaults on when the source project was not long-lived)
+--into-session-suffix TEXT      Migrate into a separate long-lived project named with this suffix (foo -> fooSuffix)
+--emit-upgrade-list FILE        Leave project tiers alone and write (dest_session_id, trace_id, start_time) per trace
+```
+
+There are deliberately **no timestamp options**: run timestamps are copied verbatim.
 
 ### Users Options
 

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -25,6 +25,7 @@ from ..core.migrators import (
     ModelPriceMapMigrator,
     PromptMigrator,
     RulesMigrator,
+    TraceMigrator,
     UserRoleMigrator,
     FleetAgentMigrator,
     FleetAuthProviderMigrator,
@@ -37,6 +38,7 @@ from ..core.migrators import (
     FleetUsageLimitMigrator,
     FleetWebhookMigrator,
 )
+from ..core.migrators.trace import TracePreflightError
 from ..core.migrators.user_role import (
     is_workspace_role_union_id,
     select_effective_workspace_role_id,
@@ -6254,6 +6256,357 @@ def contexts(
 
 
 @cli.command()
+@click.option("--project", "projects", multiple=True, help="Tracing project (session) name or ID; repeatable")
+@click.option("--all", "select_all", is_flag=True, help="Migrate all tracing projects without prompting")
+@click.option(
+    "--max-age-days",
+    type=float,
+    default=180.0,
+    show_default=True,
+    help="How far back to walk (the range). 180 days is the long-lived retention ceiling.",
+)
+@click.option(
+    "--window",
+    "window_days",
+    type=float,
+    default=1.0,
+    show_default=True,
+    help="Size in days of one slice of the range. Widen it for a many-project run.",
+)
+@click.option(
+    "--max-field-bytes",
+    type=int,
+    default=25 * 1024 * 1024,
+    show_default=True,
+    help=(
+        "Destination MAX_FIELD_SIZE_BYTES. Not advertised by the destination, so it must be "
+        "supplied; a larger re-inlined payload is reported instead of being silently stubbed."
+    ),
+)
+@click.option("--no-verify", is_flag=True, help="Skip the confirming re-query after ingest (the pre-diff still runs)")
+@click.option("--verify-content-sample", type=int, default=100, show_default=True, help="Runs per window to content-check")
+@click.option("--skip-attachments", is_flag=True, help="Migrate runs without their attachments (recorded as degraded)")
+@click.option("--map-projects", is_flag=True, help="Interactively map source projects to destination projects")
+@click.option("--project-mapping", help='Headless project mapping: JSON object or file, {"src-id": "dest-id"}')
+@click.option(
+    "--restore-session-tier/--no-restore-session-tier",
+    default=None,
+    help="Restore each destination project's trace tier after verifying it. Defaults on when the source project was not long-lived.",
+)
+@click.option("--into-session-suffix", help="Migrate into a separate long-lived project named with this suffix, leaving the live one's tier alone")
+@click.option("--emit-upgrade-list", type=click.Path(dir_okay=False), help="Leave project tiers alone and write (dest_session_id, trace_id, start_time) per trace for an operator upgrade")
+@ssl_option
+@workspace_options
+@click.pass_context
+def traces(
+    ctx,
+    projects,
+    select_all,
+    max_age_days,
+    window_days,
+    max_field_bytes,
+    no_verify,
+    verify_content_sample,
+    skip_attachments,
+    map_projects,
+    project_mapping,
+    restore_session_tier,
+    into_session_suffix,
+    emit_upgrade_list,
+    source_workspace,
+    dest_workspace,
+    map_workspaces,
+):
+    """Migrate long-lived traces between deployments.
+
+    Run IDs and timestamps are preserved verbatim; tracing projects (sessions)
+    are mapped. Stateless: there is no resume, just re-run the command.
+    Run `model-pricing` first so migrated runs' costs are computed against the
+    right price map.
+    """
+    config = ctx.obj["config"]
+    state_manager = ctx.obj["state_manager"]
+
+    display_banner()
+    if not ensure_config(config):
+        return
+
+    project_id_map = _load_project_mapping_arg(project_mapping)
+    if project_id_map is _PROJECT_MAPPING_ERROR:
+        ctx.exit(1)
+        return
+
+    orchestrator = MigrationOrchestrator(config, state_manager)
+
+    console.print("Testing connections... ", end="")
+    source_ok, dest_ok, source_error, dest_error = orchestrator.test_connections_detailed()
+    if not source_ok or not dest_ok:
+        console.print(f"[red]✗ {'Source' if not source_ok else 'Destination'} connection failed[/red]")
+        if source_error or dest_error:
+            console.print(f"[red]  {source_error or dest_error}[/red]")
+        orchestrator.cleanup()
+        return
+    console.print("[green]✓[/green]\n")
+
+    ws_result = _resolve_workspaces(
+        orchestrator, source_workspace, dest_workspace, map_workspaces,
+        non_interactive=config.migration.non_interactive,
+    )
+    if ws_result is _WS_ABORTED:
+        ctx.exit(1)
+        return
+    if ws_result is _WS_CANCELLED:
+        console.print("[yellow]Cancelled[/yellow]")
+        orchestrator.cleanup()
+        return
+
+    ws_pairs = list(ws_result.workspace_mapping.items()) if ws_result else [(None, None)]
+
+    # Run identity on the destination is (tenant, session, start_time, id), so
+    # re-ingesting preserved IDs into the same tenant duplicates rather than
+    # replaces - whatever the session mapping says. Cross-workspace on one
+    # deployment is fine.
+    if _is_same_deployment(config) and any(src == dst for src, dst in ws_pairs):
+        console.print(
+            "[red]Refusing to migrate traces into the same deployment and workspace they were read from.[/red]\n"
+            "[red]Runs keep their original IDs, so the destination would duplicate or overwrite the source.[/red]"
+        )
+        orchestrator.cleanup()
+        ctx.exit(1)
+        return
+
+    _ensure_migration_session(orchestrator, config)
+    upgrade_rows = []
+    session_reports = []
+    fidelity_notes = set()
+
+    for src_ws, dst_ws in ws_pairs:
+        if src_ws and dst_ws:
+            orchestrator.set_workspace_context(src_ws, dst_ws)
+            console.print(f"\n[bold cyan]Workspace: {src_ws} -> {dst_ws}[/bold cyan]")
+
+        migrator = TraceMigrator(
+            orchestrator.source_client,
+            orchestrator.dest_client,
+            orchestrator.state,
+            config,
+            max_age_days=max_age_days,
+            window_days=window_days,
+            max_field_bytes=max_field_bytes,
+            verify=not no_verify,
+            verify_content_sample=verify_content_sample,
+            skip_attachments=skip_attachments,
+            restore_session_tier=restore_session_tier,
+            into_session_suffix=into_session_suffix,
+            emit_upgrade_list=emit_upgrade_list,
+            project_id_map=project_id_map
+            or _workspace_scoped_project_id_map(orchestrator, ws_result, src_ws)
+            or (build_project_id_mapping_tui(orchestrator.source_client, orchestrator.dest_client) if map_projects else None),
+        )
+        _print_trace_preflight(migrator, config, max_age_days, window_days, max_field_bytes, no_verify, into_session_suffix)
+
+        try:
+            migrator.canary()
+        except TracePreflightError as exc:
+            console.print(f"[red]Pre-flight failed: {exc}[/red]")
+            console.print("[red]Nothing was migrated.[/red]")
+            _display_resolution_summary(orchestrator)
+            orchestrator.cleanup()
+            ctx.exit(1)
+            return
+
+        try:
+            selected = _select_trace_sessions(config, migrator, projects, select_all)
+        except Exception as e:
+            # Not a skip: an explicitly named project that could not be
+            # resolved must not exit zero looking like a clean no-op run.
+            console.print(f"[red]Failed to resolve tracing projects: {e}[/red]")
+            if projects:
+                orchestrator.cleanup()
+                ctx.exit(1)
+                return
+            continue
+        if projects and not selected:
+            console.print("[red]None of the requested --project values resolved to a tracing project[/red]")
+            orchestrator.cleanup()
+            ctx.exit(1)
+            return
+        if not selected:
+            console.print("[yellow]No tracing projects selected[/yellow]")
+            continue
+
+        for source_session in selected:
+            console.print(f"\n[bold]{source_session.get('name')}[/bold] ({source_session['id']})")
+            try:
+                report = migrator.migrate_session(source_session)
+            except TracePreflightError as exc:
+                console.print(f"  [red]blocked: {exc}[/red]")
+                continue
+            except Exception as e:
+                console.print(f"  [red]failed: {e}[/red]")
+                continue
+            if report is None:
+                console.print("  [yellow]skipped: supply an explicit --project-mapping for this project[/yellow]")
+                continue
+            session_reports.append((source_session.get("name"), report))
+            _record_trace_session_outcome(orchestrator, config, migrator, source_session, report)
+            _print_trace_reconciliation(report)
+        upgrade_rows.extend(migrator.upgrade_rows)
+        fidelity_notes |= migrator.fidelity_reduced
+
+    if ws_result:
+        orchestrator.clear_workspace_context()
+
+    if emit_upgrade_list and upgrade_rows:
+        _write_upgrade_list(emit_upgrade_list, upgrade_rows)
+
+    _print_trace_summary(session_reports, fidelity_notes, no_verify)
+    _display_resolution_summary(orchestrator)
+    _exit_for_remediation_if_needed(ctx, config, orchestrator)
+    orchestrator.cleanup()
+
+
+def _select_trace_sessions(config: Config, migrator, projects, select_all: bool) -> list:
+    """Resolve ``--project`` (name or ID), else offer the TUI over all projects.
+
+    A project given by ID is fetched directly. Enumerating every tracing
+    project on a busy deployment takes minutes, and naming one is the common
+    case for a trace migration.
+    """
+    if projects:
+        chosen = []
+        for value in projects:
+            session, reason = migrator.find_source_session(value)
+            if session:
+                chosen.append(session)
+            elif reason == "ambiguous":
+                console.print(
+                    f"[yellow]More than one source tracing project is named '{value}'; "
+                    f"pass its ID instead[/yellow]"
+                )
+            else:
+                console.print(f"[yellow]No source tracing project matched '{value}'[/yellow]")
+        return chosen
+    return _select_or_all(
+        config,
+        migrator.list_source_sessions(),
+        select_all=select_all,
+        title="Select Tracing Projects to Migrate",
+        columns=[
+            {"key": "name", "title": "Project", "width": 44},
+            {"key": "trace_tier", "title": "Tier", "width": 12},
+            {"key": "id", "title": "ID", "width": 38},
+        ],
+    )
+
+
+def _print_trace_preflight(migrator, config, max_age_days, window_days, max_field_bytes, no_verify, into_session_suffix):
+    """Report the destination's configuration before writing anything."""
+    max_runs, max_bytes = migrator.batch_limits()
+    table = Table(title="Destination pre-flight", show_header=True)
+    table.add_column("Setting")
+    table.add_column("Value")
+    table.add_column("Source")
+    table.add_row("Batch runs per request", str(max_runs), "GET /info (BATCH_INGEST_SIZE_LIMIT)")
+    table.add_row("Batch bytes per request", f"{max_bytes:,}", "GET /info (BATCH_INGEST_SIZE_LIMIT_BYTES)")
+    table.add_row("Max field bytes", f"{max_field_bytes:,}", "--max-field-bytes (not advertised by the destination)")
+    table.add_row("Range / window", f"{max_age_days:g}d / {window_days:g}d", "--max-age-days / --window")
+    table.add_row("Trace tier", "longlived" if not migrator.emit_upgrade_list else "left as-is (--emit-upgrade-list)", "destination session")
+    console.print(table)
+    if config.migration.dry_run:
+        console.print("[yellow]Dry run: no session creation, no canary, no ingest[/yellow]")
+    if no_verify:
+        console.print("[yellow]--no-verify: runs are reported as ingested, not verified; the completeness guarantee is off[/yellow]")
+    if into_session_suffix:
+        console.print(f"[dim]Migrating into separate projects suffixed '{into_session_suffix}'[/dim]")
+
+
+def _record_trace_session_outcome(orchestrator, config, migrator, source_session, report) -> None:
+    """One state item per project, carrying its reconciliation.
+
+    Deliberately not one per run: state is rewritten on every update, and the
+    per-run detail is already in the reconciliation counts.
+    """
+    item_id = _ensure_state_item(
+        orchestrator,
+        config,
+        "trace_session",
+        str(source_session["id"]),
+        source_session.get("name") or str(source_session["id"]),
+        metadata={"dest_session_id": report.dest_session_id},
+    )
+    evidence = {
+        "source_total": report.source_total,
+        "ingested": report.ingested,
+        "already_present": report.already_present,
+        "degraded": report.degraded,
+        "blocked": report.blocked,
+        "dest_session_id": report.dest_session_id,
+    }
+    if report.blocked:
+        migrator.mark_blocked(
+            item_id, "run_not_ingested",
+            next_action="Re-run `langsmith-migrator traces` for this project.",
+            evidence=evidence,
+        )
+    elif report.degraded:
+        migrator.mark_degraded(item_id, "migrated_with_reduced_fidelity", evidence=evidence)
+    else:
+        migrator.mark_migrated(item_id, evidence=evidence)
+
+
+def _print_trace_reconciliation(report) -> None:
+    console.print(
+        f"  source {report.source_total} = ingested {report.ingested}"
+        f" + already present {report.already_present}"
+        f" + degraded {report.degraded} + blocked {report.blocked}"
+        + (f"  [dim](destination also holds {report.extra_on_dest} run(s) the source did not)[/dim]" if report.extra_on_dest else "")
+    )
+
+
+def _print_trace_summary(session_reports, fidelity_notes, no_verify) -> None:
+    if not session_reports:
+        console.print("\n[yellow]No traces migrated[/yellow]")
+        return
+    table = Table(title="Trace migration", show_header=True)
+    for column in ("Project", "Source", "Ingested", "Present", "Degraded", "Blocked"):
+        table.add_column(column)
+    for name, r in session_reports:
+        table.add_row(name or "?", str(r.source_total), str(r.ingested), str(r.already_present), str(r.degraded), str(r.blocked))
+    console.print(table)
+    if no_verify:
+        console.print("[yellow]Completeness was not verified (--no-verify).[/yellow]")
+    if fidelity_notes:
+        # A run already on the destination is immutable, so there is no
+        # in-place repair: the only fix is to write into a different session.
+        console.print(
+            "[yellow]Fidelity was reduced for some runs. A fully ingested run cannot be modified, "
+            "so repair means re-migrating the affected window into a fresh destination project "
+            "(a new --into-session-suffix), "
+            + ", ".join(sorted(fidelity_notes))
+            + ".[/yellow]"
+        )
+
+
+def _write_upgrade_list(path: str, rows) -> None:
+    """Owner-only file of (dest_session_id, trace_id, start_time). No payload values."""
+    import os
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(target), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["dest_session_id", "trace_id", "start_time"])
+        writer.writerows(sorted(set(rows)))
+    console.print(f"Wrote {len(set(rows))} trace(s) to {target} for operator upgrade")
+    console.print(
+        "[yellow]Long-lived retention is NOT yet in effect for these traces: destination project tiers "
+        "were left as they were. Feed the list to POST /internal/runs/upgrade-trace-tier.[/yellow]"
+    )
+
+
+@cli.command()
 @ssl_option
 @click.option(
     "--retry-exhausted",
@@ -6281,6 +6634,15 @@ def resume(ctx, retry_exhausted):
     state = state_manager.load_session(session_id)
     if not state:
         console.print(f"[red]Failed to load session {session_id}[/red]")
+        return
+
+    # Trace migration derives its work from a destination diff per time window,
+    # so there is no checkpoint to resume from.
+    if any(item.type == "trace_session" for item in state.items.values()):
+        console.print(
+            "[yellow]This session migrated traces, which is stateless - there is no checkpoint to resume.[/yellow]\n"
+            "Re-run `langsmith-migrator traces` with the same options; finished windows produce an empty diff."
+        )
         return
 
     orchestrator = MigrationOrchestrator(config, state_manager)

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -6379,6 +6379,7 @@ def traces(
     upgrade_rows = []
     session_reports = []
     fidelity_notes = set()
+    failed_projects = []
 
     for src_ws, dst_ws in ws_pairs:
         if src_ws and dst_ws:
@@ -6407,9 +6408,20 @@ def traces(
 
         try:
             migrator.canary()
-        except TracePreflightError as exc:
+        except Exception as exc:
+            # Any pre-flight failure, not just a refused timestamp: a 403 on the
+            # scratch project used to escape as a raw traceback with no recorded
+            # outcome.
             console.print(f"[red]Pre-flight failed: {exc}[/red]")
             console.print("[red]Nothing was migrated.[/red]")
+            if not isinstance(exc, TracePreflightError):
+                migrator.record_issue(
+                    "blocked",
+                    "trace_preflight_failed",
+                    f"Pre-flight failed before any run was migrated: {str(exc)[:200]}",
+                    next_action="Resolve the destination error above and re-run `langsmith-migrator traces`.",
+                    evidence={"error": str(exc)[:500]},
+                )
             _display_resolution_summary(orchestrator)
             orchestrator.cleanup()
             ctx.exit(1)
@@ -6436,17 +6448,25 @@ def traces(
             continue
 
         for source_session in selected:
-            console.print(f"\n[bold]{source_session.get('name')}[/bold] ({source_session['id']})")
+            label = _trace_session_label(source_session)
+            console.print(f"\n[bold]{label}[/bold] ({source_session['id']})")
             try:
                 report = migrator.migrate_session(source_session)
-            except TracePreflightError as exc:
-                console.print(f"  [red]blocked: {exc}[/red]")
-                continue
-            except Exception as e:
-                console.print(f"  [red]failed: {e}[/red]")
+            except Exception as exc:
+                # Not just printed: a project that failed must leave a blocked
+                # outcome behind and fail the exit code, or a run that migrated
+                # nothing looks indistinguishable from a clean one.
+                blocked = isinstance(exc, TracePreflightError)
+                console.print(f"  [red]{'blocked' if blocked else 'failed'}: {exc}[/red]")
+                failed_projects.append((label, str(exc)))
+                _record_trace_session_failure(
+                    orchestrator, config, migrator, source_session,
+                    "trace_session_blocked" if blocked else "trace_session_failed", exc,
+                )
                 continue
             if report is None:
                 console.print("  [yellow]skipped: supply an explicit --project-mapping for this project[/yellow]")
+                failed_projects.append((label, "unresolved destination project"))
                 continue
             session_reports.append((source_session.get("name"), report))
             _record_trace_session_outcome(orchestrator, config, migrator, source_session, report)
@@ -6460,10 +6480,12 @@ def traces(
     if emit_upgrade_list and upgrade_rows:
         _write_upgrade_list(emit_upgrade_list, upgrade_rows)
 
-    _print_trace_summary(session_reports, fidelity_notes, no_verify)
+    _print_trace_summary(session_reports, fidelity_notes, no_verify, failed_projects)
     _display_resolution_summary(orchestrator)
     _exit_for_remediation_if_needed(ctx, config, orchestrator)
     orchestrator.cleanup()
+    if failed_projects:
+        ctx.exit(1)
 
 
 def _select_trace_sessions(config: Config, migrator, projects, select_all: bool) -> list:
@@ -6527,14 +6549,8 @@ def _record_trace_session_outcome(orchestrator, config, migrator, source_session
     Deliberately not one per run: state is rewritten on every update, and the
     per-run detail is already in the reconciliation counts.
     """
-    item_id = _ensure_state_item(
-        orchestrator,
-        config,
-        "trace_session",
-        str(source_session["id"]),
-        source_session.get("name") or str(source_session["id"]),
-        metadata={"dest_session_id": report.dest_session_id},
-    )
+    item_id = _trace_item_id(orchestrator, config, source_session,
+                             metadata={"dest_session_id": report.dest_session_id})
     evidence = {
         "source_total": report.source_total,
         "ingested": report.ingested,
@@ -6555,6 +6571,31 @@ def _record_trace_session_outcome(orchestrator, config, migrator, source_session
         migrator.mark_migrated(item_id, evidence=evidence)
 
 
+def _trace_session_label(source_session) -> str:
+    return source_session.get("name") or str(source_session["id"])
+
+
+def _trace_item_id(orchestrator, config, source_session, metadata=None):
+    return _ensure_state_item(
+        orchestrator,
+        config,
+        "trace_session",
+        str(source_session["id"]),
+        _trace_session_label(source_session),
+        metadata=metadata,
+    )
+
+
+def _record_trace_session_failure(orchestrator, config, migrator, source_session, code, exc) -> None:
+    """Persist a blocked outcome so remediation and the exit code can see it."""
+    migrator.mark_blocked(
+        _trace_item_id(orchestrator, config, source_session),
+        code,
+        next_action="Re-run `langsmith-migrator traces` for this project once the cause is resolved.",
+        evidence={"error": str(exc)[:500]},
+    )
+
+
 def _print_trace_reconciliation(report) -> None:
     console.print(
         f"  source {report.source_total} = ingested {report.ingested}"
@@ -6564,7 +6605,9 @@ def _print_trace_reconciliation(report) -> None:
     )
 
 
-def _print_trace_summary(session_reports, fidelity_notes, no_verify) -> None:
+def _print_trace_summary(session_reports, fidelity_notes, no_verify, failed_projects=()) -> None:
+    for name, err in failed_projects:
+        console.print(f"[red]x[/red] {name} did not migrate: {err[:160]}")
     if not session_reports:
         console.print("\n[yellow]No traces migrated[/yellow]")
         return

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -1776,7 +1776,12 @@ def _run_preflight(orchestrator, config: Config, resources: Iterable[str]) -> No
 
 
 def _display_resolution_summary(orchestrator) -> None:
-    """Print a consistent migration resolution summary."""
+    """Print a consistent migration resolution summary.
+
+    Counts and artifact locations only: the tool reports what happened and
+    never synthesises generic guidance to fill the gap when a migrator has
+    nothing specific to say.
+    """
     if not orchestrator.state:
         return
 
@@ -1800,22 +1805,6 @@ def _display_resolution_summary(orchestrator) -> None:
         console.print(f"  Remediation bundle: {bundle_display}")
     console.print("  Resume command: langsmith-migrator resume")
 
-    actionable_groups = orchestrator.state.get_actionable_groups()
-    if actionable_groups:
-        console.print("\n[bold]Actionable Next Steps[/bold]")
-        for group in actionable_groups[:5]:
-            item_count = len(group["items"])
-            if item_count == 1:
-                console.print(f"  • {group['subjects'][0]}: {group['next_action']}")
-            else:
-                affected = orchestrator.state.format_actionable_subjects(
-                    group["subjects"],
-                    max_items=3,
-                )
-                console.print(
-                    f"  • {group['label']} ({item_count} items: {affected}): {group['next_action']}"
-                )
-
 
 def _needs_operator_action(state) -> bool:
     """Return True when the session requires manual remediation or follow-up."""
@@ -1836,9 +1825,7 @@ def _exit_for_remediation_if_needed(ctx, config: Config, orchestrator) -> None:
         and orchestrator.state
         and _needs_operator_action(orchestrator.state)
     ):
-        console.print(
-            "\n[yellow]Manual or external follow-up is required. Review the remediation bundle and run `langsmith-migrator resume` after resolving the blockers.[/yellow]"
-        )
+        console.print("\n[yellow]Some items did not migrate; see the issues above.[/yellow]")
         ctx.exit(2)
 
 
@@ -6266,6 +6253,14 @@ def contexts(
     help="How far back to walk (the range). 180 days is the long-lived retention ceiling.",
 )
 @click.option(
+    "--max-age-stamp",
+    help=(
+        "Absolute lower bound instead of --max-age-days, e.g. 2026-08-27 or "
+        "2026-08-27T18:00:00Z. Prefer this for long runs and for resuming: a "
+        "relative age denotes a different instant every time it is evaluated."
+    ),
+)
+@click.option(
     "--window",
     "window_days",
     type=float,
@@ -6303,6 +6298,7 @@ def traces(
     projects,
     select_all,
     max_age_days,
+    max_age_stamp,
     window_days,
     max_field_bytes,
     no_verify,
@@ -6330,6 +6326,22 @@ def traces(
     display_banner()
     if not ensure_config(config):
         return
+
+    range_start = None
+    if max_age_stamp:
+        # Refuse rather than pick one: the two bounds disagree the moment the
+        # clock moves, and silently preferring either would be a trap.
+        if ctx.get_parameter_source("max_age_days").name != "DEFAULT":
+            console.print("[red]Error: --max-age-days and --max-age-stamp are mutually exclusive[/red]")
+            ctx.exit(1)
+            return
+        try:
+            range_start = _parse_age_stamp(max_age_stamp)
+        except ValueError as exc:
+            console.print(f"[red]Error: {exc}[/red]")
+            ctx.exit(1)
+            return
+        max_age_days = None
 
     project_id_map = _load_project_mapping_arg(project_mapping)
     if project_id_map is _PROJECT_MAPPING_ERROR:
@@ -6392,6 +6404,7 @@ def traces(
             orchestrator.state,
             config,
             max_age_days=max_age_days,
+            range_start=range_start,
             window_days=window_days,
             max_field_bytes=max_field_bytes,
             verify=not no_verify,
@@ -6404,7 +6417,7 @@ def traces(
             or _workspace_scoped_project_id_map(orchestrator, ws_result, src_ws)
             or (build_project_id_mapping_tui(orchestrator.source_client, orchestrator.dest_client) if map_projects else None),
         )
-        _print_trace_preflight(migrator, config, max_age_days, window_days, max_field_bytes, no_verify, into_session_suffix)
+        _print_trace_preflight(migrator, config, window_days, max_field_bytes, no_verify, into_session_suffix)
 
         try:
             migrator.canary()
@@ -6419,7 +6432,6 @@ def traces(
                     "blocked",
                     "trace_preflight_failed",
                     f"Pre-flight failed before any run was migrated: {str(exc)[:200]}",
-                    next_action="Resolve the destination error above and re-run `langsmith-migrator traces`.",
                     evidence={"error": str(exc)[:500]},
                 )
             _display_resolution_summary(orchestrator)
@@ -6468,9 +6480,15 @@ def traces(
                 console.print("  [yellow]skipped: supply an explicit --project-mapping for this project[/yellow]")
                 failed_projects.append((label, "unresolved destination project"))
                 continue
+            for reason in migrator.blocked_reasons:
+                console.print(f"  [red]blocked:[/red] {reason}")
+            del migrator.blocked_reasons[:]
             session_reports.append((source_session.get("name"), report))
             _record_trace_session_outcome(orchestrator, config, migrator, source_session, report)
-            _print_trace_reconciliation(report)
+            _print_trace_reconciliation(
+                report, migrator.batch_limits()[0],
+                verified=not no_verify and not config.migration.dry_run,
+            )
         upgrade_rows.extend(migrator.upgrade_rows)
         fidelity_notes |= migrator.fidelity_reduced
 
@@ -6522,7 +6540,18 @@ def _select_trace_sessions(config: Config, migrator, projects, select_all: bool)
     )
 
 
-def _print_trace_preflight(migrator, config, max_age_days, window_days, max_field_bytes, no_verify, into_session_suffix):
+def _human_duration(days: float) -> str:
+    """``0.01`` -> ``14m24s``. str(timedelta) would say ``0:14:24``."""
+    total = int(round(days * 86400))
+    if total <= 0:
+        return "0s"
+    d, rem = divmod(total, 86400)
+    h, rem = divmod(rem, 3600)
+    m, sec = divmod(rem, 60)
+    return "".join(f"{v}{u}" for v, u in ((d, "d"), (h, "h"), (m, "m"), (sec, "s")) if v)
+
+
+def _print_trace_preflight(migrator, config, window_days, max_field_bytes, no_verify, into_session_suffix):
     """Report the destination's configuration before writing anything."""
     max_runs, max_bytes = migrator.batch_limits()
     table = Table(title="Destination pre-flight", show_header=True)
@@ -6532,7 +6561,12 @@ def _print_trace_preflight(migrator, config, max_age_days, window_days, max_fiel
     table.add_row("Batch runs per request", str(max_runs), "GET /info (BATCH_INGEST_SIZE_LIMIT)")
     table.add_row("Batch bytes per request", f"{max_bytes:,}", "GET /info (BATCH_INGEST_SIZE_LIMIT_BYTES)")
     table.add_row("Max field bytes", f"{max_field_bytes:,}", "--max-field-bytes (not advertised by the destination)")
-    table.add_row("Range / window", f"{max_age_days:g}d / {window_days:g}d", "--max-age-days / --window")
+    table.add_row(
+        "Range / window",
+        f"{migrator.resolved_range_start().isoformat()} -> now\n"
+        f"window {window_days:g}d = {_human_duration(window_days)}",
+        ("--max-age-stamp" if migrator.range_start else "--max-age-days") + " / --window",
+    )
     table.add_row("Trace tier", "longlived" if not migrator.emit_upgrade_list else "left as-is (--emit-upgrade-list)", "destination session")
     console.print(table)
     if config.migration.dry_run:
@@ -6560,11 +6594,7 @@ def _record_trace_session_outcome(orchestrator, config, migrator, source_session
         "dest_session_id": report.dest_session_id,
     }
     if report.blocked:
-        migrator.mark_blocked(
-            item_id, "run_not_ingested",
-            next_action="Re-run `langsmith-migrator traces` for this project.",
-            evidence=evidence,
-        )
+        migrator.mark_blocked(item_id, "run_not_ingested", next_action="", evidence=evidence)
     elif report.degraded:
         migrator.mark_degraded(item_id, "migrated_with_reduced_fidelity", evidence=evidence)
     else:
@@ -6591,18 +6621,72 @@ def _record_trace_session_failure(orchestrator, config, migrator, source_session
     migrator.mark_blocked(
         _trace_item_id(orchestrator, config, source_session),
         code,
-        next_action="Re-run `langsmith-migrator traces` for this project once the cause is resolved.",
+        next_action="",  # the tool reports what happened, not what to do about it
         evidence={"error": str(exc)[:500]},
     )
 
 
-def _print_trace_reconciliation(report) -> None:
+def _print_trace_reconciliation(report, batch_runs: int, verified: bool = True) -> None:
     console.print(
         f"  source {report.source_total} = ingested {report.ingested}"
         f" + already present {report.already_present}"
         f" + degraded {report.degraded} + blocked {report.blocked}"
         + (f"  [dim](destination also holds {report.extra_on_dest} run(s) the source did not)[/dim]" if report.extra_on_dest else "")
     )
+    _print_trace_watermark(report, batch_runs, verified)
+
+
+def _parse_age_stamp(value: str):
+    """Parse --max-age-stamp as an ISO date or datetime, naive read as UTC."""
+    import datetime as _dt
+
+    try:
+        stamp = _dt.datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        raise ValueError(f"--max-age-stamp is not an ISO date/datetime: {value!r}") from None
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=_dt.timezone.utc)
+    if stamp >= _dt.datetime.now(_dt.timezone.utc):
+        raise ValueError(f"--max-age-stamp must be in the past, got {stamp.isoformat()}")
+    return stamp
+
+
+def _print_trace_watermark(report, batch_runs: int, verified: bool = True) -> None:
+    """Report the confirmed-complete span, and how to resume from it.
+
+    The resume point is the *latest* verified run, pulled back by the time one
+    ingest batch occupied: enough overlap that a boundary run cannot be
+    skipped, without re-walking the whole verified span. The overlap is sized
+    from the observed run density rather than guessed, and falls back to the
+    earliest timestamp when the whole span is smaller than one batch.
+    """
+    if not report.earliest:
+        # Only explain a *fidelity* reason here. With --dry-run or --no-verify
+        # there is simply nothing verified, and the run already said so at the
+        # top - claiming "degraded or blocked runs" would send the operator
+        # looking for problems that do not exist.
+        if report.source_total and verified:
+            console.print(
+                "  [yellow]no verified watermark: this project had degraded or blocked runs, "
+                "so no span can be claimed complete[/yellow]"
+            )
+        return
+    import datetime as _dt
+
+    earliest = _dt.datetime.fromisoformat(report.earliest)
+    latest = _dt.datetime.fromisoformat(report.latest)
+    fraction = 1.0
+    if report.verified_runs > batch_runs:
+        fraction = batch_runs / report.verified_runs
+    resume = latest - (latest - earliest) * fraction
+    console.print(
+        f"  verified complete from [bold]{report.earliest}[/bold] to {report.latest} "
+        f"({report.verified_runs} run(s))"
+    )
+    overlap = "the whole span" if fraction == 1.0 else f"~{batch_runs} run(s), one ingest batch"
+    # An absolute stamp, not a relative age: a float age would denote a
+    # different instant by the time a long run finishes.
+    console.print(f"  [dim]to continue from here: --max-age-stamp {resume.isoformat()} (redoing {overlap})[/dim]")
 
 
 def _print_trace_summary(session_reports, fidelity_notes, no_verify, failed_projects=()) -> None:
@@ -6612,23 +6696,16 @@ def _print_trace_summary(session_reports, fidelity_notes, no_verify, failed_proj
         console.print("\n[yellow]No traces migrated[/yellow]")
         return
     table = Table(title="Trace migration", show_header=True)
-    for column in ("Project", "Source", "Ingested", "Present", "Degraded", "Blocked"):
+    for column in ("Project", "Source", "Ingested", "Present", "Degraded", "Blocked", "Verified from"):
         table.add_column(column)
     for name, r in session_reports:
-        table.add_row(name or "?", str(r.source_total), str(r.ingested), str(r.already_present), str(r.degraded), str(r.blocked))
+        table.add_row(name or "?", str(r.source_total), str(r.ingested), str(r.already_present),
+                      str(r.degraded), str(r.blocked), r.earliest or "-")
     console.print(table)
     if no_verify:
         console.print("[yellow]Completeness was not verified (--no-verify).[/yellow]")
     if fidelity_notes:
-        # A run already on the destination is immutable, so there is no
-        # in-place repair: the only fix is to write into a different session.
-        console.print(
-            "[yellow]Fidelity was reduced for some runs. A fully ingested run cannot be modified, "
-            "so repair means re-migrating the affected window into a fresh destination project "
-            "(a new --into-session-suffix), "
-            + ", ".join(sorted(fidelity_notes))
-            + ".[/yellow]"
-        )
+        console.print("[yellow]Fidelity was reduced: " + "; ".join(sorted(fidelity_notes)) + ".[/yellow]")
 
 
 def _write_upgrade_list(path: str, rows) -> None:
@@ -6717,35 +6794,26 @@ def resume(ctx, retry_exhausted):
         )
         if retry_exhausted:
             console.print("[dim]Including items that used up their retry budget[/dim]")
-        actionable_groups = state.get_actionable_groups()
+        manual_items = [
+            item
+            for item in state.items.values()
+            if item.terminal_state
+            in (
+                ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value,
+                ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY.value,
+            )
+        ]
 
         console.print(f"\nResumable items: {len(resume_items)}")
-        console.print(
-            f"Checkpoint/manual items: {sum(len(group['items']) for group in actionable_groups)}"
-        )
+        console.print(f"Checkpoint/manual items: {len(manual_items)}")
 
-        if actionable_groups:
-            console.print("\n[bold]Items requiring manual attention:[/bold]")
-            for group in actionable_groups[:10]:
-                item_count = len(group["items"])
-                if item_count == 1:
-                    console.print(f"  • {group['subjects'][0]}: {group['next_action']}")
-                else:
-                    affected = state.format_actionable_subjects(
-                        group["subjects"],
-                        max_items=3,
-                    )
-                    console.print(
-                        f"  • {group['label']} ({item_count} items: {affected}): "
-                        f"{group['next_action']}"
-                    )
+        if manual_items:
+            console.print("\n[bold]Items that did not migrate:[/bold]")
+            for item in manual_items[:10]:
+                console.print(f"  • {item.name or item.id}: {item.outcome_code or item.terminal_state}")
 
         if not resume_items:
             console.print("\n[yellow]No items to resume automatically.[/yellow]")
-            if actionable_groups:
-                console.print(
-                    "[dim]Review the checkpoint items above and resolve them manually.[/dim]"
-                )
             return
 
         # Show what will be resumed

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -39,6 +39,7 @@ from ..core.migrators import (
     FleetWebhookMigrator,
 )
 from ..core.migrators.trace import TracePreflightError
+from ..core.trace_frames import DEFAULT_COMPRESS_LEVEL
 from ..core.migrators.user_role import (
     is_workspace_role_union_id,
     select_effective_workspace_role_id,
@@ -6281,6 +6282,28 @@ def contexts(
 @click.option("--no-verify", is_flag=True, help="Skip the confirming re-query after ingest (the pre-diff still runs)")
 @click.option("--verify-content-sample", type=int, default=100, show_default=True, help="Runs per window to content-check")
 @click.option("--skip-attachments", is_flag=True, help="Migrate runs without their attachments (recorded as degraded)")
+@click.option(
+    "--compress-level",
+    type=click.IntRange(1, 22),
+    default=DEFAULT_COMPRESS_LEVEL,
+    show_default=True,
+    help=(
+        "zstd level for the ingest body. 3 is nearly free; >=15 trades roughly "
+        "30x the CPU for ~16% fewer bytes, worth it only when bandwidth-bound."
+    ),
+)
+@click.option("--no-compress-upload", is_flag=True, help="Send the ingest body uncompressed")
+@click.option(
+    "--prefetch-windows",
+    type=click.IntRange(1, 32),
+    default=4,
+    show_default=True,
+    help=(
+        "How many windows to retrieve concurrently. Ingest stays serial and in "
+        "window order regardless. Peak memory is this many windows of payloads "
+        "plus the one being written, so shrink --window if it is too much."
+    ),
+)
 @click.option("--map-projects", is_flag=True, help="Interactively map source projects to destination projects")
 @click.option("--project-mapping", help='Headless project mapping: JSON object or file, {"src-id": "dest-id"}')
 @click.option(
@@ -6304,6 +6327,9 @@ def traces(
     no_verify,
     verify_content_sample,
     skip_attachments,
+    compress_level,
+    no_compress_upload,
+    prefetch_windows,
     map_projects,
     project_mapping,
     restore_session_tier,
@@ -6413,6 +6439,8 @@ def traces(
             restore_session_tier=restore_session_tier,
             into_session_suffix=into_session_suffix,
             emit_upgrade_list=emit_upgrade_list,
+            compress_level=None if no_compress_upload else compress_level,
+            prefetch_windows=prefetch_windows,
             project_id_map=project_id_map
             or _workspace_scoped_project_id_map(orchestrator, ws_result, src_ws)
             or (build_project_id_mapping_tui(orchestrator.source_client, orchestrator.dest_client) if map_projects else None),
@@ -6568,6 +6596,22 @@ def _print_trace_preflight(migrator, config, window_days, max_field_bytes, no_ve
         ("--max-age-stamp" if migrator.range_start else "--max-age-days") + " / --window",
     )
     table.add_row("Trace tier", "longlived" if not migrator.emit_upgrade_list else "left as-is (--emit-upgrade-list)", "destination session")
+    table.add_row(
+        "Ingest compression",
+        f"zstd level {migrator.compress_level}" if migrator.compress_level else "off",
+        migrator.compress_unavailable or "--compress-level / --no-compress-upload",
+    )
+    table.add_row("Page size", f"{migrator._page_limit['source']:,} runs", "/runs/query (lowered if capped)")
+    table.add_row(
+        "Window prefetch",
+        (
+            f"{migrator.prefetch_windows} concurrent\n"
+            f"up to {migrator.prefetch_windows + 1} windows resident"
+            if migrator.prefetch_windows > 1
+            else "serial"
+        ),
+        "--prefetch-windows (ingest stays serial and in order)",
+    )
     console.print(table)
     if config.migration.dry_run:
         console.print("[yellow]Dry run: no session creation, no canary, no ingest[/yellow]")

--- a/langsmith_migrator/core/migrators/__init__.py
+++ b/langsmith_migrator/core/migrators/__init__.py
@@ -12,6 +12,7 @@ from .issue import IssueMigrator
 from .chart import ChartMigrator
 from .model_price_map import ModelPriceMapMigrator
 from .user_role import UserRoleMigrator
+from .trace import TraceMigrator
 from .orchestrator import MigrationOrchestrator
 from .fleet_skill import FleetSkillMigrator
 from .fleet_mcp_server import FleetMcpServerMigrator
@@ -37,6 +38,7 @@ __all__ = [
     "ChartMigrator",
     "ModelPriceMapMigrator",
     "UserRoleMigrator",
+    "TraceMigrator",
     "MigrationOrchestrator",
     "FleetSkillMigrator",
     "FleetMcpServerMigrator",

--- a/langsmith_migrator/core/migrators/trace.py
+++ b/langsmith_migrator/core/migrators/trace.py
@@ -27,17 +27,29 @@ Two backend facts drive most of the shape here:
 from __future__ import annotations
 
 import json
+import re
+import threading
 import time
 import uuid
+from dataclasses import dataclass
+from dataclasses import field as _field
 from datetime import datetime, timezone
+from collections import deque
+from concurrent.futures import Future, ThreadPoolExecutor
 from tempfile import SpooledTemporaryFile
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple
+from typing import Any, Deque, Dict, Iterator, List, Optional, Sequence, Set, Tuple
 from urllib.parse import urlparse
 
 import requests
 from langsmith import Client
 
 from ..api_client import APIError, NotFoundError
+from ..trace_frames import (
+    DEFAULT_COMPRESS_LEVEL,
+    CompiledFrame,
+    compile_frame,
+    unavailable_reason,
+)
 from ..trace_domain import (
     ATTACHMENT_PREFIX,
     LONGLIVED,
@@ -60,9 +72,20 @@ from ..trace_domain import (
 )
 from .base import BaseMigrator
 
-# Measured on a real deployment: 2000 IDs per /runs/query is fine, 5000 returns
-# 503. Half the safe value, so a slow shard has headroom.
+# The binding constraint is the *response* size, not the ID count: 500 IDs of a
+# heavy project's full payloads is ~65 MB and a gateway rejects it with a 502 in
+# under ten seconds, while 500 IDs of a light one is fine. So this is a starting
+# point that halves itself on rejection, down to _ID_CHUNK_MIN.
 _ID_CHUNK = 500
+_ID_CHUNK_MIN = 25
+
+# Both real deployments cap /runs/query at 1000. A deployment that caps lower
+# says so in the 400, so the limit self-corrects rather than being probed.
+# Measured: an ``id``-filtered query ignores the limit entirely (2000 IDs at
+# limit=10 returned all 2000 in one page). Not relied on - ID chunks are held
+# at or under the limit so a request never depends on that leniency.
+_PAGE_LIMIT = 1000
+_PAGE_CAP_RE = re.compile(r"maximum allowed value of (\d+)")
 
 # Not advertised by /info (only the batch limits are), so it matches the
 # backend's own MAX_ATTACHMENT_SIZE_BYTES default and is a guard, not a truth.
@@ -72,6 +95,48 @@ _VERIFY_ATTEMPTS = 4
 _VERIFY_BACKOFF = 3.0
 
 _CANARY_SESSION = "langsmith-migrator-canary"
+
+
+def _size_connection_pools(*clients_and_size) -> None:
+    """Give each client a connection pool that fits the reader count.
+
+    urllib3 defaults to 10, and a full pool silently drops connections rather
+    than queueing, which shows up as ChunkedEncodingError under load.
+
+    The sessions themselves stay shared across the prepare workers. urllib3's
+    pools are thread-safe; what is not is mutating session state, and the only
+    mutable piece in play is the cookie jar - measured empty, as neither
+    deployment sends Set-Cookie on the endpoints this migrator uses. Headers
+    are mutated only on the destination write session, which is main-thread
+    only.
+    """
+    *clients, workers = clients_and_size
+    adapter = requests.adapters.HTTPAdapter(
+        pool_connections=max(10, workers * 2), pool_maxsize=max(10, workers * 2)
+    )
+    for client in clients:
+        session = getattr(client, "session", None)
+        if session is not None and hasattr(session, "mount"):
+            session.mount("https://", adapter)
+            session.mount("http://", adapter)
+
+
+def _response_too_large(error: Exception) -> bool:
+    """Whether a failure looks like "that response was too big to serve".
+
+    The gateway in front of LangSmith answers 502 (or 413) on an oversized
+    response body rather than saying so, and it does it fast - there is nothing
+    to distinguish it from a genuine outage except that retrying at the same
+    size keeps failing, which the retry layer has already established.
+    """
+    status = getattr(error, "status_code", None)
+    return status in (413, 502, 503)
+
+
+def _page_limit_cap(error: Exception) -> Optional[int]:
+    """The page cap a deployment advertises when it rejects our limit."""
+    match = _PAGE_CAP_RE.search(str(error))
+    return int(match.group(1)) if match else None
 
 
 def _raise_if_tier_denied(error: Exception) -> None:
@@ -88,6 +153,31 @@ def _raise_if_tier_denied(error: Exception) -> None:
         )
 
 
+
+
+@dataclass
+class SlicePrepared:
+    """One slice's work, built off the main thread and committed on it.
+
+    Findings accumulate here rather than on the migrator so a worker never
+    writes shared state; ``commit_slice`` merges them in window order.
+    """
+
+    window: Window
+    src_id: str
+    dst_id: str
+    plan: SlicePlan
+    population: List[Dict[str, Any]]
+    # (payloads, pre-compiled frame). The payloads are kept so a rejected batch
+    # can still be split to isolate one bad run; that is what bounds peak
+    # memory to prefetch x window, and why --window is the knob for it.
+    batches: List[Tuple[List[Dict[str, Any]], Optional[CompiledFrame]]] = _field(default_factory=list)
+    digests: Dict[str, Dict[str, str]] = _field(default_factory=dict)
+    degraded: Dict[str, Set[str]] = _field(default_factory=dict)
+    fidelity_notes: Set[str] = _field(default_factory=set)
+    upgrade_rows: List[Tuple[str, str, str]] = _field(default_factory=list)
+    # (issue_class, code, summary, evidence), replayed through record_issue.
+    issues: List[Tuple[str, str, str, Dict[str, Any]]] = _field(default_factory=list)
 
 
 class TracePreflightError(RuntimeError):
@@ -115,6 +205,8 @@ class TraceMigrator(BaseMigrator):
         into_session_suffix: Optional[str] = None,
         emit_upgrade_list: Optional[str] = None,
         project_id_map: Optional[Dict[str, str]] = None,
+        compress_level: Optional[int] = DEFAULT_COMPRESS_LEVEL,
+        prefetch_windows: int = 4,
     ):
         super().__init__(source_client, dest_client, state, config)
         self.max_age_days = max_age_days
@@ -144,6 +236,26 @@ class TraceMigrator(BaseMigrator):
         # Human-readable reasons for blocked runs, so the CLI can explain a
         # blocked count instead of only recording it into state.
         self.blocked_reasons: List[str] = []
+
+        # Per side: the two deployments need not cap /runs/query alike.
+        self._page_limit = {"source": _PAGE_LIMIT, "dest": _PAGE_LIMIT}
+        # Shrinks itself when a project's payloads make the response too big.
+        self._id_chunk = _ID_CHUNK
+
+        # None = send uncompressed through the SDK's public path. Resolved
+        # once, after the client exists, so a missing SDK internal or a
+        # destination without the feature degrades instead of failing per batch.
+        self.compress_level = compress_level
+        self.compress_unavailable: Optional[str] = None
+
+        # How many windows may be retrieved concurrently. Ingest stays serial
+        # whatever this is; only the reading ahead is parallel. Peak memory is
+        # roughly this many windows of payloads, so --window trades it back.
+        self.prefetch_windows = max(1, prefetch_windows)
+        self._main_thread = threading.get_ident()
+        # Sized to the readers: the default pool of 10 would churn connections
+        # once several windows are in flight.
+        _size_connection_pools(source_client, dest_client, self.prefetch_windows)
 
         # Blobs are proxied by whichever deployment stores them, so the
         # allow-list is per side: the destination's read-back URLs live on the
@@ -181,6 +293,10 @@ class TraceMigrator(BaseMigrator):
             omit_traced_runtime_info=True,
             tracing_error_callback=self._ingest_errors.append,
         )
+        if self.compress_level is not None:
+            self.compress_unavailable = unavailable_reason(self.dest_ls_client)
+            if self.compress_unavailable:
+                self.compress_level = None
 
     def resolved_range_start(self) -> datetime:
         """Absolute lower bound of this run's walk, fixed for the whole run."""
@@ -241,14 +357,24 @@ class TraceMigrator(BaseMigrator):
             "trace_filter": trace_filter,
             "start_time": run_start,
             "select": list(select),
-            "limit": 100,
         }
         if ids is not None:
             body["id"] = [str(i) for i in ids]
-        side = "source" if client is self.source else "dest  "
+        side = "source" if client is self.source else "dest"
+        body["limit"] = self._page_limit[side]
         page_num, seen = 0, 0
         while True:
-            response = client.post("/runs/query", body) or {}
+            try:
+                response = client.post("/runs/query", body) or {}
+            except APIError as exc:
+                cap = _page_limit_cap(exc)
+                if cap is None or cap >= body["limit"]:
+                    raise
+                # This deployment pages smaller than we asked. Adopt its
+                # number for the rest of the run and re-send.
+                self._page_limit[side] = cap
+                body = {**body, "limit": cap}
+                continue
             runs = response.get("runs") or []
             page_num += 1
             seen += len(runs)
@@ -257,7 +383,7 @@ class TraceMigrator(BaseMigrator):
                 # Kept under 80 columns: a wrapped progress line is worse
                 # than a terse one.
                 self.console.print(
-                    f"[dim]  query {side} p{page_num:<4}"
+                    f"[dim]  query {side:<6} p{page_num:<4}"
                     f"runs {n:>4} | traces {traces:>4} | {self._human(size):>9} | "
                     f"total {seen:>6}[/dim]"
                 )
@@ -290,12 +416,37 @@ class TraceMigrator(BaseMigrator):
     def fetch_runs(
         self, client, session_id: str, window: Window, run_ids: Sequence[str]
     ) -> Iterator[Dict[str, Any]]:
-        """Full payloads for a set of IDs, chunked so no request is oversized."""
+        """Full payloads for a set of IDs, chunked so no response is oversized.
+
+        A chunk is materialised before being yielded so an oversized response
+        can be retried at half the size without double-yielding what the failed
+        attempt had already produced.
+        """
+        side = "source" if client is self.source else "dest"
         ids = list(run_ids)
-        for start in range(0, len(ids), _ID_CHUNK):
-            yield from self._query_runs(
-                client, session_id, window, select=RUN_QUERY_SELECT, ids=ids[start : start + _ID_CHUNK]
-            )
+        start = 0
+        while start < len(ids):
+            chunk = min(self._id_chunk, self._page_limit[side])
+            try:
+                page = list(
+                    self._query_runs(
+                        client, session_id, window, select=RUN_QUERY_SELECT, ids=ids[start : start + chunk]
+                    )
+                )
+            except APIError as exc:
+                if not _response_too_large(exc) or chunk <= _ID_CHUNK_MIN:
+                    raise
+                # Retries at this size are already exhausted, so the size is
+                # the problem. Halve it and keep it for the rest of the run.
+                self._id_chunk = max(_ID_CHUNK_MIN, chunk // 2)
+                self.log(
+                    f"  {chunk} IDs per request was refused ({exc.status_code}); "
+                    f"continuing at {self._id_chunk}",
+                    "warning",
+                )
+                continue
+            yield from page
+            start += chunk
 
     # ------------------------------------------------------------------
     # Blobs
@@ -399,8 +550,13 @@ class TraceMigrator(BaseMigrator):
             and len(json.dumps(payload[field], default=str)) > self.max_field_bytes
         ]
 
-    def ingest(self, payloads: List[Dict[str, Any]]) -> List[Tuple[str, str]]:
+    def ingest(
+        self, payloads: List[Dict[str, Any]], frame: Optional[CompiledFrame] = None
+    ) -> List[Tuple[str, str]]:
         """Send one batch, isolating a bad run by binary split.
+
+        ``frame`` is a body compiled earlier, off this thread. A split has to
+        compile its halves here, since the parent's frame covers the whole batch.
 
         Returns ``[(run_id, error)]`` for runs that could not be ingested.
 
@@ -410,6 +566,9 @@ class TraceMigrator(BaseMigrator):
         """
         if not payloads or self.config.migration.dry_run:
             return []
+        # Ordered, serial, single-threaded is the whole basis of "a failure
+        # leaves no gap". Fail loudly rather than quietly losing that.
+        assert threading.get_ident() == self._main_thread, "ingest must run on the main thread"
         n, traces, size = self._shape(payloads)
         # Deliberately louder than the query lines around it: this is the only
         # step that writes, and it is otherwise invisible - multipart_ingest
@@ -422,18 +581,24 @@ class TraceMigrator(BaseMigrator):
         del self._ingest_errors[:]
         del self._ingest_responses[:]
         try:
-            self.dest_ls_client.multipart_ingest(create=payloads)
+            self._send(payloads, frame)
             error = self._ingest_errors[0] if self._ingest_errors else None
         except Exception as exc:  # pragma: no cover - defensive
             error = exc
         self._report_ingest_responses()
         conflict = next((body for status, body in self._ingest_responses if status == 409), None)
         if conflict is not None:
-            # A 409 rejects every payload in the request ("duplicate run create
-            # requests are not supported"), so it is not a one-bad-apple case:
-            # splitting would just repeat the same rejection per run. It also
-            # is NOT replay success - the runs exist somewhere on the tenant,
-            # but not in the project we asked for.
+            # A 409 rejects the whole request, so splitting would only repeat
+            # it per run. What it does NOT say is where those runs are: the
+            # duplicate may be a copy in another project (a real rejection) or
+            # this very request's own earlier attempt, which landed. Only the
+            # destination can tell the two apart, so when verification is going
+            # to ask anyway, defer to it rather than guessing "blocked".
+            if self.verify:
+                self.console.print(
+                    "[yellow]  ==> 409 on ingest; leaving the verdict to verification[/yellow]"
+                )
+                return []
             return [(str(p["id"]), f"HTTP 409: {conflict}") for p in payloads]
         if error is None:
             swallowed = next(((st, bd) for st, bd in self._ingest_responses if st >= 300), None)
@@ -448,6 +613,29 @@ class TraceMigrator(BaseMigrator):
             f"[yellow]  ==> batch of {len(payloads)} rejected; splitting to isolate the bad run[/yellow]"
         )
         return self.ingest(payloads[:mid]) + self.ingest(payloads[mid:])
+
+    def _send(self, payloads: List[Dict[str, Any]], frame: Optional[CompiledFrame] = None) -> None:
+        """Post one batch, compressing unless that is unavailable or refused.
+
+        ``frame`` is a body already compiled elsewhere; without one it is
+        compiled here. A split re-compiles, which is why this takes both.
+        """
+        if self.compress_level is None:
+            self.dest_ls_client.multipart_ingest(create=payloads)
+            return
+        if frame is None or set(frame.run_ids) != {str(p["id"]) for p in payloads}:
+            frame = compile_frame(self.dest_ls_client, payloads, self.compress_level)
+        self.console.print(
+            f"[dim]      zstd L{self.compress_level}: {self._human(frame.sizes[0])}"
+            f" -> {self._human(frame.sizes[1])}"
+            f" ({frame.sizes[0] / max(frame.sizes[1], 1):.1f}x)[/dim]"
+        )
+        # attempts=1 deliberately. Ingest is not idempotent - a run id is
+        # write-once per tenant - so a blind retry of a request whose outcome is
+        # unknown (a slow, large batch that the server did accept) earns a 409
+        # and makes a landed run look rejected. Verification establishes the
+        # truth instead; a genuinely lost batch shows up as missing there.
+        self.dest_ls_client._send_compressed_multipart_req(frame.stream, frame.sizes, attempts=1)
 
     def _report_ingest_responses(self) -> None:
         """Show what the multipart endpoint answered.
@@ -713,14 +901,22 @@ class TraceMigrator(BaseMigrator):
     # ------------------------------------------------------------------
     # The unit of work
     # ------------------------------------------------------------------
-    def migrate_slice(
+    def prepare_slice(
         self, source_session: Dict[str, Any], dest_session: Dict[str, Any], window: Window
-    ) -> Reconciliation:
-        """Diff, ingest the difference, confirm it is empty, sample content."""
+    ) -> SlicePrepared:
+        """Everything up to the write: diff, fetch, adapt, compile.
+
+        Runs off the main thread, so it touches no shared state - findings
+        accumulate into the returned value and are merged by ``commit_slice``.
+        The exceptions are ``self._page_limit`` and ``self._id_chunk``: both are
+        only ever lowered, toward a bound the server dictated, so concurrent
+        writes converge on the same value and a lost update just means one more
+        rejection before it sticks.
+        """
         src_id, dst_id = str(source_session["id"]), str(dest_session["id"])
         population = self.slice_runs(self.source, src_id, window)
         if not population:
-            return Reconciliation(src_id, dst_id, window.label(), 0, 0, 0, 0, 0)
+            return SlicePrepared(window, src_id, dst_id, plan_slice(set(), set()), [])
         source_ids = {str(r["id"]) for r in population}
 
         # With --emit-upgrade-list the destination sessions stay at their
@@ -731,13 +927,13 @@ class TraceMigrator(BaseMigrator):
             if self.config.migration.dry_run
             else self.long_lived_run_ids(self.dest, dst_id, window, tier_filter=not self.emit_upgrade_list)
         )
-        plan = plan_slice(source_ids, dest_ids)
+        prepared = SlicePrepared(window, src_id, dst_id, plan_slice(source_ids, dest_ids), population)
 
         if self.emit_upgrade_list:
             # Derived from the window's source population, not the diff: built
             # from the diff, a re-run whose differences are all empty would
             # emit an empty list.
-            self.upgrade_rows.extend(
+            prepared.upgrade_rows.extend(
                 (dst_id, str(r["trace_id"]), str(r["start_time"]))
                 for r in population
                 if str(r.get("trace_id")) == str(r.get("id"))
@@ -745,31 +941,107 @@ class TraceMigrator(BaseMigrator):
             # Reported against the whole population for the same reason, and
             # kept out of the reconciliation buckets so the parts still
             # partition the source total exactly once.
-            self.record_issue(
-                "degraded",
-                "longlived_pending_operator_upgrade",
-                f"{len(source_ids)} run(s) in {window.label()} are not yet long-lived: "
-                "the destination project was left at its existing tier",
-                evidence={"window": window.label(), "count": len(source_ids), "dest_session_id": dst_id},
+            prepared.issues.append(
+                (
+                    "degraded",
+                    "longlived_pending_operator_upgrade",
+                    f"{len(source_ids)} run(s) in {window.label()} are not yet long-lived: "
+                    "the destination project was left at its existing tier",
+                    {"window": window.label(), "count": len(source_ids), "dest_session_id": dst_id},
+                )
             )
 
-        degraded: Dict[str, Set[str]] = {}
+        self._build_batches(prepared)
+        return prepared
+
+    def _build_batches(self, prepared: SlicePrepared) -> None:
+        """Fetch and adapt the diff into ready-to-send batches."""
+        if not prepared.plan.to_ingest:
+            return
+        payloads: List[Dict[str, Any]] = []
+        for run in self.fetch_runs(
+            self.source, prepared.src_id, prepared.window, sorted(prepared.plan.to_ingest)
+        ):
+            run_id = str(run["id"])
+            overrides, issues = self.materialise(run)
+            payload_obj, dropped = to_ingest_payload(run, prepared.dst_id, overrides)
+            payload = payload_obj.as_dict()
+
+            oversized = self._oversized_fields(payload)
+            if oversized:
+                # The backend stubs an oversized field rather than rejecting
+                # it, so this run must not be reported as fully migrated.
+                prepared.degraded.setdefault("payload_oversized_for_destination", set()).add(run_id)
+                prepared.fidelity_notes.add("payloads exceeded --max-field-bytes")
+                continue
+
+            codes = set(issues)
+            if dropped:
+                codes.add("run_example_link_dropped")
+            for code in codes:
+                prepared.degraded.setdefault(code, set()).add(run_id)
+                if code in ("attachment_fetch_failed", "attachment_host_rejected"):
+                    prepared.fidelity_notes.add("some source blobs could not be fetched")
+
+            # Before compiling: _run_transform mutates the payload in place.
+            if len(prepared.digests) < self.verify_content_sample:
+                prepared.digests[run_id] = self._digest_of(run, overrides)
+            payloads.append(payload)
+
+        max_runs, max_bytes = self.batch_limits()
+        for batch in batch_traces(
+            group_into_traces(payloads), max_runs=max_runs, max_bytes=max_bytes, size_of=self._size_of
+        ):
+            frame = (
+                None
+                if self.compress_level is None or self.config.migration.dry_run
+                else compile_frame(self.dest_ls_client, batch, self.compress_level)
+            )
+            prepared.batches.append((batch, frame))
+
+    def commit_slice(self, prepared: SlicePrepared) -> Reconciliation:
+        """Write one prepared slice, confirm it, and account for it.
+
+        Main thread only, and called in window order, so a failure leaves every
+        earlier window complete rather than a gap.
+        """
+        src_id, dst_id, window, plan = prepared.src_id, prepared.dst_id, prepared.window, prepared.plan
+        if not prepared.population:
+            return Reconciliation(src_id, dst_id, window.label(), 0, 0, 0, 0, 0)
+
+        self.upgrade_rows.extend(prepared.upgrade_rows)
+        self.fidelity_reduced |= prepared.fidelity_notes
+        for issue_class, code, summary, evidence in prepared.issues:
+            self.record_issue(issue_class, code, summary, evidence=evidence)
+
+        degraded = prepared.degraded
         blocked: Set[str] = set()
-        digests = self._ingest_plan(src_id, dst_id, window, plan, degraded, blocked)
+        rejected: Dict[str, Set[str]] = {}
+        for batch, frame in prepared.batches:
+            for run_id, error in self.ingest(batch, frame=frame):
+                blocked.add(run_id)
+                rejected.setdefault(str(error), set()).add(run_id)
+        # Grouped by cause: twenty runs refused for one reason is one fact, not
+        # twenty truncated lines.
+        for error, ids in rejected.items():
+            self._record_blocked(
+                window, ids, "run_ingest_rejected",
+                f"{len(ids)} run(s) refused by the destination on ingest: {error}",
+            )
 
         if self.verify and plan.to_ingest and not self.config.migration.dry_run:
             still_missing = self._confirm(dst_id, window, plan.to_ingest - blocked)
             if still_missing:
                 blocked |= still_missing
                 self._block_runs(window, still_missing, dst_id)
-            if digests:
-                self._check_content(dst_id, window, digests, degraded)
+            if prepared.digests:
+                self._check_content(dst_id, window, prepared.digests, degraded)
 
         self._report_degraded(window, degraded)
 
         # A run can be both degraded and blocked; blocked wins, so the parts
         # stay a partition of the source total.
-        degraded_ids = set().union(*degraded.values())
+        degraded_ids = set().union(*degraded.values()) if degraded else set()
         degraded_only = degraded_ids - blocked
         # Only a wholly clean slice yields a watermark: a slice that degraded
         # or blocked anything cannot claim "everything up to here is complete".
@@ -778,12 +1050,12 @@ class TraceMigrator(BaseMigrator):
         # ran: --no-verify skips it, and a dry run wrote nothing to confirm.
         complete = (plan.to_ingest | plan.already_present) - blocked - degraded_ids
         clean = not (blocked or degraded_ids) and self.verify and not self.config.migration.dry_run
-        earliest, latest = verified_bounds(population, complete) if clean else (None, None)
+        earliest, latest = verified_bounds(prepared.population, complete) if clean else (None, None)
         return Reconciliation(
             session_id=src_id,
             dest_session_id=dst_id,
             window=window.label(),
-            source_total=len(source_ids),
+            source_total=len(prepared.population),
             ingested=len(plan.to_ingest) - len(degraded_only) - len(blocked),
             already_present=len(plan.already_present),
             degraded=len(degraded_only),
@@ -794,63 +1066,11 @@ class TraceMigrator(BaseMigrator):
             verified_runs=len(complete) if clean else 0,
         )
 
-    def _ingest_plan(
-        self,
-        src_id: str,
-        dst_id: str,
-        window: Window,
-        plan: SlicePlan,
-        degraded: Dict[str, Set[str]],
-        blocked: Set[str],
-    ) -> Dict[str, Dict[str, str]]:
-        """Fetch, adapt and send the diff. Returns digests for the sampled runs."""
-        digests: Dict[str, Dict[str, str]] = {}
-        if not plan.to_ingest:
-            return digests
-
-        prepared: List[Dict[str, Any]] = []
-        for run in self.fetch_runs(self.source, src_id, window, sorted(plan.to_ingest)):
-            run_id = str(run["id"])
-            overrides, issues = self.materialise(run)
-            payload_obj, dropped = to_ingest_payload(run, dst_id, overrides)
-            payload = payload_obj.as_dict()
-
-            oversized = self._oversized_fields(payload)
-            if oversized:
-                # The backend stubs an oversized field rather than rejecting
-                # it, so this run must not be reported as fully migrated.
-                degraded.setdefault("payload_oversized_for_destination", set()).add(run_id)
-                self.fidelity_reduced.add("payloads exceeded --max-field-bytes")
-                continue
-
-            codes = set(issues)
-            if dropped:
-                codes.add("run_example_link_dropped")
-            for code in codes:
-                degraded.setdefault(code, set()).add(run_id)
-                if code in ("attachment_fetch_failed", "attachment_host_rejected"):
-                    self.fidelity_reduced.add("some source blobs could not be fetched")
-
-            if len(digests) < self.verify_content_sample:
-                digests[run_id] = self._digest_of(run, overrides)
-            prepared.append(payload)
-
-        max_runs, max_bytes = self.batch_limits()
-        rejected: Dict[str, Set[str]] = {}
-        for batch in batch_traces(
-            group_into_traces(prepared), max_runs=max_runs, max_bytes=max_bytes, size_of=self._size_of
-        ):
-            for run_id, error in self.ingest(batch):
-                blocked.add(run_id)
-                rejected.setdefault(str(error), set()).add(run_id)
-        # Grouped by cause: twenty runs refused for one reason is one fact, not
-        # twenty truncated lines.
-        for error, ids in rejected.items():
-            self._record_blocked(
-                window, ids, "run_ingest_rejected",
-                f"{len(ids)} run(s) refused by the destination on ingest: {error}",
-            )
-        return digests
+    def migrate_slice(
+        self, source_session: Dict[str, Any], dest_session: Dict[str, Any], window: Window
+    ) -> Reconciliation:
+        """Prepare and commit one slice, without look-ahead."""
+        return self.commit_slice(self.prepare_slice(source_session, dest_session, window))
 
     @staticmethod
     def _digest_of(run: Dict[str, Any], overrides: Dict[str, Any]) -> Dict[str, str]:
@@ -982,8 +1202,8 @@ class TraceMigrator(BaseMigrator):
         try:
             slices = []
             end = now or datetime.now(timezone.utc)
-            for window in iter_windows(self.resolved_range_start(), end, self.window_days):
-                sliced = self.migrate_slice(source_session, dest_session, window)
+            windows = iter_windows(self.resolved_range_start(), end, self.window_days)
+            for sliced in self._walk_windows(source_session, dest_session, windows):
                 slices.append(sliced)
                 if sliced.source_total:
                     # Per-slice detail is verbose-only: the range can be 180
@@ -999,6 +1219,48 @@ class TraceMigrator(BaseMigrator):
             return recon
         finally:
             self._settle_tier(dest_session, prior_tier, source_session.get("trace_tier"), recon)
+
+    def _walk_windows(
+        self, source_session: Dict[str, Any], dest_session: Dict[str, Any], windows
+    ) -> Iterator[Reconciliation]:
+        """Prepare up to ``prefetch_windows`` slices at once; commit in order.
+
+        Retrieval is the slow half and parallelises cleanly. Ingest does not:
+        committing out of order would let a later window land while an earlier
+        one is missing, so a failure would leave a hole rather than a clean
+        prefix. Windows are therefore committed strictly oldest-first, and the
+        first failure stops the walk with every earlier window complete - which
+        is what makes the watermark a claim worth printing.
+
+        A failure still waits for the preparations already in flight, since a
+        thread mid-request cannot be interrupted; nothing further is committed.
+        """
+        if self.prefetch_windows <= 1:
+            for window in windows:
+                yield self.migrate_slice(source_session, dest_session, window)
+            return
+
+        pending: Deque[Future] = deque()
+        with ThreadPoolExecutor(
+            max_workers=self.prefetch_windows, thread_name_prefix="trace-prepare"
+        ) as pool:
+            def submit_next() -> None:
+                # Main thread only: ``windows`` is a generator, and advancing
+                # one from several threads is not safe.
+                window = next(windows, None)
+                if window is not None:
+                    pending.append(pool.submit(self.prepare_slice, source_session, dest_session, window))
+
+            for _ in range(self.prefetch_windows):
+                submit_next()
+            while pending:
+                prepared = pending.popleft().result()  # in-order: raises here on failure
+                # Refilled before committing, not after: the commit is the slow
+                # serial POST, and that is exactly when readers should be busy.
+                # Peak residency is therefore prefetch_windows in flight plus
+                # the one being written.
+                submit_next()
+                yield self.commit_slice(prepared)
 
     def _settle_tier(
         self,

--- a/langsmith_migrator/core/migrators/trace.py
+++ b/langsmith_migrator/core/migrators/trace.py
@@ -15,9 +15,10 @@ and finished windows produce an empty diff. ``resume`` does not apply.
 
 Two backend facts drive most of the shape here:
 
-* Run identity on the destination is ``(tenant_id, session_id, start_time,
-  id)``, so preserving IDs and timestamps is what makes replay an upsert - and
-  why migrating into the *same* tenant is refused outright.
+* A run id is write-once per tenant: re-sending one is refused with ``409 Run
+  create payload already received``, not upserted. Idempotency comes from the ID
+  diff never re-sending a run the destination already holds - which is also why
+  migrating into the *same* tenant is refused outright.
 * There is no per-run trace-tier field on the ingest contract. The destination
   *session's* tier is the only lever, and it must be correct at ingest time
   because the row TTL and the blob key prefix are both baked in at insert.
@@ -28,7 +29,7 @@ from __future__ import annotations
 import json
 import time
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from tempfile import SpooledTemporaryFile
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple
 from urllib.parse import urlparse
@@ -52,8 +53,10 @@ from ..trace_domain import (
     iter_windows,
     payload_digest,
     plan_slice,
+    resolve_range_start,
     resolve_window_bounds,
     to_ingest_payload,
+    verified_bounds,
 )
 from .base import BaseMigrator
 
@@ -67,15 +70,6 @@ _MAX_ATTACHMENT_BYTES = 200 * 1024 * 1024
 
 _VERIFY_ATTEMPTS = 4
 _VERIFY_BACKOFF = 3.0
-
-_DEGRADED_ACTIONS = {
-    "attachment_fetch_failed": "Once the source blob store is reachable, re-migrate this window into a fresh destination project.",
-    "attachment_host_rejected": "The source returned a blob URL off its own host; investigate, then re-migrate into a fresh destination project.",
-    "attachments_skipped": "Re-migrate this window into a fresh destination project without --skip-attachments.",
-    "payload_oversized_for_destination": "Raise MAX_FIELD_SIZE_BYTES on the destination, set a matching --max-field-bytes, and re-migrate into a fresh destination project.",
-    "run_example_link_dropped": "The run pointed at a source dataset example; re-point it after migrating datasets if needed.",
-    "longlived_pending_operator_upgrade": "Feed the emitted upgrade list to POST /internal/runs/upgrade-trace-tier; long-lived retention is not yet in effect.",
-}
 
 _CANARY_SESSION = "langsmith-migrator-canary"
 
@@ -94,7 +88,6 @@ def _raise_if_tier_denied(error: Exception) -> None:
         )
 
 
-_CANARY_NS = uuid.UUID("6f9619ff-8b86-d011-b42d-00c04fc964ff")
 
 
 class TracePreflightError(RuntimeError):
@@ -111,7 +104,8 @@ class TraceMigrator(BaseMigrator):
         state,
         config,
         *,
-        max_age_days: float = 180.0,
+        max_age_days: Optional[float] = 180.0,
+        range_start: Optional[datetime] = None,
         window_days: float = 1.0,
         max_field_bytes: int = 25 * 1024 * 1024,
         verify: bool = True,
@@ -124,6 +118,13 @@ class TraceMigrator(BaseMigrator):
     ):
         super().__init__(source_client, dest_client, state, config)
         self.max_age_days = max_age_days
+        self.range_start = range_start
+        # Resolved exactly once. Recomputing "now - max_age_days" per call gave
+        # a slightly different instant each time, which is the same drift an
+        # absolute --max-age-stamp exists to avoid.
+        self._resolved_start = resolve_range_start(
+            datetime.now(timezone.utc), max_age_days, range_start
+        )
         self.window_days = window_days
         self.max_field_bytes = max_field_bytes
         self.verify = verify
@@ -134,14 +135,15 @@ class TraceMigrator(BaseMigrator):
         self.emit_upgrade_list = emit_upgrade_list
         self.project_id_map = dict(project_id_map or {})
 
-        # Anything that reduces fidelity names its repair. A run that landed
-        # incomplete is invisible to the ordinary ID diff - its ID is present -
-        # and cannot be fixed by re-sending, because a fully ingested run is
-        # immutable. The only repair is a different destination session.
+        # What was reduced, stated as fact. A run that landed incomplete is
+        # invisible to the ordinary ID diff, since its ID is present.
         self.fidelity_reduced: Set[str] = set()
         if skip_attachments:
-            self.fidelity_reduced.add("without --skip-attachments")
+            self.fidelity_reduced.add("attachments were skipped (--skip-attachments)")
         self.upgrade_rows: List[Tuple[str, str, str]] = []
+        # Human-readable reasons for blocked runs, so the CLI can explain a
+        # blocked count instead of only recording it into state.
+        self.blocked_reasons: List[str] = []
 
         # Blobs are proxied by whichever deployment stores them, so the
         # allow-list is per side: the destination's read-back URLs live on the
@@ -153,6 +155,23 @@ class TraceMigrator(BaseMigrator):
         if not config.destination.verify_ssl:
             self._dest_session_http.verify = False
         self._ingest_errors: List[Exception] = []
+        # The SDK reports nothing on a 2xx, and a backend that accepts the
+        # request then drops the runs is indistinguishable from success. We own
+        # this session, so record what the multipart POST actually answered.
+        self._ingest_responses: List[Tuple[int, str]] = []
+        _session_request = self._dest_session_http.request
+
+        def _record_ingest(method, url, **kwargs):
+            response = _session_request(method, url, **kwargs)
+            if "/runs/multipart" in str(url):
+                try:
+                    body = (response.text or "").strip()[:600]
+                except Exception:
+                    body = "<unreadable>"
+                self._ingest_responses.append((response.status_code, body))
+            return response
+
+        self._dest_session_http.request = _record_ingest
         # The SDK logs multipart failures and returns normally, so an exception
         # never reaches us. The callback is the only way to notice.
         self.dest_ls_client = Client(
@@ -162,6 +181,10 @@ class TraceMigrator(BaseMigrator):
             omit_traced_runtime_info=True,
             tracing_error_callback=self._ingest_errors.append,
         )
+
+    def resolved_range_start(self) -> datetime:
+        """Absolute lower bound of this run's walk, fixed for the whole run."""
+        return self._resolved_start
 
     # ------------------------------------------------------------------
     # Plumbing
@@ -379,9 +402,11 @@ class TraceMigrator(BaseMigrator):
     def ingest(self, payloads: List[Dict[str, Any]]) -> List[Tuple[str, str]]:
         """Send one batch, isolating a bad run by binary split.
 
-        Returns ``[(run_id, error)]`` for runs that could not be ingested. A
-        single-run conflict is replay success: the SDK breaks out of its retry
-        loop without reporting it, so it never reaches us as an error.
+        Returns ``[(run_id, error)]`` for runs that could not be ingested.
+
+        The SDK reports neither a 409 (it breaks out of its retry loop
+        silently) nor any other non-2xx it has already logged, so failures are
+        read off the recorded response rather than from an exception.
         """
         if not payloads or self.config.migration.dry_run:
             return []
@@ -395,11 +420,25 @@ class TraceMigrator(BaseMigrator):
         )
         self._sync_dest_headers()
         del self._ingest_errors[:]
+        del self._ingest_responses[:]
         try:
             self.dest_ls_client.multipart_ingest(create=payloads)
             error = self._ingest_errors[0] if self._ingest_errors else None
         except Exception as exc:  # pragma: no cover - defensive
             error = exc
+        self._report_ingest_responses()
+        conflict = next((body for status, body in self._ingest_responses if status == 409), None)
+        if conflict is not None:
+            # A 409 rejects every payload in the request ("duplicate run create
+            # requests are not supported"), so it is not a one-bad-apple case:
+            # splitting would just repeat the same rejection per run. It also
+            # is NOT replay success - the runs exist somewhere on the tenant,
+            # but not in the project we asked for.
+            return [(str(p["id"]), f"HTTP 409: {conflict}") for p in payloads]
+        if error is None:
+            swallowed = next(((st, bd) for st, bd in self._ingest_responses if st >= 300), None)
+            if swallowed:
+                error = RuntimeError(f"HTTP {swallowed[0]}: {swallowed[1]}")
         if error is None:
             return []
         if len(payloads) == 1:
@@ -409,6 +448,26 @@ class TraceMigrator(BaseMigrator):
             f"[yellow]  ==> batch of {len(payloads)} rejected; splitting to isolate the bad run[/yellow]"
         )
         return self.ingest(payloads[:mid]) + self.ingest(payloads[mid:])
+
+    def _report_ingest_responses(self) -> None:
+        """Show what the multipart endpoint answered.
+
+        A non-2xx is printed unconditionally - it is the direct explanation for
+        runs that never arrive, and the SDK only logs it. A 2xx with a body is
+        printed too, because per-run rejections are reported that way.
+        """
+        for status, body in self._ingest_responses:
+            interesting = body and body not in ("{}", "null", '""')
+            if status >= 300:
+                self.console.print(f"[red]      ingest POST -> HTTP {status}: {body or '<empty body>'}[/red]")
+            elif interesting:
+                self.console.print(f"[yellow]      ingest POST -> HTTP {status}: {body}[/yellow]")
+            else:
+                self.log(f"      ingest POST -> HTTP {status} (empty body)", "info")
+
+    def last_ingest_summary(self) -> str:
+        """Last multipart status codes, for blocked-run evidence."""
+        return ", ".join(f"HTTP {st}{': ' + bd if bd else ''}" for st, bd in self._ingest_responses) or "no response recorded"
 
     # ------------------------------------------------------------------
     # Sessions
@@ -469,12 +528,20 @@ class TraceMigrator(BaseMigrator):
             return None, "ambiguous"
         return (matches[0], "name") if matches else (None, "missing")
 
-    def _dest_sessions_by_name(self) -> Dict[str, List[Dict[str, Any]]]:
-        index: Dict[str, List[Dict[str, Any]]] = {}
-        for s in self.dest.get_paginated("/sessions", params={"reference_free": "true"}, page_size=100):
-            if isinstance(s, dict) and not s.get("reference_dataset_id"):
-                index.setdefault(s.get("name"), []).append(s)
-        return index
+    def _dest_sessions_named(self, name: str) -> List[Dict[str, Any]]:
+        """Destination tracing projects with exactly this name.
+
+        Uses the endpoint's ``name`` filter rather than enumerating every
+        project: the previous full walk cost one request per 100 projects on
+        the destination, repeated for the canary and again for each project
+        being migrated, which dominated the request count on a busy tenant.
+        Returning every match keeps the ambiguity check intact.
+        """
+        found = self.dest.get("/sessions", params={"name": name, "reference_free": "true"}) or []
+        return [
+            s for s in found
+            if isinstance(s, dict) and s.get("name") == name and not s.get("reference_dataset_id")
+        ]
 
     def resolve_dest_session(self, source_session: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Operator mapping -> destination name match -> create.
@@ -497,8 +564,7 @@ class TraceMigrator(BaseMigrator):
             if existing:
                 return existing
 
-        by_name = self._dest_sessions_by_name()
-        matches = by_name.get(target_name) or []
+        matches = self._dest_sessions_named(target_name)
         if len(matches) > 1:
             self.log(f"Ambiguous destination session name '{target_name}'; supply --project-mapping", "warning")
             return None
@@ -579,22 +645,26 @@ class TraceMigrator(BaseMigrator):
         Historical ingest is refused outright by a deployment that enforces the
         ±24h window, and the whole multipart request fails - so this is checked
         once, before anything is migrated, rather than discovered mid-transfer.
-        The run ID is deterministic and the session is scratch, so repeated
-        stateless invocations upsert one canary instead of accumulating them.
+        The ID is fresh on every invocation. It used to be derived from the
+        scratch project and an hour-rounded stamp, so repeated runs would
+        "upsert one canary" - but the destination does not upsert a re-sent
+        run, it answers ``409 Run create payload already received``. The write
+        was therefore rejected and the read-back found the *previous* run,
+        so the check passed while proving nothing about this invocation. A
+        unique ID means the read-back can only succeed if our own write landed.
+
+        The cost is one tiny run per invocation in the scratch project, which
+        cannot be cleaned up because run deletion is not exposed. That is worth
+        paying for a gate that actually gates.
         """
         if self.config.migration.dry_run:
             return
         session = self._scratch_session()
-        # Quantised to the hour, and the ID derived from it: ``start_time`` is
-        # part of the destination's dedup key, so a canary re-sent under the
-        # same ID with a drifted timestamp lands as a *second* row and the
-        # read-back then compares against the wrong one. Same hour, same pair,
-        # real upsert. Run deletion is not exposed by the API, so the scratch
-        # project keeps at most one canary per hour the tool is used.
-        stamp = (datetime.now(timezone.utc) - timedelta(days=self.max_age_days)).replace(
-            minute=0, second=0, microsecond=0
-        )
-        run_id = str(uuid.uuid5(_CANARY_NS, f"canary:{session['id']}:{stamp.isoformat()}"))
+        # The exact range start, not an hour-rounded one: with a unique ID
+        # there is no dedup pair to keep stable, so the canary can test the
+        # precise oldest instant this run will send.
+        stamp = self.resolved_range_start()
+        run_id = str(uuid.uuid4())
         payload = {
             "id": run_id,
             "trace_id": run_id,
@@ -624,23 +694,18 @@ class TraceMigrator(BaseMigrator):
         self._block_historical("canary run absent after ingest")
 
     def _block_historical(self, detail: str) -> None:
-        next_action = (
-            "Raise the destination's ingest time window "
-            "(V1_INGEST_ENFORCE_TIME_WINDOW_EXCLUDED_ORGS) and re-run `langsmith-migrator traces`."
-        )
         issue = self.record_issue(
             "blocked",
             "historical_ingest_rejected",
-            f"Destination refuses historical run timestamps ({self.max_age_days:g}d): {detail}",
-            next_action=next_action,
-            evidence={"max_age_days": self.max_age_days, "detail": detail},
+            f"Destination refuses historical run timestamps "
+            f"(from {self.resolved_range_start().isoformat()}): {detail}",
+            evidence={"range_start": self.resolved_range_start().isoformat(), "detail": detail},
         )
-        if issue:
-            self.queue_remediation(issue_id=issue.id, next_action=next_action, command="langsmith-migrator traces")
+        del issue
         raise TracePreflightError(f"historical_ingest_rejected: {detail}")
 
     def _scratch_session(self) -> Dict[str, Any]:
-        existing = next(iter(self._dest_sessions_by_name().get(_CANARY_SESSION, [])), None)
+        existing = next(iter(self._dest_sessions_named(_CANARY_SESSION)), None)
         return existing or self.dest.post(
             "/sessions", {"name": _CANARY_SESSION, "description": "langsmith-migrator pre-flight canary"}
         )
@@ -685,7 +750,6 @@ class TraceMigrator(BaseMigrator):
                 "longlived_pending_operator_upgrade",
                 f"{len(source_ids)} run(s) in {window.label()} are not yet long-lived: "
                 "the destination project was left at its existing tier",
-                next_action=_DEGRADED_ACTIONS["longlived_pending_operator_upgrade"],
                 evidence={"window": window.label(), "count": len(source_ids), "dest_session_id": dst_id},
             )
 
@@ -697,7 +761,7 @@ class TraceMigrator(BaseMigrator):
             still_missing = self._confirm(dst_id, window, plan.to_ingest - blocked)
             if still_missing:
                 blocked |= still_missing
-                self._block_runs(window, still_missing)
+                self._block_runs(window, still_missing, dst_id)
             if digests:
                 self._check_content(dst_id, window, digests, degraded)
 
@@ -707,6 +771,14 @@ class TraceMigrator(BaseMigrator):
         # stay a partition of the source total.
         degraded_ids = set().union(*degraded.values())
         degraded_only = degraded_ids - blocked
+        # Only a wholly clean slice yields a watermark: a slice that degraded
+        # or blocked anything cannot claim "everything up to here is complete".
+        # A watermark is a claim that everything up to it is confirmed on the
+        # destination, so it may only be made when a confirming query actually
+        # ran: --no-verify skips it, and a dry run wrote nothing to confirm.
+        complete = (plan.to_ingest | plan.already_present) - blocked - degraded_ids
+        clean = not (blocked or degraded_ids) and self.verify and not self.config.migration.dry_run
+        earliest, latest = verified_bounds(population, complete) if clean else (None, None)
         return Reconciliation(
             session_id=src_id,
             dest_session_id=dst_id,
@@ -717,6 +789,9 @@ class TraceMigrator(BaseMigrator):
             degraded=len(degraded_only),
             blocked=len(blocked),
             extra_on_dest=len(plan.extra_on_dest),
+            earliest=earliest,
+            latest=latest,
+            verified_runs=len(complete) if clean else 0,
         )
 
     def _ingest_plan(
@@ -745,7 +820,7 @@ class TraceMigrator(BaseMigrator):
                 # The backend stubs an oversized field rather than rejecting
                 # it, so this run must not be reported as fully migrated.
                 degraded.setdefault("payload_oversized_for_destination", set()).add(run_id)
-                self.fidelity_reduced.add("after raising --max-field-bytes")
+                self.fidelity_reduced.add("payloads exceeded --max-field-bytes")
                 continue
 
             codes = set(issues)
@@ -754,19 +829,27 @@ class TraceMigrator(BaseMigrator):
             for code in codes:
                 degraded.setdefault(code, set()).add(run_id)
                 if code in ("attachment_fetch_failed", "attachment_host_rejected"):
-                    self.fidelity_reduced.add("once the source blob store is reachable")
+                    self.fidelity_reduced.add("some source blobs could not be fetched")
 
             if len(digests) < self.verify_content_sample:
                 digests[run_id] = self._digest_of(run, overrides)
             prepared.append(payload)
 
         max_runs, max_bytes = self.batch_limits()
+        rejected: Dict[str, Set[str]] = {}
         for batch in batch_traces(
             group_into_traces(prepared), max_runs=max_runs, max_bytes=max_bytes, size_of=self._size_of
         ):
             for run_id, error in self.ingest(batch):
                 blocked.add(run_id)
-                self.log(f"Run {run_id} rejected: {str(error)[:200]}", "error")
+                rejected.setdefault(str(error), set()).add(run_id)
+        # Grouped by cause: twenty runs refused for one reason is one fact, not
+        # twenty truncated lines.
+        for error, ids in rejected.items():
+            self._record_blocked(
+                window, ids, "run_ingest_rejected",
+                f"{len(ids)} run(s) refused by the destination on ingest: {error}",
+            )
         return digests
 
     @staticmethod
@@ -811,7 +894,6 @@ class TraceMigrator(BaseMigrator):
                 "degraded",
                 "run_fidelity_mismatch",
                 f"{len(mismatched)} sampled run(s) differ from the source ({window.label()})",
-                next_action="Re-migrate this window into a fresh destination project.",
                 # Field names and counts only - never values.
                 evidence={"window": window.label(), "runs": dict(list(mismatched.items())[:20])},
             )
@@ -829,21 +911,54 @@ class TraceMigrator(BaseMigrator):
                 "degraded",
                 code,
                 f"{len(run_ids)} run(s) migrated with reduced fidelity ({code}) in {window.label()}",
-                next_action=_DEGRADED_ACTIONS.get(code),
                 evidence={"window": window.label(), "count": len(run_ids), "run_ids": sorted(run_ids)[:20]},
             )
 
-    def _block_runs(self, window: Window, run_ids: Set[str]) -> None:
-        next_action = "Re-run `langsmith-migrator traces` for this window; the diff will re-send them."
-        issue = self.record_issue(
+    def _record_blocked(self, window: Window, run_ids: Set[str], code: str, summary: str) -> None:
+        """One record per (window, cause), whichever path blocked the runs.
+
+        Both the ingest rejection and the confirm miss land here, so a blocked
+        count always has a matching reason in the output and in state - rather
+        than a reason only for one of the two ways runs get blocked.
+        """
+        self.blocked_reasons.append(f"{window.label()}: {summary}")
+        self.record_issue(
             "blocked",
-            "run_not_ingested",
-            f"{len(run_ids)} run(s) still missing from the destination after ingest ({window.label()})",
-            next_action=next_action,
-            evidence={"window": window.label(), "run_ids": sorted(run_ids)[:20], "count": len(run_ids)},
+            code,
+            f"{summary} ({window.label()})",
+            evidence={"window": window.label(), "count": len(run_ids), "run_ids": sorted(run_ids)[:20]},
         )
-        if issue:
-            self.queue_remediation(issue_id=issue.id, next_action=next_action, command="langsmith-migrator traces")
+
+    def _diagnose_missing(self, dest_session_id: str, run_ids: Set[str]) -> Tuple[str, str]:
+        """Explain why runs are absent, by asking where they actually are.
+
+        The common cause is not a lost write: the destination keeps one copy of
+        a run id per tenant, so a run that already landed in another project
+        cannot be ingested into a second one - the write is accepted and then
+        dropped. Saying "still missing" for that is true but useless.
+        """
+        for run_id in sorted(run_ids)[:3]:
+            try:
+                run = self.dest.get(f"/runs/{run_id}")
+            except Exception:
+                continue
+            other = str((run or {}).get("session_id") or "")
+            if other and other != dest_session_id:
+                return (
+                    "run_exists_in_other_project",
+                    f"{len(run_ids)} run(s) already exist on this destination under a different "
+                    f"project ({other}); the destination keeps one copy per run id per tenant, so "
+                    f"they were not written into {dest_session_id}",
+                )
+        return (
+            "run_not_ingested",
+            f"{len(run_ids)} run(s) still missing from the destination after ingest "
+            f"(last ingest response: {self.last_ingest_summary()})",
+        )
+
+    def _block_runs(self, window: Window, run_ids: Set[str], dest_session_id: str) -> None:
+        code, summary = self._diagnose_missing(dest_session_id, run_ids)
+        self._record_blocked(window, run_ids, code, summary)
 
     # ------------------------------------------------------------------
     # Per-session driver
@@ -866,7 +981,8 @@ class TraceMigrator(BaseMigrator):
         recon = None
         try:
             slices = []
-            for window in iter_windows(now or datetime.now(timezone.utc), self.max_age_days, self.window_days):
+            end = now or datetime.now(timezone.utc)
+            for window in iter_windows(self.resolved_range_start(), end, self.window_days):
                 sliced = self.migrate_slice(source_session, dest_session, window)
                 slices.append(sliced)
                 if sliced.source_total:
@@ -875,7 +991,8 @@ class TraceMigrator(BaseMigrator):
                     self.log(
                         f"  {sliced.window}: source {sliced.source_total} = ingested {sliced.ingested}"
                         f" + already present {sliced.already_present}"
-                        f" + degraded {sliced.degraded} + blocked {sliced.blocked}",
+                        f" + degraded {sliced.degraded} + blocked {sliced.blocked}"
+                        + (f" | verified {sliced.earliest} .. {sliced.latest}" if sliced.earliest else ""),
                         "info",
                     )
             recon = Reconciliation.of(str(source_session["id"]), str(dest_session["id"]), slices)
@@ -913,10 +1030,6 @@ class TraceMigrator(BaseMigrator):
             "degraded",
             "dest_tier_left_raised",
             f"Destination project {dest_session['id']} was raised to {LONGLIVED} and left raised "
-            f"because {reason}",
-            next_action=(
-                f"Re-run `langsmith-migrator traces` to finish it, or set the tier back to "
-                f"'{prior_tier}' by hand once you no longer need it raised."
-            ),
+            f"because {reason}; its previous tier was '{prior_tier}'",
             evidence={"dest_session_id": str(dest_session["id"]), "prior_tier": prior_tier, "reason": reason},
         )

--- a/langsmith_migrator/core/migrators/trace.py
+++ b/langsmith_migrator/core/migrators/trace.py
@@ -25,6 +25,7 @@ Two backend facts drive most of the shape here:
 
 from __future__ import annotations
 
+import json
 import time
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -41,9 +42,8 @@ from ..trace_domain import (
     LONGLIVED,
     RUN_QUERY_SELECT,
     S3_URL_PAYLOAD_FIELDS,
-    SessionReconciliation,
+    Reconciliation,
     SlicePlan,
-    SliceReconciliation,
     Window,
     batch_traces,
     digest_mismatches,
@@ -94,10 +94,6 @@ def _raise_if_tier_denied(error: Exception) -> None:
         )
 
 
-def _is_select_rejection(error: Exception) -> bool:
-    """True when the source refused a name in ``select`` rather than the query."""
-    text = str(error)
-    return "select" in text and ("422" in text or "Input should be" in text)
 _CANARY_NS = uuid.UUID("6f9619ff-8b86-d011-b42d-00c04fc964ff")
 
 
@@ -147,9 +143,11 @@ class TraceMigrator(BaseMigrator):
             self.fidelity_reduced.add("without --skip-attachments")
         self.upgrade_rows: List[Tuple[str, str, str]] = []
 
-        self._dest_sessions: Dict[str, Dict[str, Any]] = {}
-        self._select_unsupported = False
+        # Blobs are proxied by whichever deployment stores them, so the
+        # allow-list is per side: the destination's read-back URLs live on the
+        # destination host, not the source's.
         self._source_blob_host = urlparse(self._host(config.source.base_url)).netloc
+        self._dest_blob_host = urlparse(self._host(config.destination.base_url)).netloc
 
         self._dest_session_http = requests.Session()
         if not config.destination.verify_ssl:
@@ -179,11 +177,9 @@ class TraceMigrator(BaseMigrator):
     @staticmethod
     def _shape(runs: Sequence[Dict[str, Any]]) -> Tuple[int, int, int]:
         """``(runs, distinct traces, serialized bytes)`` for a page or a batch."""
-        import json as _json
-
         traces = {str(r.get("trace_id")) for r in runs}
         size = sum(
-            len(_json.dumps({k: v for k, v in r.items() if k != "attachments"}, default=str))
+            len(json.dumps({k: v for k, v in r.items() if k != "attachments"}, default=str))
             + sum(len(data) for _, data in (r.get("attachments") or {}).values())
             for r in runs
         )
@@ -226,29 +222,10 @@ class TraceMigrator(BaseMigrator):
         }
         if ids is not None:
             body["id"] = [str(i) for i in ids]
-        if self._select_unsupported:
-            body.pop("select")
         side = "source" if client is self.source else "dest  "
         page_num, seen = 0, 0
         while True:
-            try:
-                response = client.post("/runs/query", body) or {}
-            except Exception as exc:
-                # One fallback, no cascade: a source that rejects a name in
-                # `select` gets the query again with no projection at all. The
-                # endpoint then returns every column, which is a superset of
-                # what we asked for, so nothing is lost but the narrowing.
-                if self._select_unsupported or "select" not in body or not _is_select_rejection(exc):
-                    raise
-                self._select_unsupported = True
-                self.record_issue(
-                    "degraded",
-                    "run_query_select_unsupported",
-                    "The source rejected the requested `select`; querying without a projection instead",
-                    evidence={"select": list(select), "error": str(exc)[:300]},
-                )
-                body.pop("select")
-                continue
+            response = client.post("/runs/query", body) or {}
             runs = response.get("runs") or []
             page_num += 1
             seen += len(runs)
@@ -287,18 +264,20 @@ class TraceMigrator(BaseMigrator):
     def long_lived_run_ids(self, client, session_id: str, window: Window, *, tier_filter: bool = True) -> Set[str]:
         return {str(r["id"]) for r in self.slice_runs(client, session_id, window, tier_filter=tier_filter)}
 
-    def fetch_runs(self, session_id: str, window: Window, run_ids: Sequence[str]) -> Iterator[Dict[str, Any]]:
+    def fetch_runs(
+        self, client, session_id: str, window: Window, run_ids: Sequence[str]
+    ) -> Iterator[Dict[str, Any]]:
         """Full payloads for a set of IDs, chunked so no request is oversized."""
         ids = list(run_ids)
         for start in range(0, len(ids), _ID_CHUNK):
             yield from self._query_runs(
-                self.source, session_id, window, select=RUN_QUERY_SELECT, ids=ids[start : start + _ID_CHUNK]
+                client, session_id, window, select=RUN_QUERY_SELECT, ids=ids[start : start + _ID_CHUNK]
             )
 
     # ------------------------------------------------------------------
     # Blobs
     # ------------------------------------------------------------------
-    def _fetch_blob(self, url: str, limit: int) -> Tuple[str, bytes]:
+    def _fetch_blob(self, url: str, limit: int, host: str, sess) -> Tuple[str, bytes]:
         """Download one presigned blob through the tool's configured session.
 
         Never the SDK's own conversion, which uses a bare ``requests.get`` that
@@ -308,9 +287,9 @@ class TraceMigrator(BaseMigrator):
         source steering us somewhere else.
         """
         parsed = urlparse(url)
-        if parsed.scheme != "https" or parsed.netloc != self._source_blob_host:
+        if parsed.scheme != "https" or parsed.netloc != host:
             raise PermissionError("attachment_host_rejected")
-        with self.source.session.get(url, stream=True, timeout=120, allow_redirects=False) as resp:
+        with sess.get(url, stream=True, timeout=120, allow_redirects=False) as resp:
             resp.raise_for_status()
             content_type = (resp.headers.get("Content-Type") or "application/octet-stream").split(";")[0].strip()
             with SpooledTemporaryFile(max_size=8 * 1024 * 1024) as buf:
@@ -323,7 +302,7 @@ class TraceMigrator(BaseMigrator):
                 buf.seek(0)
                 return content_type, buf.read()
 
-    def materialise(self, run: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
+    def materialise(self, run: Dict[str, Any], *, side: str = "source") -> Tuple[Dict[str, Any], List[str]]:
         """Re-inline anything the source left in blob storage, and fetch attachments.
 
         The query API usually resolves offloaded ``inputs`` / ``outputs`` /
@@ -334,15 +313,19 @@ class TraceMigrator(BaseMigrator):
         """
         overrides: Dict[str, Any] = {}
         issues: List[str] = []
-        import json as _json
+        host, sess = (
+            (self._source_blob_host, self.source.session)
+            if side == "source"
+            else (self._dest_blob_host, self.dest.session)
+        )
 
         def pull(field: str, ref: Dict[str, Any], limit: int) -> None:
             url = (ref or {}).get("presigned_url")
             if not url:
                 return
             try:
-                _, raw = self._fetch_blob(url, limit)
-                overrides[field] = _json.loads(raw)
+                _, raw = self._fetch_blob(url, limit, host, sess)
+                overrides[field] = json.loads(raw)
             except PermissionError:
                 issues.append("attachment_host_rejected")
             except Exception:
@@ -361,7 +344,9 @@ class TraceMigrator(BaseMigrator):
                     issues.append("attachments_skipped")
                     continue
                 try:
-                    attachments[name] = self._fetch_blob(ref.get("presigned_url", ""), _MAX_ATTACHMENT_BYTES)
+                    attachments[name] = self._fetch_blob(
+                        ref.get("presigned_url", ""), _MAX_ATTACHMENT_BYTES, host, sess
+                    )
                 except PermissionError:
                     issues.append("attachment_host_rejected")
                 except Exception:
@@ -375,14 +360,9 @@ class TraceMigrator(BaseMigrator):
     # ------------------------------------------------------------------
     # Write path
     # ------------------------------------------------------------------
-    @staticmethod
-    def _size_of(payload: Dict[str, Any]) -> int:
-        import json as _json
-
-        attachments = payload.get("attachments") or {}
-        blob_bytes = sum(len(data) for _, data in attachments.values())
-        body = {k: v for k, v in payload.items() if k != "attachments"}
-        return len(_json.dumps(body, default=str)) + blob_bytes
+    @classmethod
+    def _size_of(cls, payload: Dict[str, Any]) -> int:
+        return cls._shape([payload])[2]
 
     def _oversized_fields(self, payload: Dict[str, Any]) -> List[str]:
         """Fields the destination would silently replace with a placeholder.
@@ -391,13 +371,11 @@ class TraceMigrator(BaseMigrator):
         rejecting it, and does not advertise the limit, so this is checked
         against the operator-supplied value before sending.
         """
-        import json as _json
-
         return [
             field
             for field in ("inputs", "outputs")
             if payload.get(field) is not None
-            and len(_json.dumps(payload[field], default=str)) > self.max_field_bytes
+            and len(json.dumps(payload[field], default=str)) > self.max_field_bytes
         ]
 
     def ingest(self, payloads: List[Dict[str, Any]]) -> List[Tuple[str, str]]:
@@ -664,21 +642,22 @@ class TraceMigrator(BaseMigrator):
         raise TracePreflightError(f"historical_ingest_rejected: {detail}")
 
     def _scratch_session(self) -> Dict[str, Any]:
-        for existing in self._dest_sessions_by_name().get(_CANARY_SESSION, []):
-            return existing
-        return self.dest.post("/sessions", {"name": _CANARY_SESSION, "description": "langsmith-migrator pre-flight canary"})
+        existing = next(iter(self._dest_sessions_by_name().get(_CANARY_SESSION, [])), None)
+        return existing or self.dest.post(
+            "/sessions", {"name": _CANARY_SESSION, "description": "langsmith-migrator pre-flight canary"}
+        )
 
     # ------------------------------------------------------------------
     # The unit of work
     # ------------------------------------------------------------------
     def migrate_slice(
         self, source_session: Dict[str, Any], dest_session: Dict[str, Any], window: Window
-    ) -> SliceReconciliation:
+    ) -> Reconciliation:
         """Diff, ingest the difference, confirm it is empty, sample content."""
         src_id, dst_id = str(source_session["id"]), str(dest_session["id"])
         population = self.slice_runs(self.source, src_id, window)
         if not population:
-            return SliceReconciliation(src_id, dst_id, window.label(), 0, 0, 0, 0, 0)
+            return Reconciliation(src_id, dst_id, window.label(), 0, 0, 0, 0, 0)
         source_ids = {str(r["id"]) for r in population}
 
         # With --emit-upgrade-list the destination sessions stay at their
@@ -728,13 +707,13 @@ class TraceMigrator(BaseMigrator):
 
         # A run can be both degraded and blocked; blocked wins, so the parts
         # stay a partition of the source total.
-        degraded_ids = set().union(*degraded.values()) if degraded else set()
+        degraded_ids = set().union(*degraded.values())
         degraded_only = degraded_ids - blocked
-        return SliceReconciliation(
+        return Reconciliation(
             session_id=src_id,
             dest_session_id=dst_id,
             window=window.label(),
-            source_total=len(plan.source_ids),
+            source_total=len(source_ids),
             ingested=len(plan.to_ingest) - len(degraded_only) - len(blocked),
             already_present=len(plan.already_present),
             degraded=len(degraded_only),
@@ -757,7 +736,7 @@ class TraceMigrator(BaseMigrator):
             return digests
 
         prepared: List[Dict[str, Any]] = []
-        for run in self.fetch_runs(src_id, window, sorted(plan.to_ingest)):
+        for run in self.fetch_runs(self.source, src_id, window, sorted(plan.to_ingest)):
             run_id = str(run["id"])
             overrides, issues = self.materialise(run)
             payload_obj, dropped = to_ingest_payload(run, dst_id, overrides)
@@ -815,11 +794,16 @@ class TraceMigrator(BaseMigrator):
     ) -> None:
         """Compare sampled per-field digests. Reports field names, never values."""
         mismatched: Dict[str, List[str]] = {}
-        for run in self.fetch_runs_dest(dest_session_id, window, sorted(digests)):
+        for run in self.fetch_runs(self.dest, dest_session_id, window, sorted(digests)):
             run_id = str(run["id"])
             if run_id not in digests:
                 continue
-            overrides, _ = self.materialise(run)
+            overrides, issues = self.materialise(run, side="dest")
+            if issues:
+                # Otherwise a read-back failure is indistinguishable from the
+                # destination genuinely holding different content.
+                self.log(f"Could not read back run {run_id} for comparison: {sorted(set(issues))}", "warning")
+                continue
             fields = digest_mismatches(digests[run_id], self._digest_of(run, overrides))
             if fields:
                 mismatched[run_id] = list(fields)
@@ -832,13 +816,6 @@ class TraceMigrator(BaseMigrator):
                 next_action="Re-migrate this window into a fresh destination project.",
                 # Field names and counts only - never values.
                 evidence={"window": window.label(), "runs": dict(list(mismatched.items())[:20])},
-            )
-
-    def fetch_runs_dest(self, session_id: str, window: Window, run_ids: Sequence[str]) -> Iterator[Dict[str, Any]]:
-        ids = list(run_ids)
-        for start in range(0, len(ids), _ID_CHUNK):
-            yield from self._query_runs(
-                self.dest, session_id, window, select=RUN_QUERY_SELECT, ids=ids[start : start + _ID_CHUNK]
             )
 
     def _report_degraded(self, window: Window, degraded: Dict[str, Set[str]]) -> None:
@@ -873,7 +850,7 @@ class TraceMigrator(BaseMigrator):
     # ------------------------------------------------------------------
     # Per-session driver
     # ------------------------------------------------------------------
-    def migrate_session(self, source_session: Dict[str, Any], now: Optional[datetime] = None) -> Optional[SessionReconciliation]:
+    def migrate_session(self, source_session: Dict[str, Any], now: Optional[datetime] = None) -> Optional[Reconciliation]:
         """Raise tier -> migrate windows oldest-first -> verify -> restore."""
         dest_session = self.resolve_dest_session(source_session)
         if not dest_session:
@@ -893,7 +870,7 @@ class TraceMigrator(BaseMigrator):
                     f" + degraded {recon.degraded} + blocked {recon.blocked}",
                     "info",
                 )
-        recon = SessionReconciliation.of(str(source_session["id"]), str(dest_session["id"]), slices)
+        recon = Reconciliation.of(str(source_session["id"]), str(dest_session["id"]), slices)
 
         source_tier = source_session.get("trace_tier")
         restore = self.restore_session_tier

--- a/langsmith_migrator/core/migrators/trace.py
+++ b/langsmith_migrator/core/migrators/trace.py
@@ -1,0 +1,905 @@
+"""Long-lived trace migration.
+
+Copies runs whose trace tier is ``longlived`` between two LangSmith
+deployments, preserving ``id`` / ``trace_id`` / ``parent_run_id`` /
+``dotted_order`` and every timestamp verbatim. Contrast with
+``ExperimentMigrator``, which remaps run IDs, time-shifts into the ingest
+window, and checkpoints a cursor: none of that happens here.
+
+The unit of work is a ``(session, time window)`` slice. For each one we ask the
+source for its long-lived run IDs, ask the mapped destination session for the
+same, ingest the difference, and re-query to confirm the difference is now
+empty. That diff is simultaneously the work-list, the skip-list and the
+completeness proof, which is why nothing is checkpointed: interrupt and re-run,
+and finished windows produce an empty diff. ``resume`` does not apply.
+
+Two backend facts drive most of the shape here:
+
+* Run identity on the destination is ``(tenant_id, session_id, start_time,
+  id)``, so preserving IDs and timestamps is what makes replay an upsert - and
+  why migrating into the *same* tenant is refused outright.
+* There is no per-run trace-tier field on the ingest contract. The destination
+  *session's* tier is the only lever, and it must be correct at ingest time
+  because the row TTL and the blob key prefix are both baked in at insert.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from tempfile import SpooledTemporaryFile
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple
+from urllib.parse import urlparse
+
+import requests
+from langsmith import Client
+
+from ..api_client import APIError, NotFoundError
+from ..trace_domain import (
+    ATTACHMENT_PREFIX,
+    LONGLIVED,
+    RUN_QUERY_SELECT,
+    S3_URL_PAYLOAD_FIELDS,
+    SessionReconciliation,
+    SlicePlan,
+    SliceReconciliation,
+    Window,
+    batch_traces,
+    digest_mismatches,
+    group_into_traces,
+    is_long_lived,
+    iter_windows,
+    payload_digest,
+    plan_slice,
+    resolve_window_bounds,
+    to_ingest_payload,
+)
+from .base import BaseMigrator
+
+# Measured on a real deployment: 2000 IDs per /runs/query is fine, 5000 returns
+# 503. Half the safe value, so a slow shard has headroom.
+_ID_CHUNK = 500
+
+# Not advertised by /info (only the batch limits are), so it matches the
+# backend's own MAX_ATTACHMENT_SIZE_BYTES default and is a guard, not a truth.
+_MAX_ATTACHMENT_BYTES = 200 * 1024 * 1024
+
+_VERIFY_ATTEMPTS = 4
+_VERIFY_BACKOFF = 3.0
+
+_DEGRADED_ACTIONS = {
+    "attachment_fetch_failed": "Once the source blob store is reachable, re-migrate this window into a fresh destination project.",
+    "attachment_host_rejected": "The source returned a blob URL off its own host; investigate, then re-migrate into a fresh destination project.",
+    "attachments_skipped": "Re-migrate this window into a fresh destination project without --skip-attachments.",
+    "payload_oversized_for_destination": "Raise MAX_FIELD_SIZE_BYTES on the destination, set a matching --max-field-bytes, and re-migrate into a fresh destination project.",
+    "run_example_link_dropped": "The run pointed at a source dataset example; re-point it after migrating datasets if needed.",
+    "longlived_pending_operator_upgrade": "Feed the emitted upgrade list to POST /internal/runs/upgrade-trace-tier; long-lived retention is not yet in effect.",
+}
+
+_CANARY_SESSION = "langsmith-migrator-canary"
+
+
+def _raise_if_tier_denied(error: Exception) -> None:
+    """Turn a 403 on a tier-carrying write into an explicit pre-flight blocker.
+
+    ``PROJECTS_INCREASE_TRACE_TIER`` is checked on *create* too, not only on
+    update, when the destination tenant's default tier is short-lived.
+    """
+    text = str(error)
+    if "403" in text or "Forbidden" in text:
+        raise TracePreflightError(
+            "trace_tier_permission_denied: the destination key needs PROJECTS_INCREASE_TRACE_TIER "
+            f"(and PROJECTS_DECREASE_TRACE_TIER to restore). {text[:200]}"
+        )
+
+
+def _is_select_rejection(error: Exception) -> bool:
+    """True when the source refused a name in ``select`` rather than the query."""
+    text = str(error)
+    return "select" in text and ("422" in text or "Input should be" in text)
+_CANARY_NS = uuid.UUID("6f9619ff-8b86-d011-b42d-00c04fc964ff")
+
+
+class TracePreflightError(RuntimeError):
+    """A destination precondition failed; nothing may be migrated."""
+
+
+class TraceMigrator(BaseMigrator):
+    """Migrates long-lived traces, statelessly, one (session, window) at a time."""
+
+    def __init__(
+        self,
+        source_client,
+        dest_client,
+        state,
+        config,
+        *,
+        max_age_days: float = 180.0,
+        window_days: float = 1.0,
+        max_field_bytes: int = 25 * 1024 * 1024,
+        verify: bool = True,
+        verify_content_sample: int = 100,
+        skip_attachments: bool = False,
+        restore_session_tier: Optional[bool] = None,
+        into_session_suffix: Optional[str] = None,
+        emit_upgrade_list: Optional[str] = None,
+        project_id_map: Optional[Dict[str, str]] = None,
+    ):
+        super().__init__(source_client, dest_client, state, config)
+        self.max_age_days = max_age_days
+        self.window_days = window_days
+        self.max_field_bytes = max_field_bytes
+        self.verify = verify
+        self.verify_content_sample = verify_content_sample
+        self.skip_attachments = skip_attachments
+        self.restore_session_tier = restore_session_tier
+        self.into_session_suffix = into_session_suffix
+        self.emit_upgrade_list = emit_upgrade_list
+        self.project_id_map = dict(project_id_map or {})
+
+        # Anything that reduces fidelity names its repair. A run that landed
+        # incomplete is invisible to the ordinary ID diff - its ID is present -
+        # and cannot be fixed by re-sending, because a fully ingested run is
+        # immutable. The only repair is a different destination session.
+        self.fidelity_reduced: Set[str] = set()
+        if skip_attachments:
+            self.fidelity_reduced.add("without --skip-attachments")
+        self.upgrade_rows: List[Tuple[str, str, str]] = []
+
+        self._dest_sessions: Dict[str, Dict[str, Any]] = {}
+        self._select_unsupported = False
+        self._source_blob_host = urlparse(self._host(config.source.base_url)).netloc
+
+        self._dest_session_http = requests.Session()
+        if not config.destination.verify_ssl:
+            self._dest_session_http.verify = False
+        self._ingest_errors: List[Exception] = []
+        # The SDK logs multipart failures and returns normally, so an exception
+        # never reaches us. The callback is the only way to notice.
+        self.dest_ls_client = Client(
+            api_key=config.destination.api_key,
+            api_url=self._host(config.destination.base_url),
+            session=self._dest_session_http,
+            omit_traced_runtime_info=True,
+            tracing_error_callback=self._ingest_errors.append,
+        )
+
+    # ------------------------------------------------------------------
+    # Plumbing
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _human(size: float) -> str:
+        for unit in ("B", "KB", "MB", "GB"):
+            if size < 1024 or unit == "GB":
+                return f"{size:,.0f} {unit}" if unit == "B" else f"{size:,.1f} {unit}"
+            size /= 1024
+        return f"{size:,.1f} GB"
+
+    @staticmethod
+    def _shape(runs: Sequence[Dict[str, Any]]) -> Tuple[int, int, int]:
+        """``(runs, distinct traces, serialized bytes)`` for a page or a batch."""
+        import json as _json
+
+        traces = {str(r.get("trace_id")) for r in runs}
+        size = sum(
+            len(_json.dumps({k: v for k, v in r.items() if k != "attachments"}, default=str))
+            + sum(len(data) for _, data in (r.get("attachments") or {}).values())
+            for r in runs
+        )
+        return len(runs), len(traces), size
+
+    @staticmethod
+    def _host(base_url: str) -> str:
+        clean = (base_url or "").rstrip("/")
+        return clean[: -len("/api/v1")] if clean.endswith("/api/v1") else clean
+
+    def _sync_dest_headers(self) -> None:
+        ws = self.dest.session.headers.get("X-Tenant-Id")
+        if ws:
+            self._dest_session_http.headers["X-Tenant-Id"] = ws
+        else:
+            self._dest_session_http.headers.pop("X-Tenant-Id", None)
+
+    def batch_limits(self) -> Tuple[int, int]:
+        """Runs-per-request and bytes-per-request the destination advertises."""
+        try:
+            cfg = dict(self.dest_ls_client.info.batch_ingest_config or {})
+        except Exception:
+            cfg = {}
+        return int(cfg.get("size_limit") or 100), int(cfg.get("size_limit_bytes") or 20_971_520)
+
+    # ------------------------------------------------------------------
+    # Read path
+    # ------------------------------------------------------------------
+    def _query_runs(
+        self, client, session_id: str, window: Window, *, select: Sequence[str], ids=None
+    ) -> Iterator[Dict[str, Any]]:
+        """Paginate ``POST /runs/query`` for one session and window."""
+        trace_filter, run_start = resolve_window_bounds(window)
+        body: Dict[str, Any] = {
+            "session": [str(session_id)],
+            "trace_filter": trace_filter,
+            "start_time": run_start,
+            "select": list(select),
+            "limit": 100,
+        }
+        if ids is not None:
+            body["id"] = [str(i) for i in ids]
+        if self._select_unsupported:
+            body.pop("select")
+        side = "source" if client is self.source else "dest  "
+        page_num, seen = 0, 0
+        while True:
+            try:
+                response = client.post("/runs/query", body) or {}
+            except Exception as exc:
+                # One fallback, no cascade: a source that rejects a name in
+                # `select` gets the query again with no projection at all. The
+                # endpoint then returns every column, which is a superset of
+                # what we asked for, so nothing is lost but the narrowing.
+                if self._select_unsupported or "select" not in body or not _is_select_rejection(exc):
+                    raise
+                self._select_unsupported = True
+                self.record_issue(
+                    "degraded",
+                    "run_query_select_unsupported",
+                    "The source rejected the requested `select`; querying without a projection instead",
+                    evidence={"select": list(select), "error": str(exc)[:300]},
+                )
+                body.pop("select")
+                continue
+            runs = response.get("runs") or []
+            page_num += 1
+            seen += len(runs)
+            if self.config.migration.verbose and runs:
+                n, traces, size = self._shape(runs)
+                # Kept under 80 columns: a wrapped progress line is worse
+                # than a terse one.
+                self.console.print(
+                    f"[dim]  query {side} p{page_num:<4}"
+                    f"runs {n:>4} | traces {traces:>4} | {self._human(size):>9} | "
+                    f"total {seen:>6}[/dim]"
+                )
+            yield from runs
+            cursor = (response.get("cursors") or {}).get("next")
+            if not cursor or not runs:
+                return
+            body = {**body, "cursor": cursor}
+
+    # Enough to identify a run and place its trace, so one pass over a slice
+    # serves both the diff and the deferred-upgrade list.
+    _ID_SELECT = ("id", "trace_tier", "trace_id", "start_time")
+
+    def slice_runs(self, client, session_id: str, window: Window, *, tier_filter: bool = True) -> List[Dict[str, Any]]:
+        """The long-lived runs of one slice, projected to identity fields only.
+
+        ``trace_tier`` is filtered client-side: the V1 endpoint rejects it
+        inside ``trace_filter`` ("Attribute trace_tier not accepted") but
+        returns it on every run.
+        """
+        return [
+            run
+            for run in self._query_runs(client, session_id, window, select=self._ID_SELECT)
+            if run.get("id") and (not tier_filter or is_long_lived(run))
+        ]
+
+    def long_lived_run_ids(self, client, session_id: str, window: Window, *, tier_filter: bool = True) -> Set[str]:
+        return {str(r["id"]) for r in self.slice_runs(client, session_id, window, tier_filter=tier_filter)}
+
+    def fetch_runs(self, session_id: str, window: Window, run_ids: Sequence[str]) -> Iterator[Dict[str, Any]]:
+        """Full payloads for a set of IDs, chunked so no request is oversized."""
+        ids = list(run_ids)
+        for start in range(0, len(ids), _ID_CHUNK):
+            yield from self._query_runs(
+                self.source, session_id, window, select=RUN_QUERY_SELECT, ids=ids[start : start + _ID_CHUNK]
+            )
+
+    # ------------------------------------------------------------------
+    # Blobs
+    # ------------------------------------------------------------------
+    def _fetch_blob(self, url: str, limit: int) -> Tuple[str, bytes]:
+        """Download one presigned blob through the tool's configured session.
+
+        Never the SDK's own conversion, which uses a bare ``requests.get`` that
+        ignores SSL config, CA bundles and proxies, and substitutes a
+        placeholder on failure. Redirects are not followed: the deployment
+        proxies blob downloads on its own host, so a redirect would be the
+        source steering us somewhere else.
+        """
+        parsed = urlparse(url)
+        if parsed.scheme != "https" or parsed.netloc != self._source_blob_host:
+            raise PermissionError("attachment_host_rejected")
+        with self.source.session.get(url, stream=True, timeout=120, allow_redirects=False) as resp:
+            resp.raise_for_status()
+            content_type = (resp.headers.get("Content-Type") or "application/octet-stream").split(";")[0].strip()
+            with SpooledTemporaryFile(max_size=8 * 1024 * 1024) as buf:
+                size = 0
+                for chunk in resp.iter_content(65536):
+                    size += len(chunk)
+                    if size > limit:
+                        raise ValueError(f"blob exceeds {limit} bytes")
+                    buf.write(chunk)
+                buf.seek(0)
+                return content_type, buf.read()
+
+    def materialise(self, run: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]:
+        """Re-inline anything the source left in blob storage, and fetch attachments.
+
+        The query API usually resolves offloaded ``inputs`` / ``outputs`` /
+        ``extra`` for us; the blob reference is only followed when the inline
+        value is genuinely absent. Attachments are never inlined and always
+        need fetching. Returns ``(overrides, degraded_codes)`` - a failure is
+        explicit, never a placeholder.
+        """
+        overrides: Dict[str, Any] = {}
+        issues: List[str] = []
+        import json as _json
+
+        def pull(field: str, ref: Dict[str, Any], limit: int) -> None:
+            url = (ref or {}).get("presigned_url")
+            if not url:
+                return
+            try:
+                _, raw = self._fetch_blob(url, limit)
+                overrides[field] = _json.loads(raw)
+            except PermissionError:
+                issues.append("attachment_host_rejected")
+            except Exception:
+                issues.append("attachment_fetch_failed")
+
+        for field, key in (("inputs", "inputs_s3_urls"), ("outputs", "outputs_s3_urls")):
+            refs = run.get(key) or {}
+            if run.get(field) is None and refs.get("ROOT"):
+                pull(field, refs["ROOT"], self.max_field_bytes)
+
+        attachments: Dict[str, Tuple[str, bytes]] = {}
+        for key, ref in (run.get("s3_urls") or {}).items():
+            if key.startswith(ATTACHMENT_PREFIX):
+                name = key[len(ATTACHMENT_PREFIX) :]
+                if self.skip_attachments:
+                    issues.append("attachments_skipped")
+                    continue
+                try:
+                    attachments[name] = self._fetch_blob(ref.get("presigned_url", ""), _MAX_ATTACHMENT_BYTES)
+                except PermissionError:
+                    issues.append("attachment_host_rejected")
+                except Exception:
+                    issues.append("attachment_fetch_failed")
+            elif key in S3_URL_PAYLOAD_FIELDS and run.get(key) is None:
+                pull(key, ref, self.max_field_bytes)
+        if attachments:
+            overrides["attachments"] = attachments
+        return overrides, issues
+
+    # ------------------------------------------------------------------
+    # Write path
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _size_of(payload: Dict[str, Any]) -> int:
+        import json as _json
+
+        attachments = payload.get("attachments") or {}
+        blob_bytes = sum(len(data) for _, data in attachments.values())
+        body = {k: v for k, v in payload.items() if k != "attachments"}
+        return len(_json.dumps(body, default=str)) + blob_bytes
+
+    def _oversized_fields(self, payload: Dict[str, Any]) -> List[str]:
+        """Fields the destination would silently replace with a placeholder.
+
+        The backend stubs an oversized ``inputs`` / ``outputs`` rather than
+        rejecting it, and does not advertise the limit, so this is checked
+        against the operator-supplied value before sending.
+        """
+        import json as _json
+
+        return [
+            field
+            for field in ("inputs", "outputs")
+            if payload.get(field) is not None
+            and len(_json.dumps(payload[field], default=str)) > self.max_field_bytes
+        ]
+
+    def ingest(self, payloads: List[Dict[str, Any]]) -> List[Tuple[str, str]]:
+        """Send one batch, isolating a bad run by binary split.
+
+        Returns ``[(run_id, error)]`` for runs that could not be ingested. A
+        single-run conflict is replay success: the SDK breaks out of its retry
+        loop without reporting it, so it never reaches us as an error.
+        """
+        if not payloads or self.config.migration.dry_run:
+            return []
+        n, traces, size = self._shape(payloads)
+        # Deliberately louder than the query lines around it: this is the only
+        # step that writes, and it is otherwise invisible - multipart_ingest
+        # goes through the SDK, which does not emit the client's request logs.
+        self.console.print(
+            f"[bold cyan]  ==> MULTIPART INGEST -> destination[/bold cyan] "
+            f"[cyan]runs {n} | traces {traces} | {self._human(size)}[/cyan]"
+        )
+        self._sync_dest_headers()
+        del self._ingest_errors[:]
+        try:
+            self.dest_ls_client.multipart_ingest(create=payloads)
+            error = self._ingest_errors[0] if self._ingest_errors else None
+        except Exception as exc:  # pragma: no cover - defensive
+            error = exc
+        if error is None:
+            return []
+        if len(payloads) == 1:
+            return [(str(payloads[0]["id"]), str(error))]
+        mid = len(payloads) // 2
+        self.console.print(
+            f"[yellow]  ==> batch of {len(payloads)} rejected; splitting to isolate the bad run[/yellow]"
+        )
+        return self.ingest(payloads[:mid]) + self.ingest(payloads[mid:])
+
+    # ------------------------------------------------------------------
+    # Sessions
+    # ------------------------------------------------------------------
+    def list_source_sessions(self) -> List[Dict[str, Any]]:
+        """Real tracing sessions only - never experiment/test-run sessions."""
+        return [
+            s
+            for s in self.source.get_paginated("/sessions", params={"reference_free": "true"}, page_size=100)
+            if isinstance(s, dict) and not s.get("reference_dataset_id")
+        ]
+
+    def get_source_session(self, value: str) -> Optional[Dict[str, Any]]:
+        """Fetch one source tracing session by ID. ``None`` when it is not one.
+
+        Only a 404 means "not a session ID". Anything else - a rate limit, a
+        gateway blip - is re-raised: swallowing it would make a transient
+        failure indistinguishable from a name the operator mistyped, and the
+        command would report success having migrated nothing.
+        """
+        try:
+            session = self.source.get(f"/sessions/{value}")
+        except NotFoundError:
+            return None
+        except APIError as exc:
+            if "404" in str(exc):
+                return None
+            raise
+        if not isinstance(session, dict) or session.get("reference_dataset_id"):
+            return None
+        return session
+
+    def find_source_session(self, value: str) -> Tuple[Optional[Dict[str, Any]], str]:
+        """Resolve one ``--project`` value, by ID or by exact name.
+
+        Returns ``(session, reason)``. The name lookup uses the endpoint's own
+        ``name`` filter rather than enumerating sessions: a busy deployment has
+        tens of thousands of them, so a full walk would take minutes to answer
+        a question the backend answers in one request.
+        """
+        # Only try the ID endpoint when the value actually is one: it rejects a
+        # non-UUID path segment with a 422, and sniffing that out of an error
+        # string to decide "this was a name all along" is the wrong shape.
+        try:
+            uuid.UUID(str(value))
+        except (ValueError, AttributeError, TypeError):
+            pass
+        else:
+            by_id = self.get_source_session(value)
+            if by_id:
+                return by_id, "id"
+        matches = [
+            s
+            for s in (self.source.get("/sessions", params={"name": value, "reference_free": "true"}) or [])
+            if isinstance(s, dict) and not s.get("reference_dataset_id")
+        ]
+        if len(matches) > 1:
+            return None, "ambiguous"
+        return (matches[0], "name") if matches else (None, "missing")
+
+    def _dest_sessions_by_name(self) -> Dict[str, List[Dict[str, Any]]]:
+        index: Dict[str, List[Dict[str, Any]]] = {}
+        for s in self.dest.get_paginated("/sessions", params={"reference_free": "true"}, page_size=100):
+            if isinstance(s, dict) and not s.get("reference_dataset_id"):
+                index.setdefault(s.get("name"), []).append(s)
+        return index
+
+    def resolve_dest_session(self, source_session: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Operator mapping -> destination name match -> create.
+
+        Re-derived every invocation and never read back from state. Nothing
+        downstream may assume the two IDs are equal: reusing the source ID on
+        create is a convenience, and a rejection is normal progress.
+        """
+        source_id = str(source_session["id"])
+        name = source_session.get("name")
+        target_name = f"{name}{self.into_session_suffix}" if self.into_session_suffix else name
+
+        mapped = self.project_id_map.get(source_id)
+        if mapped:
+            try:
+                existing = self.dest.get(f"/sessions/{mapped}")
+            except Exception as exc:
+                self.log(f"Mapped destination project {mapped} is not reachable: {exc}", "warning")
+                existing = None
+            if existing:
+                return existing
+
+        by_name = self._dest_sessions_by_name()
+        matches = by_name.get(target_name) or []
+        if len(matches) > 1:
+            self.log(f"Ambiguous destination session name '{target_name}'; supply --project-mapping", "warning")
+            return None
+        if matches:
+            return matches[0]
+
+        if self.config.migration.dry_run:
+            return {"id": f"dry-run-{source_id}", "name": target_name, "trace_tier": LONGLIVED}
+
+        # Explicit tier, never omitted: a nil tier resolves to the destination
+        # tenant's default, and the tier cannot be repaired after ingest.
+        payload = {
+            "name": target_name,
+            "description": source_session.get("description"),
+            "metadata": source_session.get("metadata"),
+            "extra": source_session.get("extra"),
+            "start_time": source_session.get("start_time"),
+            "end_time": source_session.get("end_time"),
+            "trace_tier": source_session.get("trace_tier") if self.emit_upgrade_list else LONGLIVED,
+        }
+        # Reusing the source ID is convenient, not load-bearing: a rejection
+        # just means the session gets mapped instead.
+        with_id = payload if self.into_session_suffix else {**payload, "id": source_id}
+        try:
+            created = self.dest.post("/sessions", with_id)
+        except Exception as exc:
+            _raise_if_tier_denied(exc)
+            created = None
+        if not created or not created.get("id"):
+            try:
+                created = self.dest.post("/sessions", payload)
+            except Exception as exc:
+                _raise_if_tier_denied(exc)
+                raise
+            self.log(f"Destination session for '{name}' created with a new ID {created.get('id')}", "info")
+        return created
+
+    def ensure_long_lived(self, dest_session: Dict[str, Any]) -> None:
+        """Raise an existing session's tier and wait until the raise is observable.
+
+        The ingest path caches session lookups, and a stale short-lived entry
+        writes blobs under the short-lived prefix - which cannot be repaired
+        afterwards. So we re-read until the new tier comes back before any run
+        is ingested into it.
+        """
+        if self.emit_upgrade_list or self.config.migration.dry_run:
+            return
+        if dest_session.get("trace_tier") == LONGLIVED:
+            return
+        session_id = dest_session["id"]
+        try:
+            self.dest.patch(f"/sessions/{session_id}", {"trace_tier": LONGLIVED})
+        except Exception as exc:
+            raise TracePreflightError(f"trace_tier_permission_denied: {exc}") from exc
+        for attempt in range(_VERIFY_ATTEMPTS):
+            current = self.dest.get(f"/sessions/{session_id}") or {}
+            if current.get("trace_tier") == LONGLIVED:
+                dest_session["trace_tier"] = LONGLIVED
+                return
+            time.sleep(_VERIFY_BACKOFF * (attempt + 1))
+        raise TracePreflightError(f"trace_tier_not_observed for session {session_id}")
+
+    def restore_tier(self, dest_session: Dict[str, Any], source_tier: Optional[str]) -> None:
+        """Put a raised session back, so only the session being migrated is exposed."""
+        if self.config.migration.dry_run or not source_tier or source_tier == LONGLIVED:
+            return
+        try:
+            self.dest.patch(f"/sessions/{dest_session['id']}", {"trace_tier": source_tier})
+        except Exception as exc:
+            self.log(f"Could not restore trace tier on {dest_session['id']}: {exc}", "warning")
+
+    # ------------------------------------------------------------------
+    # Pre-flight
+    # ------------------------------------------------------------------
+    def canary(self) -> None:
+        """Prove the destination still accepts a timestamp at the far end of the range.
+
+        Historical ingest is refused outright by a deployment that enforces the
+        ±24h window, and the whole multipart request fails - so this is checked
+        once, before anything is migrated, rather than discovered mid-transfer.
+        The run ID is deterministic and the session is scratch, so repeated
+        stateless invocations upsert one canary instead of accumulating them.
+        """
+        if self.config.migration.dry_run:
+            return
+        session = self._scratch_session()
+        # Quantised to the hour, and the ID derived from it: ``start_time`` is
+        # part of the destination's dedup key, so a canary re-sent under the
+        # same ID with a drifted timestamp lands as a *second* row and the
+        # read-back then compares against the wrong one. Same hour, same pair,
+        # real upsert. Run deletion is not exposed by the API, so the scratch
+        # project keeps at most one canary per hour the tool is used.
+        stamp = (datetime.now(timezone.utc) - timedelta(days=self.max_age_days)).replace(
+            minute=0, second=0, microsecond=0
+        )
+        run_id = str(uuid.uuid5(_CANARY_NS, f"canary:{session['id']}:{stamp.isoformat()}"))
+        payload = {
+            "id": run_id,
+            "trace_id": run_id,
+            "session_id": str(session["id"]),
+            "name": "langsmith-migrator historical ingest canary",
+            "run_type": "chain",
+            "start_time": stamp.isoformat(),
+            "end_time": stamp.isoformat(),
+            "dotted_order": f"{stamp.strftime('%Y%m%dT%H%M%S%fZ')}{run_id}",
+            "status": "success",
+            "inputs": {"canary": True},
+        }
+        failures = self.ingest([payload])
+        if failures:
+            self._block_historical(f"ingest rejected: {failures[0][1]}")
+        for attempt in range(_VERIFY_ATTEMPTS):
+            time.sleep(_VERIFY_BACKOFF * (attempt + 1))
+            try:
+                run = self.dest.get(f"/runs/{run_id}")
+            except Exception:
+                run = None
+            if run and run.get("start_time"):
+                observed = str(run["start_time"])[:19]
+                if observed != stamp.isoformat()[:19]:
+                    self._block_historical(f"start_time rewritten to {observed}")
+                return
+        self._block_historical("canary run absent after ingest")
+
+    def _block_historical(self, detail: str) -> None:
+        next_action = (
+            "Raise the destination's ingest time window "
+            "(V1_INGEST_ENFORCE_TIME_WINDOW_EXCLUDED_ORGS) and re-run `langsmith-migrator traces`."
+        )
+        issue = self.record_issue(
+            "blocked",
+            "historical_ingest_rejected",
+            f"Destination refuses historical run timestamps ({self.max_age_days:g}d): {detail}",
+            next_action=next_action,
+            evidence={"max_age_days": self.max_age_days, "detail": detail},
+        )
+        if issue:
+            self.queue_remediation(issue_id=issue.id, next_action=next_action, command="langsmith-migrator traces")
+        raise TracePreflightError(f"historical_ingest_rejected: {detail}")
+
+    def _scratch_session(self) -> Dict[str, Any]:
+        for existing in self._dest_sessions_by_name().get(_CANARY_SESSION, []):
+            return existing
+        return self.dest.post("/sessions", {"name": _CANARY_SESSION, "description": "langsmith-migrator pre-flight canary"})
+
+    # ------------------------------------------------------------------
+    # The unit of work
+    # ------------------------------------------------------------------
+    def migrate_slice(
+        self, source_session: Dict[str, Any], dest_session: Dict[str, Any], window: Window
+    ) -> SliceReconciliation:
+        """Diff, ingest the difference, confirm it is empty, sample content."""
+        src_id, dst_id = str(source_session["id"]), str(dest_session["id"])
+        population = self.slice_runs(self.source, src_id, window)
+        if not population:
+            return SliceReconciliation(src_id, dst_id, window.label(), 0, 0, 0, 0, 0)
+        source_ids = {str(r["id"]) for r in population}
+
+        # With --emit-upgrade-list the destination sessions stay at their
+        # existing tier, so filtering on tier there would read every migrated
+        # run as missing.
+        dest_ids = (
+            set()
+            if self.config.migration.dry_run
+            else self.long_lived_run_ids(self.dest, dst_id, window, tier_filter=not self.emit_upgrade_list)
+        )
+        plan = plan_slice(source_ids, dest_ids)
+
+        if self.emit_upgrade_list:
+            # Derived from the window's source population, not the diff: built
+            # from the diff, a re-run whose differences are all empty would
+            # emit an empty list.
+            self.upgrade_rows.extend(
+                (dst_id, str(r["trace_id"]), str(r["start_time"]))
+                for r in population
+                if str(r.get("trace_id")) == str(r.get("id"))
+            )
+            # Reported against the whole population for the same reason, and
+            # kept out of the reconciliation buckets so the parts still
+            # partition the source total exactly once.
+            self.record_issue(
+                "degraded",
+                "longlived_pending_operator_upgrade",
+                f"{len(source_ids)} run(s) in {window.label()} are not yet long-lived: "
+                "the destination project was left at its existing tier",
+                next_action=_DEGRADED_ACTIONS["longlived_pending_operator_upgrade"],
+                evidence={"window": window.label(), "count": len(source_ids), "dest_session_id": dst_id},
+            )
+
+        degraded: Dict[str, Set[str]] = {}
+        blocked: Set[str] = set()
+        digests = self._ingest_plan(src_id, dst_id, window, plan, degraded, blocked)
+
+        if self.verify and plan.to_ingest and not self.config.migration.dry_run:
+            still_missing = self._confirm(dst_id, window, plan.to_ingest - blocked)
+            if still_missing:
+                blocked |= still_missing
+                self._block_runs(window, still_missing)
+            if digests:
+                self._check_content(dst_id, window, digests, degraded)
+
+        self._report_degraded(window, degraded)
+
+        # A run can be both degraded and blocked; blocked wins, so the parts
+        # stay a partition of the source total.
+        degraded_ids = set().union(*degraded.values()) if degraded else set()
+        degraded_only = degraded_ids - blocked
+        return SliceReconciliation(
+            session_id=src_id,
+            dest_session_id=dst_id,
+            window=window.label(),
+            source_total=len(plan.source_ids),
+            ingested=len(plan.to_ingest) - len(degraded_only) - len(blocked),
+            already_present=len(plan.already_present),
+            degraded=len(degraded_only),
+            blocked=len(blocked),
+            extra_on_dest=len(plan.extra_on_dest),
+        )
+
+    def _ingest_plan(
+        self,
+        src_id: str,
+        dst_id: str,
+        window: Window,
+        plan: SlicePlan,
+        degraded: Dict[str, Set[str]],
+        blocked: Set[str],
+    ) -> Dict[str, Dict[str, str]]:
+        """Fetch, adapt and send the diff. Returns digests for the sampled runs."""
+        digests: Dict[str, Dict[str, str]] = {}
+        if not plan.to_ingest:
+            return digests
+
+        prepared: List[Dict[str, Any]] = []
+        for run in self.fetch_runs(src_id, window, sorted(plan.to_ingest)):
+            run_id = str(run["id"])
+            overrides, issues = self.materialise(run)
+            payload_obj, dropped = to_ingest_payload(run, dst_id, overrides)
+            payload = payload_obj.as_dict()
+
+            oversized = self._oversized_fields(payload)
+            if oversized:
+                # The backend stubs an oversized field rather than rejecting
+                # it, so this run must not be reported as fully migrated.
+                degraded.setdefault("payload_oversized_for_destination", set()).add(run_id)
+                self.fidelity_reduced.add("after raising --max-field-bytes")
+                continue
+
+            codes = set(issues)
+            if dropped:
+                codes.add("run_example_link_dropped")
+            for code in codes:
+                degraded.setdefault(code, set()).add(run_id)
+                if code in ("attachment_fetch_failed", "attachment_host_rejected"):
+                    self.fidelity_reduced.add("once the source blob store is reachable")
+
+            if len(digests) < self.verify_content_sample:
+                digests[run_id] = self._digest_of(run, overrides)
+            prepared.append(payload)
+
+        max_runs, max_bytes = self.batch_limits()
+        for batch in batch_traces(
+            group_into_traces(prepared), max_runs=max_runs, max_bytes=max_bytes, size_of=self._size_of
+        ):
+            for run_id, error in self.ingest(batch):
+                blocked.add(run_id)
+                self.log(f"Run {run_id} rejected: {str(error)[:200]}", "error")
+        return digests
+
+    @staticmethod
+    def _digest_of(run: Dict[str, Any], overrides: Dict[str, Any]) -> Dict[str, str]:
+        merged = {**run, **overrides}
+        sizes = {name: len(data) for name, (_, data) in (overrides.get("attachments") or {}).items()}
+        return payload_digest(merged, sizes)
+
+    def _confirm(self, dest_session_id: str, window: Window, expected: Set[str]) -> Set[str]:
+        """Re-query with backoff until the difference is empty or attempts run out."""
+        missing = set(expected)
+        for attempt in range(_VERIFY_ATTEMPTS):
+            time.sleep(_VERIFY_BACKOFF * (attempt + 1))
+            missing -= self.long_lived_run_ids(
+                self.dest, dest_session_id, window, tier_filter=not self.emit_upgrade_list
+            )
+            if not missing:
+                return set()
+        return missing
+
+    def _check_content(
+        self, dest_session_id: str, window: Window, digests: Dict[str, Dict[str, str]], degraded: Dict[str, Set[str]]
+    ) -> None:
+        """Compare sampled per-field digests. Reports field names, never values."""
+        mismatched: Dict[str, List[str]] = {}
+        for run in self.fetch_runs_dest(dest_session_id, window, sorted(digests)):
+            run_id = str(run["id"])
+            if run_id not in digests:
+                continue
+            overrides, _ = self.materialise(run)
+            fields = digest_mismatches(digests[run_id], self._digest_of(run, overrides))
+            if fields:
+                mismatched[run_id] = list(fields)
+                degraded.setdefault("run_fidelity_mismatch", set()).add(run_id)
+        if mismatched:
+            self.record_issue(
+                "degraded",
+                "run_fidelity_mismatch",
+                f"{len(mismatched)} sampled run(s) differ from the source ({window.label()})",
+                next_action="Re-migrate this window into a fresh destination project.",
+                # Field names and counts only - never values.
+                evidence={"window": window.label(), "runs": dict(list(mismatched.items())[:20])},
+            )
+
+    def fetch_runs_dest(self, session_id: str, window: Window, run_ids: Sequence[str]) -> Iterator[Dict[str, Any]]:
+        ids = list(run_ids)
+        for start in range(0, len(ids), _ID_CHUNK):
+            yield from self._query_runs(
+                self.dest, session_id, window, select=RUN_QUERY_SELECT, ids=ids[start : start + _ID_CHUNK]
+            )
+
+    def _report_degraded(self, window: Window, degraded: Dict[str, Set[str]]) -> None:
+        """One issue per (window, code), not per run.
+
+        ``record_issue`` rewrites the whole state file, so per-run issues would
+        make a large window quadratic in I/O for no extra information.
+        """
+        for code, run_ids in sorted(degraded.items()):
+            if code == "run_fidelity_mismatch":
+                continue  # already reported with its field names
+            self.record_issue(
+                "degraded",
+                code,
+                f"{len(run_ids)} run(s) migrated with reduced fidelity ({code}) in {window.label()}",
+                next_action=_DEGRADED_ACTIONS.get(code),
+                evidence={"window": window.label(), "count": len(run_ids), "run_ids": sorted(run_ids)[:20]},
+            )
+
+    def _block_runs(self, window: Window, run_ids: Set[str]) -> None:
+        next_action = "Re-run `langsmith-migrator traces` for this window; the diff will re-send them."
+        issue = self.record_issue(
+            "blocked",
+            "run_not_ingested",
+            f"{len(run_ids)} run(s) still missing from the destination after ingest ({window.label()})",
+            next_action=next_action,
+            evidence={"window": window.label(), "run_ids": sorted(run_ids)[:20], "count": len(run_ids)},
+        )
+        if issue:
+            self.queue_remediation(issue_id=issue.id, next_action=next_action, command="langsmith-migrator traces")
+
+    # ------------------------------------------------------------------
+    # Per-session driver
+    # ------------------------------------------------------------------
+    def migrate_session(self, source_session: Dict[str, Any], now: Optional[datetime] = None) -> Optional[SessionReconciliation]:
+        """Raise tier -> migrate windows oldest-first -> verify -> restore."""
+        dest_session = self.resolve_dest_session(source_session)
+        if not dest_session:
+            return None
+        self.ensure_long_lived(dest_session)
+
+        slices = []
+        for window in iter_windows(now or datetime.now(timezone.utc), self.max_age_days, self.window_days):
+            recon = self.migrate_slice(source_session, dest_session, window)
+            slices.append(recon)
+            if recon.source_total:
+                # Per-slice detail is verbose-only: the range can be 180
+                # windows wide, and the per-session total is always printed.
+                self.log(
+                    f"  {recon.window}: source {recon.source_total} = ingested {recon.ingested}"
+                    f" + already present {recon.already_present}"
+                    f" + degraded {recon.degraded} + blocked {recon.blocked}",
+                    "info",
+                )
+        recon = SessionReconciliation.of(str(source_session["id"]), str(dest_session["id"]), slices)
+
+        source_tier = source_session.get("trace_tier")
+        restore = self.restore_session_tier
+        if restore is None:
+            restore = source_tier != LONGLIVED
+        # Never restore an incomplete session: a re-run must still ingest long-lived.
+        if restore and recon.complete:
+            self.restore_tier(dest_session, source_tier)
+        return recon

--- a/langsmith_migrator/core/migrators/trace.py
+++ b/langsmith_migrator/core/migrators/trace.py
@@ -313,11 +313,9 @@ class TraceMigrator(BaseMigrator):
         """
         overrides: Dict[str, Any] = {}
         issues: List[str] = []
-        host, sess = (
-            (self._source_blob_host, self.source.session)
-            if side == "source"
-            else (self._dest_blob_host, self.dest.session)
-        )
+        src = side == "source"
+        host = self._source_blob_host if src else self._dest_blob_host
+        sess = (self.source if src else self.dest).session
 
         def pull(field: str, ref: Dict[str, Any], limit: int) -> None:
             url = (ref or {}).get("presigned_url")
@@ -563,12 +561,12 @@ class TraceMigrator(BaseMigrator):
             time.sleep(_VERIFY_BACKOFF * (attempt + 1))
         raise TracePreflightError(f"trace_tier_not_observed for session {session_id}")
 
-    def restore_tier(self, dest_session: Dict[str, Any], source_tier: Optional[str]) -> None:
-        """Put a raised session back, so only the session being migrated is exposed."""
-        if self.config.migration.dry_run or not source_tier or source_tier == LONGLIVED:
+    def restore_tier(self, dest_session: Dict[str, Any], tier: Optional[str]) -> None:
+        """Put a raised session back to the tier it had before we touched it."""
+        if self.config.migration.dry_run or not tier or tier == LONGLIVED:
             return
         try:
-            self.dest.patch(f"/sessions/{dest_session['id']}", {"trace_tier": source_tier})
+            self.dest.patch(f"/sessions/{dest_session['id']}", {"trace_tier": tier})
         except Exception as exc:
             self.log(f"Could not restore trace tier on {dest_session['id']}: {exc}", "warning")
 
@@ -851,32 +849,74 @@ class TraceMigrator(BaseMigrator):
     # Per-session driver
     # ------------------------------------------------------------------
     def migrate_session(self, source_session: Dict[str, Any], now: Optional[datetime] = None) -> Optional[Reconciliation]:
-        """Raise tier -> migrate windows oldest-first -> verify -> restore."""
+        """Raise tier -> migrate windows oldest-first -> verify -> restore.
+
+        The tier is settled in a ``finally``: once an existing project has been
+        raised, walking away without deciding what to do about it would leave a
+        project long-lived indefinitely on any mid-run failure, silently
+        changing retention for traffic that has nothing to do with this
+        migration.
+        """
         dest_session = self.resolve_dest_session(source_session)
         if not dest_session:
             return None
+        prior_tier = dest_session.get("trace_tier")
         self.ensure_long_lived(dest_session)
 
-        slices = []
-        for window in iter_windows(now or datetime.now(timezone.utc), self.max_age_days, self.window_days):
-            recon = self.migrate_slice(source_session, dest_session, window)
-            slices.append(recon)
-            if recon.source_total:
-                # Per-slice detail is verbose-only: the range can be 180
-                # windows wide, and the per-session total is always printed.
-                self.log(
-                    f"  {recon.window}: source {recon.source_total} = ingested {recon.ingested}"
-                    f" + already present {recon.already_present}"
-                    f" + degraded {recon.degraded} + blocked {recon.blocked}",
-                    "info",
-                )
-        recon = Reconciliation.of(str(source_session["id"]), str(dest_session["id"]), slices)
+        recon = None
+        try:
+            slices = []
+            for window in iter_windows(now or datetime.now(timezone.utc), self.max_age_days, self.window_days):
+                sliced = self.migrate_slice(source_session, dest_session, window)
+                slices.append(sliced)
+                if sliced.source_total:
+                    # Per-slice detail is verbose-only: the range can be 180
+                    # windows wide, and the per-session total is always printed.
+                    self.log(
+                        f"  {sliced.window}: source {sliced.source_total} = ingested {sliced.ingested}"
+                        f" + already present {sliced.already_present}"
+                        f" + degraded {sliced.degraded} + blocked {sliced.blocked}",
+                        "info",
+                    )
+            recon = Reconciliation.of(str(source_session["id"]), str(dest_session["id"]), slices)
+            return recon
+        finally:
+            self._settle_tier(dest_session, prior_tier, source_session.get("trace_tier"), recon)
 
-        source_tier = source_session.get("trace_tier")
+    def _settle_tier(
+        self,
+        dest_session: Dict[str, Any],
+        prior_tier: Optional[str],
+        source_tier: Optional[str],
+        recon: Optional[Reconciliation],
+    ) -> None:
+        """Restore a raised destination tier, or say why it was left raised.
+
+        ``ensure_long_lived`` only mutates the session dict on a real raise, so
+        a changed tier is exactly "we raised this one".
+        """
+        if dest_session.get("trace_tier") == prior_tier:
+            return
         restore = self.restore_session_tier
         if restore is None:
             restore = source_tier != LONGLIVED
-        # Never restore an incomplete session: a re-run must still ingest long-lived.
-        if restore and recon.complete:
-            self.restore_tier(dest_session, source_tier)
-        return recon
+        if not restore:
+            return
+        if recon is not None and recon.complete:
+            self.restore_tier(dest_session, prior_tier)
+            return
+        # Left raised on purpose - a re-run must still ingest long-lived - but
+        # recorded, because an operator otherwise has no way to know this
+        # project's retention was changed and not put back.
+        reason = "the migration did not finish" if recon is None else "the project has blocked runs"
+        self.record_issue(
+            "degraded",
+            "dest_tier_left_raised",
+            f"Destination project {dest_session['id']} was raised to {LONGLIVED} and left raised "
+            f"because {reason}",
+            next_action=(
+                f"Re-run `langsmith-migrator traces` to finish it, or set the tier back to "
+                f"'{prior_tier}' by hand once you no longer need it raised."
+            ),
+            evidence={"dest_session_id": str(dest_session["id"]), "prior_tier": prior_tier, "reason": reason},
+        )

--- a/langsmith_migrator/core/trace_domain.py
+++ b/langsmith_migrator/core/trace_domain.py
@@ -24,9 +24,11 @@ LONGLIVED = "longlived"
 SKEW_BUFFER = timedelta(seconds=60)
 
 # Read-only fields the query API returns that we need to materialise a payload
-# but must never forward: blob references, and the source-only example pointer.
-BLOB_REF_FIELDS = ("inputs_s3_urls", "outputs_s3_urls", "s3_urls")
-READ_ONLY_SELECT = BLOB_REF_FIELDS + ("trace_tier", "reference_example_id")
+# but must never forward: blob references, the tier, and the source-only
+# example pointer.
+READ_ONLY_SELECT = (
+    "inputs_s3_urls", "outputs_s3_urls", "s3_urls", "trace_tier", "reference_example_id",
+)
 
 # Fields of the write contract that the query API cannot project. Attachments
 # come back as ``s3_urls["attachment.<name>"]`` entries instead.
@@ -251,8 +253,6 @@ def batch_traces(
 class SlicePlan:
     """What one ``(session, window)`` diff says to do."""
 
-    source_ids: Set[str]
-    dest_ids: Set[str]
     to_ingest: Set[str]
     already_present: Set[str]
     extra_on_dest: Set[str]
@@ -266,23 +266,23 @@ def plan_slice(source_ids: Set[str], dest_ids: Set[str]) -> SlicePlan:
     on the destination cannot repair it. Repair means writing into a *different*
     destination session, because run identity includes ``session_id``.
     """
-    present = source_ids & dest_ids
     return SlicePlan(
-        source_ids=source_ids,
-        dest_ids=dest_ids,
         to_ingest=source_ids - dest_ids,
-        already_present=present,
+        already_present=source_ids & dest_ids,
         extra_on_dest=dest_ids - source_ids,
     )
 
 
 @dataclass(frozen=True)
-class SliceReconciliation:
-    """Counts for one window. The parts must account for the source total."""
+class Reconciliation:
+    """Counts for one window, or a session's total. The parts must account for
+    the source total, so the "counts add up" rule holds on every real run
+    rather than only in a test.
+    """
 
     session_id: str
     dest_session_id: str
-    window: str
+    window: str  # "" for a session-level total
     source_total: int
     ingested: int
     already_present: int
@@ -293,41 +293,21 @@ class SliceReconciliation:
     def __post_init__(self) -> None:
         total = self.ingested + self.already_present + self.degraded + self.blocked
         if total != self.source_total:
+            scope = f"window {self.window}" if self.window else f"session {self.session_id}"
             raise ValueError(
-                f"reconciliation does not add up for {self.window}: "
-                f"source_total={self.source_total} but parts sum to {total}"
-            )
-
-
-@dataclass(frozen=True)
-class SessionReconciliation:
-    """Sum of a session's slices, with the same invariant."""
-
-    session_id: str
-    dest_session_id: str
-    source_total: int
-    ingested: int
-    already_present: int
-    degraded: int
-    blocked: int
-    extra_on_dest: int = 0
-
-    def __post_init__(self) -> None:
-        total = self.ingested + self.already_present + self.degraded + self.blocked
-        if total != self.source_total:
-            raise ValueError(
-                f"reconciliation does not add up for session {self.session_id}: "
+                f"reconciliation does not add up for {scope}: "
                 f"source_total={self.source_total} but parts sum to {total}"
             )
 
     @classmethod
-    def of(cls, session_id: str, dest_session_id: str, slices: Sequence[SliceReconciliation]):
+    def of(cls, session_id: str, dest_session_id: str, slices: Sequence["Reconciliation"]) -> "Reconciliation":
         def s(attr: str) -> int:
             return sum(getattr(x, attr) for x in slices)
 
         return cls(
             session_id=session_id,
             dest_session_id=dest_session_id,
+            window="",
             source_total=s("source_total"),
             ingested=s("ingested"),
             already_present=s("already_present"),

--- a/langsmith_migrator/core/trace_domain.py
+++ b/langsmith_migrator/core/trace_domain.py
@@ -1,0 +1,341 @@
+"""Pure core for long-lived trace migration.
+
+No HTTP client, no implicit clock: every function here takes what it needs and
+returns a value, so the requirements it encodes (windowing, the read/write
+contract split, digests, reconciliation arithmetic) are unit-testable without
+mocking a backend. The imperative shell lives in ``core/migrators/trace.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, fields
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Set, Tuple
+
+LONGLIVED = "longlived"
+
+# Root and child runs of one trace can be stamped microseconds apart in either
+# direction (the backend buffers for the same skew). The run-level lower bound
+# is relaxed by this much so a child stamped just before its own root is still
+# returned. It never widens which *traces* are selected - that is decided by
+# the trace-level predicate on the root.
+SKEW_BUFFER = timedelta(seconds=60)
+
+# Read-only fields the query API returns that we need to materialise a payload
+# but must never forward: blob references, and the source-only example pointer.
+BLOB_REF_FIELDS = ("inputs_s3_urls", "outputs_s3_urls", "s3_urls")
+READ_ONLY_SELECT = BLOB_REF_FIELDS + ("trace_tier", "reference_example_id")
+
+# Fields of the write contract that the query API cannot project. Attachments
+# come back as ``s3_urls["attachment.<name>"]`` entries instead.
+WRITE_ONLY_FIELDS = frozenset({"attachments"})
+
+# Offloadable payload fields carried in the generic ``s3_urls`` map.
+S3_URL_PAYLOAD_FIELDS = ("extra", "events", "error", "serialized", "inputs", "outputs")
+ATTACHMENT_PREFIX = "attachment."
+
+
+@dataclass(frozen=True)
+class RunIngestPayload:
+    """The ingest write contract (``smith-go/runs/runs.go`` ``type Run struct``).
+
+    Constructing one *is* the allow-list: ``manifest_id``, ``*_s3_urls``,
+    ``reference_example_id`` and the token/cost rollups are structurally
+    unsendable because there is no field to put them in. An SDK or backend bump
+    means re-checking this list against that Go struct.
+    """
+
+    id: str
+    trace_id: str
+    name: str
+    run_type: str
+    start_time: str
+    dotted_order: str
+    session_id: str
+    end_time: Optional[str] = None
+    parent_run_id: Optional[str] = None
+    status: Optional[str] = None
+    inputs: Optional[Any] = None
+    outputs: Optional[Any] = None
+    extra: Optional[Any] = None
+    error: Optional[Any] = None
+    serialized: Optional[Any] = None
+    events: Optional[Any] = None
+    tags: Optional[Any] = None
+    attachments: Optional[Dict[str, Tuple[str, bytes]]] = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Drop unset optionals so the destination keeps its own defaults."""
+        return {f.name: getattr(self, f.name) for f in fields(self) if getattr(self, f.name) is not None}
+
+
+# Derived, not hand-maintained: adding a field to the write contract selects it
+# with no second edit. Order is stable for test comparison.
+RUN_QUERY_SELECT: Tuple[str, ...] = tuple(
+    [f.name for f in fields(RunIngestPayload) if f.name not in WRITE_ONLY_FIELDS]
+    + list(READ_ONLY_SELECT)
+)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class Window:
+    """A half-open ``[start, end)`` slice of the walked range."""
+
+    start: datetime
+    end: datetime
+
+    def label(self) -> str:
+        return f"{self.start.date()}..{self.end.date()}"
+
+
+def iter_windows(now: datetime, max_age_days: float, window_days: float) -> Iterator[Window]:
+    """Yield half-open windows covering ``[now - max_age_days, now)``, oldest first.
+
+    Windows abut exactly, so every instant in the range belongs to exactly one.
+    """
+    if max_age_days <= 0 or window_days <= 0:
+        raise ValueError("max_age_days and window_days must be positive")
+    start = now - timedelta(days=max_age_days)
+    step = timedelta(days=window_days)
+    while start < now:
+        end = min(start + step, now)
+        yield Window(start, end)
+        start = end
+
+
+def resolve_window_bounds(window: Window) -> Tuple[str, str]:
+    """Return ``(trace_filter, run_level_start_time)`` for one window.
+
+    The window is expressed **only** as a predicate on the trace root, so a
+    trace is selected whole and belongs to exactly one window. There is
+    deliberately no run-level upper bound: children start after their root, so
+    one would truncate late children out of in-window traces. The run-level
+    lower bound is always sent explicitly (the endpoint otherwise defaults to
+    ~1 day ago) and carries the skew buffer.
+    """
+    trace_filter = (
+        f'and(gte(start_time,"{_iso(window.start)}"),lt(start_time,"{_iso(window.end)}"))'
+    )
+    return trace_filter, _iso(window.start - SKEW_BUFFER)
+
+
+def is_long_lived(run: Dict[str, Any]) -> bool:
+    """Tier predicate applied client-side.
+
+    ``trace_tier`` is not accepted inside ``trace_filter`` on the V1 endpoint
+    ("Attribute trace_tier not accepted"), but it *is* returned on every run,
+    so the filter moves here.
+    """
+    return run.get("trace_tier") == LONGLIVED
+
+
+def to_ingest_payload(
+    source_run: Dict[str, Any],
+    dest_session_id: str,
+    materialised: Optional[Dict[str, Any]] = None,
+) -> Tuple[RunIngestPayload, Tuple[str, ...]]:
+    """Adapt one queried run to the write contract.
+
+    ``materialised`` supplies re-inlined values for fields the source offloaded
+    to blob storage (and the fetched ``attachments``); it overrides the run's
+    own value for those keys. Returns the payload plus the names of source
+    fields that could not be carried, for ``degraded`` reporting.
+    """
+    merged = dict(source_run)
+    merged.update(materialised or {})
+
+    dropped: List[str] = []
+    if source_run.get("reference_example_id"):
+        dropped.append("reference_example_id")
+
+    payload = RunIngestPayload(
+        id=str(merged["id"]),
+        trace_id=str(merged["trace_id"]),
+        name=merged.get("name") or "run",
+        run_type=merged.get("run_type") or "chain",
+        start_time=merged["start_time"],
+        dotted_order=merged["dotted_order"],
+        session_id=str(dest_session_id),
+        end_time=merged.get("end_time"),
+        parent_run_id=(str(merged["parent_run_id"]) if merged.get("parent_run_id") else None),
+        status=merged.get("status"),
+        inputs=merged.get("inputs"),
+        outputs=merged.get("outputs"),
+        extra=merged.get("extra"),
+        error=merged.get("error"),
+        serialized=merged.get("serialized"),
+        events=merged.get("events"),
+        tags=merged.get("tags"),
+        attachments=merged.get("attachments") or None,
+    )
+    return payload, tuple(dropped)
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def payload_digest(run: Dict[str, Any], attachments: Optional[Dict[str, int]] = None) -> Dict[str, str]:
+    """Per-field digests over a materialised run, for the fidelity comparison.
+
+    Field *names* and digests are safe to report; values are not. ``serialized``
+    is only compared for llm/prompt runs, because the SDK drops it for every
+    other run type on the way in.
+    """
+    parts = {
+        "inputs": run.get("inputs"),
+        "outputs": run.get("outputs"),
+        "error": run.get("error"),
+        "events": run.get("events"),
+    }
+    if run.get("run_type") in ("llm", "prompt"):
+        parts["serialized"] = run.get("serialized")
+    if attachments is not None:
+        parts["attachments"] = sorted(attachments.items())
+    return {
+        key: hashlib.sha256(_canonical(value).encode()).hexdigest()[:16]
+        for key, value in parts.items()
+    }
+
+
+def digest_mismatches(left: Dict[str, str], right: Dict[str, str]) -> Tuple[str, ...]:
+    """Field names whose digests differ. Never returns values."""
+    return tuple(sorted(k for k in set(left) | set(right) if left.get(k) != right.get(k)))
+
+
+def group_into_traces(runs: Iterable[Dict[str, Any]]) -> List[List[Dict[str, Any]]]:
+    """Group runs by ``trace_id``, parents before children within each trace.
+
+    Sorting on ``dotted_order`` puts a parent before its children because a
+    child's dotted order is its parent's plus a suffix.
+    """
+    traces: Dict[str, List[Dict[str, Any]]] = {}
+    for run in runs:
+        traces.setdefault(str(run.get("trace_id")), []).append(run)
+    for group in traces.values():
+        group.sort(key=lambda r: r.get("dotted_order") or "")
+    return [traces[key] for key in sorted(traces, key=lambda t: traces[t][0].get("dotted_order") or "")]
+
+
+def batch_traces(
+    traces: Sequence[Sequence[Dict[str, Any]]],
+    *,
+    max_runs: int,
+    max_bytes: int,
+    size_of,
+) -> Iterator[List[Dict[str, Any]]]:
+    """Flush at trace boundaries, so a trace never splits across requests.
+
+    A single trace larger than a limit still ships alone rather than being cut.
+    """
+    batch: List[Dict[str, Any]] = []
+    batch_bytes = 0
+    for trace in traces:
+        trace_bytes = sum(size_of(run) for run in trace)
+        if batch and (len(batch) + len(trace) > max_runs or batch_bytes + trace_bytes > max_bytes):
+            yield batch
+            batch, batch_bytes = [], 0
+        batch.extend(trace)
+        batch_bytes += trace_bytes
+    if batch:
+        yield batch
+
+
+@dataclass(frozen=True)
+class SlicePlan:
+    """What one ``(session, window)`` diff says to do."""
+
+    source_ids: Set[str]
+    dest_ids: Set[str]
+    to_ingest: Set[str]
+    already_present: Set[str]
+    extra_on_dest: Set[str]
+
+
+def plan_slice(source_ids: Set[str], dest_ids: Set[str]) -> SlicePlan:
+    """The diff is the work-list, the skip-list and the completeness proof.
+
+    There is deliberately no "re-send anyway" mode: a run is immutable once
+    fully ingested (its ``end_time`` is persisted), so re-sending one already
+    on the destination cannot repair it. Repair means writing into a *different*
+    destination session, because run identity includes ``session_id``.
+    """
+    present = source_ids & dest_ids
+    return SlicePlan(
+        source_ids=source_ids,
+        dest_ids=dest_ids,
+        to_ingest=source_ids - dest_ids,
+        already_present=present,
+        extra_on_dest=dest_ids - source_ids,
+    )
+
+
+@dataclass(frozen=True)
+class SliceReconciliation:
+    """Counts for one window. The parts must account for the source total."""
+
+    session_id: str
+    dest_session_id: str
+    window: str
+    source_total: int
+    ingested: int
+    already_present: int
+    degraded: int
+    blocked: int
+    extra_on_dest: int = 0
+
+    def __post_init__(self) -> None:
+        total = self.ingested + self.already_present + self.degraded + self.blocked
+        if total != self.source_total:
+            raise ValueError(
+                f"reconciliation does not add up for {self.window}: "
+                f"source_total={self.source_total} but parts sum to {total}"
+            )
+
+
+@dataclass(frozen=True)
+class SessionReconciliation:
+    """Sum of a session's slices, with the same invariant."""
+
+    session_id: str
+    dest_session_id: str
+    source_total: int
+    ingested: int
+    already_present: int
+    degraded: int
+    blocked: int
+    extra_on_dest: int = 0
+
+    def __post_init__(self) -> None:
+        total = self.ingested + self.already_present + self.degraded + self.blocked
+        if total != self.source_total:
+            raise ValueError(
+                f"reconciliation does not add up for session {self.session_id}: "
+                f"source_total={self.source_total} but parts sum to {total}"
+            )
+
+    @classmethod
+    def of(cls, session_id: str, dest_session_id: str, slices: Sequence[SliceReconciliation]):
+        def s(attr: str) -> int:
+            return sum(getattr(x, attr) for x in slices)
+
+        return cls(
+            session_id=session_id,
+            dest_session_id=dest_session_id,
+            source_total=s("source_total"),
+            ingested=s("ingested"),
+            already_present=s("already_present"),
+            degraded=s("degraded"),
+            blocked=s("blocked"),
+            extra_on_dest=s("extra_on_dest"),
+        )
+
+    @property
+    def complete(self) -> bool:
+        return self.blocked == 0

--- a/langsmith_migrator/core/trace_domain.py
+++ b/langsmith_migrator/core/trace_domain.py
@@ -96,19 +96,34 @@ class Window:
         return f"{self.start.date()}..{self.end.date()}"
 
 
-def iter_windows(now: datetime, max_age_days: float, window_days: float) -> Iterator[Window]:
-    """Yield half-open windows covering ``[now - max_age_days, now)``, oldest first.
+def iter_windows(start: datetime, end: datetime, window_days: float) -> Iterator[Window]:
+    """Yield half-open windows covering ``[start, end)``, oldest first.
 
-    Windows abut exactly, so every instant in the range belongs to exactly one.
+    Bounds are absolute on purpose. Deriving them from ``now`` inside here
+    meant the same relative age denoted a different instant every time it was
+    evaluated, so a watermark expressed in days silently drifted while a long
+    migration was still running.
     """
-    if max_age_days <= 0 or window_days <= 0:
-        raise ValueError("max_age_days and window_days must be positive")
-    start = now - timedelta(days=max_age_days)
+    if window_days <= 0:
+        raise ValueError("window_days must be positive")
+    if start >= end:
+        raise ValueError("range start must precede its end")
     step = timedelta(days=window_days)
-    while start < now:
-        end = min(start + step, now)
-        yield Window(start, end)
-        start = end
+    while start < end:
+        boundary = min(start + step, end)
+        yield Window(start, boundary)
+        start = boundary
+
+
+def resolve_range_start(
+    now: datetime, max_age_days: Optional[float], stamp: Optional[datetime]
+) -> datetime:
+    """The absolute lower bound of the walk, from whichever bound was given."""
+    if stamp is not None:
+        return stamp.astimezone(timezone.utc) if stamp.tzinfo else stamp.replace(tzinfo=timezone.utc)
+    if not max_age_days or max_age_days <= 0:
+        raise ValueError("max_age_days must be positive")
+    return now - timedelta(days=max_age_days)
 
 
 def resolve_window_bounds(window: Window) -> Tuple[str, str]:
@@ -211,6 +226,32 @@ def digest_mismatches(left: Dict[str, str], right: Dict[str, str]) -> Tuple[str,
     return tuple(sorted(k for k in set(left) | set(right) if left.get(k) != right.get(k)))
 
 
+def verified_bounds(
+    runs: Iterable[Dict[str, Any]], complete_ids: Set[str]
+) -> Tuple[Optional[str], Optional[str]]:
+    """Earliest and latest ``start_time`` among runs confirmed complete.
+
+    Timestamps are parsed rather than string-compared: the API is consistent
+    today, but a mix of offset-bearing and naive ISO strings would order
+    wrongly, and this value is meant to be trusted as a watermark. Naive
+    values are read as UTC, which is what the endpoint returns - without that,
+    a mixed set raises rather than ordering, and comparing them is the whole
+    point of this function.
+    """
+    stamps = []
+    for run in runs:
+        if str(run.get("id")) not in complete_ids or not run.get("start_time"):
+            continue
+        try:
+            stamp = datetime.fromisoformat(str(run["start_time"]).replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        stamps.append(stamp if stamp.tzinfo else stamp.replace(tzinfo=timezone.utc))
+    if not stamps:
+        return None, None
+    return min(stamps).isoformat(), max(stamps).isoformat()
+
+
 def group_into_traces(runs: Iterable[Dict[str, Any]]) -> List[List[Dict[str, Any]]]:
     """Group runs by ``trace_id``, parents before children within each trace.
 
@@ -289,6 +330,14 @@ class Reconciliation:
     degraded: int
     blocked: int
     extra_on_dest: int = 0
+    # Bounds of the runs confirmed complete on the destination. A slice that
+    # degraded or blocked anything contributes nothing, so the pair always
+    # describes runs that are wholly there.
+    earliest: Optional[str] = None
+    latest: Optional[str] = None
+    # How many runs the span above covers, so a resume overlap can be sized in
+    # runs (one ingest batch) rather than guessed in time.
+    verified_runs: int = 0
 
     def __post_init__(self) -> None:
         total = self.ingested + self.already_present + self.degraded + self.blocked
@@ -314,6 +363,9 @@ class Reconciliation:
             degraded=s("degraded"),
             blocked=s("blocked"),
             extra_on_dest=s("extra_on_dest"),
+            earliest=min([x.earliest for x in slices if x.earliest], default=None),
+            latest=max([x.latest for x in slices if x.latest], default=None),
+            verified_runs=s("verified_runs"),
         )
 
     @property

--- a/langsmith_migrator/core/trace_frames.py
+++ b/langsmith_migrator/core/trace_frames.py
@@ -1,0 +1,105 @@
+"""Compile a multipart ingest body, optionally zstd-compressed.
+
+The SDK's ``multipart_ingest`` builds and sends in one call, so its CPU lands
+wherever the send happens. Splitting the two lets the body be built off the
+serial ingest path (see ``TraceMigrator.prepare_slice``) and lets us choose a
+compression level: the SDK hardcodes zstd level 1, which measures at 5.9x on
+real trace payloads against 68.5x at level 3 with long-distance matching.
+
+Everything here is reachable only through SDK private API. The imports are
+guarded and reported as one reason string so an SDK bump degrades to the
+uncompressed public path instead of crashing.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+# Level 3 + long-distance matching, measured per assembled frame on real dev
+# payloads: 30.6x -> 68.5x at the same 1755 MB/s. window_log 24 (16 MB) covers
+# the ~20 MB batch cap; 32 MB and 128 MB windows add 1% for 8x the memory.
+DEFAULT_COMPRESS_LEVEL = 3
+_WINDOW_LOG = 24
+
+_UNAVAILABLE: Optional[str] = None
+try:  # pragma: no cover - import shape, exercised by test_frames_unavailable
+    import zstandard as _zstd
+    from langsmith.client import _BOUNDARY
+    from langsmith._internal._multipart import join_multipart_parts_and_context
+    from langsmith._internal._operations import (
+        combine_serialized_queue_operations,
+        serialize_run_dict,
+        serialized_run_operation_to_multipart_parts_and_context,
+    )
+    from requests_toolbelt import multipart as _rqtb
+except ImportError as exc:
+    _UNAVAILABLE = f"{exc}"
+
+
+def unavailable_reason(client: Any) -> Optional[str]:
+    """Why frames cannot be compiled here, or None when they can."""
+    if _UNAVAILABLE:
+        return f"langsmith SDK internals moved ({_UNAVAILABLE})"
+    if not hasattr(client, "_send_compressed_multipart_req"):
+        return "langsmith Client has no _send_compressed_multipart_req"
+    return None
+
+
+@dataclass(frozen=True)
+class CompiledFrame:
+    """A ready-to-POST ingest body and the run IDs it carries."""
+
+    run_ids: Tuple[str, ...]
+    stream: io.BytesIO  # the zstd frame
+    sizes: Tuple[int, int]  # (raw, compressed), for the ingest log
+
+
+def _params(level: int):
+    return _zstd.ZstdCompressionParameters.from_level(
+        level, enable_ldm=True, window_log=_WINDOW_LOG
+    )
+
+
+def compile_frame(
+    client: Any, payloads: Sequence[Dict[str, Any]], level: int
+) -> CompiledFrame:
+    """Build one compressed ingest body. Safe to call from a worker thread.
+
+    Mirrors ``Client.multipart_ingest`` minus the parts that cannot apply here:
+    the 404 fallback to ``/runs/batch`` (this migrator requires multipart), the
+    filesystem-attachment check (attachments are already in-memory bytes), and
+    the create/update merge (this path only creates).
+
+    NB: ``_run_transform`` mutates each payload in place - ``id`` becomes a
+    ``UUID`` - so digests must be taken before compiling.
+    """
+    run_ids = tuple(str(p["id"]) for p in payloads)
+    # multipart_ingest validates this before serializing; this path skips it, so
+    # the check has to live here rather than in an assert that -O would strip.
+    if not all(p.get("trace_id") and p.get("dotted_order") for p in payloads):
+        raise ValueError("multipart ingest requires trace_id and dotted_order on every run")
+    if client.tracing_sample_rate is not None:
+        # Sampling keeps per-trace state on the client, which a worker thread
+        # must not touch. Nothing sets it here; fail loudly if that changes.
+        raise RuntimeError("frame compilation requires tracing_sample_rate to be unset")
+
+    transformed = [client._run_transform(p) for p in payloads]
+    client._insert_runtime_env(transformed)  # no-op under omit_traced_runtime_info
+    ops = combine_serialized_queue_operations(
+        [serialize_run_dict("post", run) for run in transformed]
+    )
+    parts: List[Any] = []
+    for op in ops:
+        part, opened = serialized_run_operation_to_multipart_parts_and_context(op)
+        assert not opened, "attachments must be in-memory, not filesystem paths"
+        parts.append(part)
+    acc = join_multipart_parts_and_context(parts)
+
+    raw = _rqtb.MultipartEncoder(acc.parts, boundary=_BOUNDARY).to_string()
+    comp = _zstd.ZstdCompressor(compression_params=_params(level)).compress(raw)
+    stream = io.BytesIO(comp)
+    # The SDK's sender joins this into the request's log context.
+    stream.context = getattr(acc, "context", [])
+    return CompiledFrame(run_ids=run_ids, stream=stream, sizes=(len(raw), len(comp)))

--- a/langsmith_migrator/utils/retry.py
+++ b/langsmith_migrator/utils/retry.py
@@ -149,6 +149,10 @@ def retry_on_failure(max_retries: int = 3, delay: float = 1.0, backoff: float = 
                     requests.exceptions.ConnectionError,
                     requests.exceptions.Timeout,
                     requests.exceptions.ReadTimeout,
+                    # A truncated response body. Not a ConnectionError subclass,
+                    # so it needs naming: it is the usual way a full connection
+                    # pool surfaces once several readers are in flight.
+                    requests.exceptions.ChunkedEncodingError,
                     socket.timeout,
                 ) as e:
                     # Retry network errors

--- a/langsmith_migrator/utils/state.py
+++ b/langsmith_migrator/utils/state.py
@@ -63,65 +63,8 @@ REPAIR_POLICIES = {
 }
 
 
-_ACTIONABLE_GROUP_LABELS = {
-    "unmapped_role": "Roles are missing from the mapping",
-    "unmapped_workspace_role": "Workspace roles are missing from the mapping",
-    "org_member_role_update_failed": "Org role updates failed",
-    "org_member_pending_invite_cancel_unsupported": "Pending org invites could not be cancelled",
-    "org_member_pending_invite_replace_conflict": "Pending org invites could not be replaced",
-    "org_member_pending_invite_replace_failed": "Pending org invites could not be refreshed",
-    "org_member_invite_failed": "Org invites failed",
-    "org_member_remove_failed": "Extra org users or pending invites could not be removed",
-    "ws_member_role_update_failed": "Workspace role updates failed",
-    "ws_member_not_in_org": "Workspace users are missing org access",
-    "ws_member_pending_org_invite": "Workspace users are waiting on pending org invites",
-    "ws_member_add_failed": "Workspace memberships failed to add",
-    "ws_member_remove_failed": "Extra workspace memberships could not be removed",
-}
 
 
-_ACTIONABLE_NEXT_ACTION_OVERRIDES = {
-    "org_member_role_update_failed": (
-        "Review the org role update error in the remediation bundle, "
-        "then re-run `langsmith-migrator users`."
-    ),
-    "org_member_pending_invite_replace_failed": (
-        "Cancel or replace the pending org invite on the target, "
-        "then re-run `langsmith-migrator users`."
-    ),
-    "org_member_pending_invite_cancel_unsupported": (
-        "Cancel or replace the pending org invite on the target, "
-        "then re-run `langsmith-migrator users`."
-    ),
-    "org_member_pending_invite_replace_conflict": (
-        "Cancel or replace the pending org invite on the target, "
-        "then re-run `langsmith-migrator users`."
-    ),
-    "org_member_invite_failed": (
-        "Review the org invite error in the remediation bundle, "
-        "then re-run `langsmith-migrator users`."
-    ),
-    "org_member_remove_failed": (
-        "Remove the extra org user or pending invite manually if needed, "
-        "then re-run `langsmith-migrator users --sync`."
-    ),
-    "ws_member_role_update_failed": (
-        "Review the workspace role update error in the remediation bundle, "
-        "then re-run `langsmith-migrator users`."
-    ),
-    "ws_member_add_failed": (
-        "Review the workspace membership create error in the remediation bundle, "
-        "then re-run `langsmith-migrator users`."
-    ),
-    "ws_member_pending_org_invite": (
-        "Wait for the pending org invite to be accepted, "
-        "then re-run `langsmith-migrator users`."
-    ),
-    "ws_member_remove_failed": (
-        "Remove the extra workspace membership manually if needed, "
-        "then re-run `langsmith-migrator users --sync`."
-    ),
-}
 
 
 def _now() -> float:
@@ -559,97 +502,6 @@ class MigrationState:
                 items.append(item)
         return items
 
-    @staticmethod
-    def _humanize_outcome_code(code: str) -> str:
-        text = code.replace("_", " ").strip()
-        if not text:
-            return "Items need attention"
-        return text[:1].upper() + text[1:]
-
-    def _actionable_subject(self, item: MigrationItem) -> str:
-        return str(
-            item.evidence.get("email")
-            or item.name
-            or item.source_id
-            or item.id
-        )
-
-    def _actionable_label(self, item: MigrationItem) -> str:
-        code = item.outcome_code or item.error or ""
-        if code in _ACTIONABLE_GROUP_LABELS:
-            return _ACTIONABLE_GROUP_LABELS[code]
-        if code:
-            return self._humanize_outcome_code(code)
-        return self._humanize_outcome_code(item.type)
-
-    def _actionable_next_action(self, item: MigrationItem) -> str:
-        code = item.outcome_code or item.error or ""
-        if code in _ACTIONABLE_NEXT_ACTION_OVERRIDES:
-            return _ACTIONABLE_NEXT_ACTION_OVERRIDES[code]
-        if item.next_action:
-            return item.next_action
-        return (
-            "Review the remediation bundle for the specific error and retry "
-            "once the issue is resolved."
-        )
-
-    @staticmethod
-    def format_actionable_subjects(
-        subjects: List[str],
-        *,
-        max_items: Optional[int] = None,
-    ) -> str:
-        unique_subjects: List[str] = []
-        seen: set[str] = set()
-        for subject in subjects:
-            if subject and subject not in seen:
-                unique_subjects.append(subject)
-                seen.add(subject)
-
-        if max_items is not None and len(unique_subjects) > max_items:
-            preview = ", ".join(unique_subjects[:max_items])
-            return f"{preview}, +{len(unique_subjects) - max_items} more"
-        return ", ".join(unique_subjects)
-
-    def get_actionable_groups(self) -> List[Dict[str, Any]]:
-        """Group blocked/exported items into higher-signal remediation steps."""
-        grouped: Dict[tuple[str, str, str, str], Dict[str, Any]] = {}
-
-        for item in sorted(
-            self.get_checkpoint_items(),
-            key=lambda current: (
-                current.outcome_code or "",
-                current.type,
-                self._actionable_subject(current).lower(),
-            ),
-        ):
-            label = self._actionable_label(item)
-            next_action = self._actionable_next_action(item)
-            key = (
-                item.outcome_code or "",
-                item.type,
-                label,
-                next_action,
-            )
-            group = grouped.setdefault(
-                key,
-                {
-                    "label": label,
-                    "next_action": next_action,
-                    "subjects": [],
-                    "items": [],
-                    "artifacts": [],
-                },
-            )
-            subject = self._actionable_subject(item)
-            if subject not in group["subjects"]:
-                group["subjects"].append(subject)
-            group["items"].append(item)
-            if item.export_path and item.export_path not in group["artifacts"]:
-                group["artifacts"].append(item.export_path)
-
-        return list(grouped.values())
-
     def record_capability(
         self,
         scope: str,
@@ -866,54 +718,7 @@ class MigrationState:
             encoding="utf-8",
         )
 
-        stats = self.get_statistics()
-        actionable_groups = self.get_actionable_groups()
-        resume_command = "langsmith-migrator resume"
-        lines = [
-            f"# Remediation Summary: {self.session_id}",
-            "",
-            f"- Session ID: `{self.session_id}`",
-            f"- Source: `{self.source_url}`",
-            f"- Destination: `{self.destination_url}`",
-            f"- Migrated: {stats['terminal'][ResolutionOutcome.MIGRATED.value]}",
-            f"- Verified downgrade: {stats['terminal'][ResolutionOutcome.MIGRATED_WITH_VERIFIED_DOWNGRADE.value]}",
-            f"- Blocked: {stats['terminal'][ResolutionOutcome.BLOCKED_WITH_CHECKPOINT.value]}",
-            f"- Exported/manual apply: {stats['terminal'][ResolutionOutcome.EXPORTED_WITH_MANUAL_APPLY.value]}",
-            f"- Issues: {len(self.issue_log)}",
-            f"- Remediation tasks: {len(self.remediation_queue)}",
-            f"- Resume command: `{resume_command}`",
-            "",
-        ]
-
-        if actionable_groups:
-            lines.append("## Actionable Items")
-            lines.append("")
-            for group in actionable_groups:
-                item_count = len(group["items"])
-                if item_count == 1:
-                    lines.append(
-                        f"- {group['subjects'][0]}: {group['label']}"
-                    )
-                else:
-                    lines.append(
-                        f"- {group['label']} ({item_count} items)"
-                    )
-                    lines.append(
-                        "  Affected: "
-                        + self.format_actionable_subjects(
-                            group["subjects"],
-                            max_items=10,
-                        )
-                    )
-                lines.append(f"  Next: {group['next_action']}")
-                for artifact_path in group["artifacts"][:3]:
-                    lines.append(f"  Artifact: `{artifact_path}`")
-                if len(group["artifacts"]) > 3:
-                    lines.append(
-                        f"  Artifacts: {len(group['artifacts'])} files in the remediation bundle"
-                    )
-            lines.append("")
-
+        lines: List[str] = []
         if self.remediation_queue:
             lines.append("## Remediation Queue")
             lines.append("")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langsmith-data-migration-tool"
-version = "0.0.83"
+version = "0.0.84"
 description = "A tool for migrating datasets, experiments, prompts, rules, annotation queues, charts, and Fleet resources between LangSmith instances"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -27,6 +27,9 @@ dependencies = [
     "requests==2.34.2",
     "urllib3==2.7.0",
     "langsmith==0.10.16",
+    # Used directly to compress the trace ingest body; arrives transitively via
+    # langsmith, but this pins it because trace_frames.py imports it.
+    "zstandard==0.25.0",
     "python-dotenv==1.2.2",
     "langchain-core==1.5.3",
     # Model packages required for pulling prompts with include_model=True

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -62,6 +62,7 @@ def test_registered_command_names_match_public_cli_surface():
         "resume",
         "rules",
         "test",
+        "traces",
         "users",
     ]
 

--- a/tests/functional/test_cli_functional.py
+++ b/tests/functional/test_cli_functional.py
@@ -132,8 +132,13 @@ def test_normalize_deployment_url_treats_api_suffixes_as_the_same_deployment():
     )
 
 
-def test_display_resolution_summary_groups_duplicate_user_failures(monkeypatch, tmp_path):
-    """Resolution summaries should collapse repeated user-role blockers into a grouped next step."""
+def test_display_resolution_summary_reports_counts_without_advice(monkeypatch, tmp_path):
+    """The summary states outcomes; it does not prescribe fixes.
+
+    It used to synthesise a next step per blocked item, falling back to generic
+    text when a migrator had nothing specific to say - which produced confident
+    advice that was sometimes simply wrong.
+    """
 
     state = build_state("migration_grouped_summary")
     state.remediation_bundle_path = str((tmp_path / "remediation" / state.session_id).resolve())
@@ -170,12 +175,10 @@ def test_display_resolution_summary_groups_duplicate_user_failures(monkeypatch, 
     cli_main._display_resolution_summary(StubOrchestrator(state))
 
     normalized_output = " ".join(console.text.split())
-    assert "Actionable Next Steps" in normalized_output
-    assert (
-        "Workspace memberships failed to add (2 items: alice@example.com, "
-        "bob@example.com): Review the workspace membership create error in the "
-        "remediation bundle, then re-run `langsmith-migrator users`."
-    ) in normalized_output
+    assert "Blocked: 2" in normalized_output
+    assert "Remediation bundle:" in normalized_output
+    for advice in ("Actionable Next Steps", "Re-run", "Review the", "retry once"):
+        assert advice not in normalized_output, advice
 
 
 def test_resolve_workspaces_with_explicit_pair_sets_context(monkeypatch):

--- a/tests/test_state_resolution.py
+++ b/tests/test_state_resolution.py
@@ -97,8 +97,8 @@ def test_loading_v1_state_upgrades_to_schema_v2(tmp_path):
     assert loaded.verification_summary["total"] == 1
 
 
-def test_remediation_summary_groups_duplicate_actionable_items(tmp_path):
-    """Remediation summaries should collapse repeated user-role failures into one actionable step."""
+def test_remediation_bundle_records_outcomes_without_advice(tmp_path):
+    """The bundle carries evidence, not a synthesised plan of action."""
 
     state = MigrationState(
         session_id="migration_grouped_actions",
@@ -131,9 +131,9 @@ def test_remediation_summary_groups_duplicate_actionable_items(tmp_path):
 
     assert bundle_dir is not None
     summary = (bundle_dir / "summary.md").read_text(encoding="utf-8")
-    assert "Workspace memberships failed to add (2 items)" in summary
-    assert "Affected: alice@example.com, bob@example.com" in summary
-    assert (
-        "Next: Review the workspace membership create error in the remediation "
-        "bundle, then re-run `langsmith-migrator users`."
-    ) in summary
+    for advice in ("## Actionable Items", "Next:", "Affected:"):
+        assert advice not in summary, advice
+    # the evidence itself is still exported
+    items = json.loads((bundle_dir / "items.json").read_text(encoding="utf-8"))
+    assert len(items) == 2
+    assert all(i["outcome_code"] == "ws_member_add_failed" for i in items.values())

--- a/tests/test_trace_migrator.py
+++ b/tests/test_trace_migrator.py
@@ -11,7 +11,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from langsmith_migrator.core.api_client import EnhancedAPIClient
-from langsmith_migrator.core.migrators.trace import TraceMigrator, TracePreflightError
+from langsmith_migrator.core.migrators.trace import _CANARY_SESSION, TraceMigrator, TracePreflightError
 from langsmith_migrator.core.trace_domain import Reconciliation, Window
 
 NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
@@ -150,10 +150,32 @@ def test_a_run_that_never_appears_is_blocked(sample_config, migration_state):
     m = _migrator(sample_config, migration_state)
     _wire_slice(m, [_run("a")], [], confirmed=[])
     m.ingest = Mock(return_value=[])
+    m.dest.get.return_value = None  # nowhere else either
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
         report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
     assert (report.blocked, report.ingested) == (1, 0)
     assert any(i.code == "run_not_ingested" for i in migration_state.issue_log)
+    assert any("still missing" in r for r in m.blocked_reasons)
+
+
+def test_a_run_held_by_another_project_says_so(sample_config, migration_state):
+    """The destination keeps one copy of a run id per tenant.
+
+    Reporting "still missing" here is true and useless: the write was accepted
+    and dropped, and re-running will never fix it.
+    """
+    m = _migrator(sample_config, migration_state)
+    _wire_slice(m, [_run("a")], [], confirmed=[])
+    m.ingest = Mock(return_value=[])
+    m.dest.get.return_value = {"id": "a", "session_id": "some-other-project"}
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+    assert report.blocked == 1
+    issue = next(i for i in migration_state.issue_log if i.code == "run_exists_in_other_project")
+    assert "some-other-project" in issue.summary
+    assert any("different project" in r for r in m.blocked_reasons)
+    # facts only, no instructions
+    assert not issue.next_action
 
 
 def test_ingest_queue_lag_is_tolerated(sample_config):
@@ -280,7 +302,7 @@ def test_skip_attachments_degrades_rather_than_pretending(sample_config):
     assert issues == ["attachments_skipped"]
     assert "attachments" not in overrides
     # the repair is named, and it is never "pass --skip-attachments again"
-    assert m.fidelity_reduced == {"without --skip-attachments"}
+    assert m.fidelity_reduced == {"attachments were skipped (--skip-attachments)"}
 
 
 def test_offloaded_inputs_are_re_inlined_only_when_absent(sample_config):
@@ -327,7 +349,7 @@ def test_a_payload_over_the_field_limit_is_degraded_before_sending(sample_config
 # --------------------------------------------------------------------------
 def test_the_source_session_id_is_attempted_on_create(sample_config):
     m = _migrator(sample_config)
-    m.dest.get_paginated.return_value = []
+    m.dest.get.return_value = []
     m.dest.post.return_value = {"id": "src-1", "trace_tier": "longlived"}
     resolved = m.resolve_dest_session({"id": "src-1", "name": "proj"})
     assert m.dest.post.call_args[0][1]["id"] == "src-1"
@@ -337,7 +359,7 @@ def test_the_source_session_id_is_attempted_on_create(sample_config):
 
 def test_a_rejected_source_id_is_retried_without_one(sample_config):
     m = _migrator(sample_config)
-    m.dest.get_paginated.return_value = []
+    m.dest.get.return_value = []
     m.dest.post.side_effect = [RuntimeError("id taken"), {"id": "fresh", "trace_tier": "longlived"}]
     resolved = m.resolve_dest_session({"id": "src-1", "name": "proj"})
     assert resolved["id"] == "fresh"
@@ -346,7 +368,7 @@ def test_a_rejected_source_id_is_retried_without_one(sample_config):
 
 def test_an_existing_destination_session_is_matched_by_name(sample_config):
     m = _migrator(sample_config)
-    m.dest.get_paginated.return_value = [{"id": "other-id", "name": "proj", "trace_tier": "longlived"}]
+    m.dest.get.return_value = [{"id": "other-id", "name": "proj", "trace_tier": "longlived"}]
     resolved = m.resolve_dest_session({"id": "src-1", "name": "proj"})
     assert resolved["id"] == "other-id"  # identity is a coincidence, not a requirement
     m.dest.post.assert_not_called()
@@ -360,15 +382,13 @@ def test_an_operator_mapping_wins_over_name_matching(sample_config):
 
 def test_an_ambiguous_destination_name_is_skipped(sample_config):
     m = _migrator(sample_config)
-    m.dest.get_paginated.return_value = [
-        {"id": "a", "name": "proj"}, {"id": "b", "name": "proj"},
-    ]
+    m.dest.get.return_value = [{"id": "a", "name": "proj"}, {"id": "b", "name": "proj"}]
     assert m.resolve_dest_session({"id": "src-1", "name": "proj"}) is None
 
 
 def test_into_session_suffix_targets_a_separate_session(sample_config):
     m = _migrator(sample_config, into_session_suffix="-migrated")
-    m.dest.get_paginated.return_value = [{"id": "live", "name": "proj", "trace_tier": "shortlived"}]
+    m.dest.get.return_value = [{"id": "live", "name": "proj", "trace_tier": "shortlived"}]
     m.dest.post.return_value = {"id": "copy", "trace_tier": "longlived"}
     resolved = m.resolve_dest_session({"id": "src-1", "name": "proj"})
     assert m.dest.post.call_args[0][1]["name"] == "proj-migrated"
@@ -407,11 +427,19 @@ def test_the_tier_is_not_restored_while_a_session_is_incomplete(sample_config):
 # --------------------------------------------------------------------------
 # Pre-flight canary
 # --------------------------------------------------------------------------
+def _dest_get(run_payload):
+    """Route dest.get: /sessions is the scratch lookup, /runs/<id> the read-back."""
+    def get(path, params=None):
+        if path == "/sessions":
+            return [{"id": "scratch", "name": _CANARY_SESSION}]
+        return run_payload() if callable(run_payload) else run_payload
+    return get
+
+
 def test_the_canary_blocks_when_the_timestamp_is_rewritten(sample_config, migration_state):
     m = _migrator(sample_config, migration_state, max_age_days=180)
-    m.dest.get_paginated.return_value = [{"id": "scratch", "name": "langsmith-migrator-canary"}]
     m.ingest = Mock(return_value=[])
-    m.dest.get.return_value = {"start_time": datetime.now(timezone.utc).isoformat()}
+    m.dest.get.side_effect = _dest_get({"start_time": datetime.now(timezone.utc).isoformat()})
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
         with pytest.raises(TracePreflightError, match="historical_ingest_rejected"):
             m.canary()
@@ -420,28 +448,41 @@ def test_the_canary_blocks_when_the_timestamp_is_rewritten(sample_config, migrat
 
 def test_the_canary_blocks_when_the_run_never_appears(sample_config, migration_state):
     m = _migrator(sample_config, migration_state, max_age_days=180)
-    m.dest.get_paginated.return_value = [{"id": "scratch", "name": "langsmith-migrator-canary"}]
     m.ingest = Mock(return_value=[])
-    m.dest.get.return_value = None
+    m.dest.get.side_effect = _dest_get(None)
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
         with pytest.raises(TracePreflightError):
             m.canary()
 
 
-def test_repeated_preflights_reuse_one_canary_identity(sample_config):
+def test_each_preflight_writes_its_own_canary(sample_config):
+    """The read-back must prove *this* invocation's write landed.
+
+    A deterministic ID made repeated pre-flights 409 ("duplicate run create
+    requests are not supported"), after which the read-back found the previous
+    invocation's canary and the gate passed having verified nothing.
+    """
     m = _migrator(sample_config, max_age_days=180)
-    m.dest.get_paginated.return_value = [{"id": "scratch", "name": "langsmith-migrator-canary"}]
     sent = []
     m.ingest = lambda batch: sent.extend(batch) or []
-    m.dest.get.side_effect = lambda path: {"start_time": sent[-1]["start_time"]}
+    m.dest.get.side_effect = _dest_get(lambda: {"start_time": sent[-1]["start_time"]})
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
         m.canary()
         m.canary()
-    # same id AND same start_time: start_time is part of the dedup key, so a
-    # drifted stamp would add a row instead of replacing one
-    assert sent[0]["id"] == sent[1]["id"]
-    assert sent[0]["start_time"] == sent[1]["start_time"]
+    assert sent[0]["id"] != sent[1]["id"], "a reused ID is rejected, not upserted"
     assert sent[0]["session_id"] == "scratch"  # never a migration target
+    # the exact resolved range start, not an hour-rounded value, and stable
+    # across calls because it is resolved once per run
+    assert sent[0]["start_time"] == sent[1]["start_time"] == m.resolved_range_start().isoformat()
+
+
+def test_a_conflicted_canary_blocks_instead_of_passing(sample_config, migration_state):
+    m = _migrator(sample_config, migration_state, max_age_days=180)
+    m.ingest = Mock(return_value=[("id", "HTTP 409: duplicate run create")])
+    m.dest.get.side_effect = _dest_get({"start_time": "whatever"})
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        with pytest.raises(TracePreflightError, match="historical_ingest_rejected"):
+            m.canary()
 
 
 def test_dry_run_skips_the_canary_entirely(sample_config):
@@ -511,7 +552,7 @@ def test_a_query_failure_is_never_swallowed(sample_config):
 def test_a_forbidden_session_create_is_a_tier_permission_blocker(sample_config):
     # PROJECTS_INCREASE_TRACE_TIER is checked on create too, not only on update.
     m = _migrator(sample_config)
-    m.dest.get_paginated.return_value = []
+    m.dest.get.return_value = []
     m.dest.post.side_effect = RuntimeError("403 Forbidden")
     with pytest.raises(TracePreflightError, match="trace_tier_permission_denied"):
         m.resolve_dest_session({"id": "src-1", "name": "proj"})
@@ -767,3 +808,125 @@ def test_a_tier_we_never_raised_is_never_touched(sample_config, migration_state)
         m.migrate_session({"id": "src", "name": "p", "trace_tier": "shortlived"}, now=NOW)
     m.restore_tier.assert_not_called()
     assert not any(i.code == "dest_tier_left_raised" for i in migration_state.issue_log)
+
+
+# --------------------------------------------------------------------------
+# The watermark is a completeness claim, so it needs real verification
+# --------------------------------------------------------------------------
+def _one_run_slice(m):
+    page = {"runs": [_run("a")], "cursors": {}}
+    m.source.post.side_effect = [page, page]
+    m.dest.post.side_effect = [{"runs": [], "cursors": {}}] * 6
+    m.ingest = Mock(return_value=[])
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        return m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+
+
+def test_a_dry_run_claims_no_watermark(sample_config):
+    # Nothing was written, so there is nothing to be complete.
+    sample_config.migration.dry_run = True
+    report = _one_run_slice(_migrator(sample_config))
+    assert (report.earliest, report.latest, report.verified_runs) == (None, None, 0)
+
+
+def test_no_verify_claims_no_watermark(sample_config):
+    # Runs were ingested but never confirmed readable; the watermark would be
+    # an unearned completeness claim an operator might skip work on.
+    report = _one_run_slice(_migrator(sample_config, verify=False))
+    assert (report.earliest, report.latest, report.verified_runs) == (None, None, 0)
+
+
+def test_a_verified_run_does_claim_a_watermark(sample_config):
+    m = _migrator(sample_config)
+    page = {"runs": [_run("a")], "cursors": {}}
+    m.source.post.side_effect = [page, page]
+    m.dest.post.side_effect = [
+        {"runs": [], "cursors": {}},          # pre-diff: missing
+        {"runs": [_run("a")], "cursors": {}},  # confirm: present
+        {"runs": [_run("a")], "cursors": {}},  # content sample
+    ]
+    m.ingest = Mock(return_value=[])
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+    assert report.earliest is not None and report.verified_runs == 1
+
+
+# --------------------------------------------------------------------------
+# A conflict is a rejection, not a replay
+# --------------------------------------------------------------------------
+def test_a_409_fails_every_run_in_the_request(sample_config):
+    """409 rejects the whole request, so it is neither success nor one bad run."""
+    m = _migrator(sample_config)
+    m.dest_ls_client.multipart_ingest.return_value = None
+    m._ingest_responses.append((409, '{"error":"Run create payload already received."}'))
+    original = m._ingest_responses[:]
+    m.dest_ls_client.multipart_ingest.side_effect = lambda create: m._ingest_responses.extend(original)
+    del m._ingest_responses[:]
+
+    failures = m.ingest([{"id": "a", "trace_id": "t"}, {"id": "b", "trace_id": "t"}])
+    assert {rid for rid, _ in failures} == {"a", "b"}
+    assert all("409" in err for _, err in failures)
+    # no binary split: the rejection applies to every payload equally
+    assert m.dest_ls_client.multipart_ingest.call_count == 1
+
+
+def test_a_swallowed_non_2xx_is_still_a_failure(sample_config):
+    m = _migrator(sample_config)
+    original = [(503, "Service unavailable")]
+    m.dest_ls_client.multipart_ingest.side_effect = lambda create: m._ingest_responses.extend(original)
+    failures = m.ingest([{"id": "solo", "trace_id": "t"}])
+    assert failures and "503" in failures[0][1]
+
+
+def test_a_clean_202_is_success(sample_config):
+    m = _migrator(sample_config)
+    m.dest_ls_client.multipart_ingest.side_effect = lambda create: m._ingest_responses.append((202, ""))
+    assert m.ingest([{"id": "a", "trace_id": "t"}]) == []
+
+
+# --------------------------------------------------------------------------
+# A blocked count always has a matching reason, from either path
+# --------------------------------------------------------------------------
+def test_an_ingest_rejection_is_reported_once_per_cause(sample_config, migration_state):
+    """Twenty runs refused for one reason is one fact, not twenty log lines.
+
+    The confirm-miss path recorded a reason but the ingest-rejection path did
+    not, and because a fully-blocked slice leaves nothing for the confirm to
+    check, a blocked count could appear with no reason anywhere.
+    """
+    m = _migrator(sample_config, migration_state)
+    runs = [_run(c, trace="t1", order=f"A.{c}") for c in "abcde"]
+    _wire_slice(m, runs, [])
+    m.ingest = lambda batch: [(str(p["id"]), 'HTTP 409: {"error":"already received"}') for p in batch]
+
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+
+    assert report.blocked == 5
+    reasons = [r for r in m.blocked_reasons if "refused by the destination" in r]
+    assert len(reasons) == 1, f"expected one grouped reason, got {m.blocked_reasons}"
+    assert "5 run(s)" in reasons[0] and "409" in reasons[0]
+    issue = next(i for i in migration_state.issue_log if i.code == "run_ingest_rejected")
+    assert issue.evidence["count"] == 5
+
+
+def test_distinct_causes_are_reported_separately(sample_config, migration_state):
+    m = _migrator(sample_config, migration_state)
+    runs = [_run(c, trace="t1", order=f"A.{c}") for c in "ab"]
+    _wire_slice(m, runs, [])
+    m.ingest = lambda batch: [(str(p["id"]), f"HTTP {409 if p['id'] == 'a' else 503}") for p in batch]
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+    assert len({r for r in m.blocked_reasons if "refused" in r}) == 2
+
+
+def test_the_migrator_records_no_remediation_advice(migration_state, sample_config):
+    """Every issue states what happened; none prescribes what to do."""
+    m = _migrator(sample_config, migration_state)
+    _wire_slice(m, [_run("a")], [])
+    m.ingest = lambda batch: [("a", "HTTP 409")]
+    m.dest.get.return_value = None
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+    assert migration_state.issue_log
+    assert not any(i.next_action for i in migration_state.issue_log)

--- a/tests/test_trace_migrator.py
+++ b/tests/test_trace_migrator.py
@@ -91,7 +91,7 @@ def test_payload_fetch_is_chunked_without_changing_the_result(sample_config):
     m = _migrator(sample_config)
     with patch("langsmith_migrator.core.migrators.trace._ID_CHUNK", 2):
         m.source.post.side_effect = _pages([_run("a"), _run("b")]) + _pages([_run("c")])
-        fetched = [r["id"] for r in m.fetch_runs("src", WINDOW, ["a", "b", "c"])]
+        fetched = [r["id"] for r in m.fetch_runs(m.source, "src", WINDOW, ["a", "b", "c"])]
     assert sorted(fetched) == ["a", "b", "c"]
     assert [len(call[0][1]["id"]) for call in m.source.post.call_args_list] == [2, 1]
 
@@ -398,8 +398,8 @@ def test_the_tier_is_not_restored_while_a_session_is_incomplete(sample_config):
     m.resolve_dest_session = Mock(return_value={"id": DEST, "trace_tier": "longlived"})
     m.restore_tier = Mock()
     m.migrate_slice = Mock(side_effect=lambda s, d, w: __import__(
-        "langsmith_migrator.core.trace_domain", fromlist=["SliceReconciliation"]
-    ).SliceReconciliation("src", DEST, w.label(), 1, 0, 0, 0, 1))
+        "langsmith_migrator.core.trace_domain", fromlist=["Reconciliation"]
+    ).Reconciliation("src", DEST, w.label(), 1, 0, 0, 0, 1))
     m.migrate_session({"id": "src", "name": "p", "trace_tier": "shortlived"}, now=NOW)
     m.restore_tier.assert_not_called()
 
@@ -499,20 +499,9 @@ def test_a_deferred_upgrade_leaves_the_session_tier_alone(sample_config):
 # --------------------------------------------------------------------------
 # Source and destination capability fallbacks
 # --------------------------------------------------------------------------
-def test_a_rejected_select_falls_back_to_no_projection_once(sample_config, migration_state):
-    m = _migrator(sample_config, migration_state)
-    rejection = RuntimeError("422 body.select.3: Input should be 'id', 'name', ...")
-    m.source.post.side_effect = [rejection, {"runs": [_run("a")], "cursors": {}}, {"runs": [_run("b")], "cursors": {}}]
-
-    assert m.long_lived_run_ids(m.source, "src", WINDOW) == {"a"}
-    # retried without the projection, and the fallback is remembered, not re-probed
-    assert "select" not in m.source.post.call_args_list[1][0][1]
-    assert m.long_lived_run_ids(m.source, "src", WINDOW) == {"b"}
-    assert "select" not in m.source.post.call_args_list[2][0][1]
-    assert [i.code for i in migration_state.issue_log].count("run_query_select_unsupported") == 1
-
-
-def test_an_unrelated_query_failure_is_not_swallowed(sample_config):
+def test_a_query_failure_is_never_swallowed(sample_config):
+    # There is no select-rejection fallback: the derived select is built from
+    # the write contract, every name of which the endpoint accepts.
     m = _migrator(sample_config)
     m.source.post.side_effect = RuntimeError("503 Service unavailable")
     with pytest.raises(RuntimeError, match="503"):
@@ -677,3 +666,44 @@ def test_human_sizes_are_readable():
     assert TraceMigrator._human(512) == "512 B"
     assert TraceMigrator._human(1536) == "1.5 KB"
     assert TraceMigrator._human(5 * 1024 * 1024) == "5.0 MB"
+
+
+# --------------------------------------------------------------------------
+# Blob hosts are per side
+# --------------------------------------------------------------------------
+def test_the_destination_read_back_uses_the_destination_blob_host(sample_config):
+    """A destination presigned URL lives on the destination host.
+
+    Validating it against the *source* host refused every read-back, so the
+    fidelity digest compared N attachments against 0 and reported a mismatch
+    that was not real.
+    """
+    m = _migrator(sample_config)
+    m._source_blob_host, m._dest_blob_host = "source.api.test.com", "dest.api.test.com"
+    m.dest.session.get.return_value = _blob_response(b"attachment-bytes")
+
+    run = _run("a", s3_urls={"attachment.note": {"presigned_url": "https://dest.api.test.com/public/download?jwt=x"}})
+    overrides, issues = m.materialise(run, side="dest")
+
+    assert issues == []
+    assert overrides["attachments"]["note"] == ("text/plain", b"attachment-bytes")
+    m.source.session.get.assert_not_called()
+
+
+def test_a_source_url_is_still_refused_on_the_destination_side(sample_config):
+    m = _migrator(sample_config)
+    m._source_blob_host, m._dest_blob_host = "source.api.test.com", "dest.api.test.com"
+    run = _run("a", s3_urls={"attachment.note": {"presigned_url": "https://source.api.test.com/x"}})
+    assert m.materialise(run, side="dest")[1] == ["attachment_host_rejected"]
+
+
+def test_an_unreadable_read_back_is_not_reported_as_a_content_mismatch(sample_config, migration_state):
+    m = _migrator(sample_config, migration_state)
+    m._source_blob_host, m._dest_blob_host = "source.api.test.com", "dest.api.test.com"
+    m.dest.session.get.side_effect = RuntimeError("blob store down")
+    m.dest.post.side_effect = _pages([_run("a", s3_urls={"attachment.n": {"presigned_url": "https://dest.api.test.com/x"}})])
+
+    degraded = {}
+    m._check_content(DEST, WINDOW, {"a": {"attachments": "deadbeef"}}, degraded)
+    assert degraded == {}
+    assert not any(i.code == "run_fidelity_mismatch" for i in migration_state.issue_log)

--- a/tests/test_trace_migrator.py
+++ b/tests/test_trace_migrator.py
@@ -12,7 +12,7 @@ import pytest
 
 from langsmith_migrator.core.api_client import EnhancedAPIClient
 from langsmith_migrator.core.migrators.trace import TraceMigrator, TracePreflightError
-from langsmith_migrator.core.trace_domain import Window
+from langsmith_migrator.core.trace_domain import Reconciliation, Window
 
 NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
 WINDOW = Window(NOW - timedelta(days=1), NOW)
@@ -707,3 +707,63 @@ def test_an_unreadable_read_back_is_not_reported_as_a_content_mismatch(sample_co
     m._check_content(DEST, WINDOW, {"a": {"attachments": "deadbeef"}}, degraded)
     assert degraded == {}
     assert not any(i.code == "run_fidelity_mismatch" for i in migration_state.issue_log)
+
+
+# --------------------------------------------------------------------------
+# A raised destination tier is always settled
+# --------------------------------------------------------------------------
+def _raisable(m, source_tier="shortlived"):
+    """A destination project that ensure_long_lived() has to raise."""
+    dest = {"id": DEST, "trace_tier": "shortlived"}
+    m.resolve_dest_session = Mock(return_value=dest)
+    m.dest.get.return_value = {"trace_tier": "longlived"}
+    m.restore_tier = Mock()
+    return {"id": "src", "name": "p", "trace_tier": source_tier}, dest
+
+
+def test_a_raised_tier_is_restored_after_a_clean_migration(sample_config):
+    m = _migrator(sample_config)
+    src, dest = _raisable(m)
+    m.migrate_slice = Mock(side_effect=lambda s, d, w: Reconciliation("src", DEST, w.label(), 0, 0, 0, 0, 0))
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        m.migrate_session(src, now=NOW)
+    m.restore_tier.assert_called_once_with(dest, "shortlived")
+
+
+def test_a_raised_tier_is_settled_even_when_the_migration_raises(sample_config, migration_state):
+    # Walking away here would leave the project long-lived indefinitely,
+    # changing retention for traffic unrelated to this migration.
+    m = _migrator(sample_config, migration_state)
+    src, dest = _raisable(m)
+    m.migrate_slice = Mock(side_effect=RuntimeError("source query blew up"))
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        with pytest.raises(RuntimeError, match="blew up"):
+            m.migrate_session(src, now=NOW)
+    # deliberately left raised so a re-run still ingests long-lived...
+    m.restore_tier.assert_not_called()
+    # ...but never silently
+    issue = next(i for i in migration_state.issue_log if i.code == "dest_tier_left_raised")
+    assert "did not finish" in issue.summary
+    assert issue.evidence["prior_tier"] == "shortlived"
+
+
+def test_an_incomplete_migration_leaves_the_tier_raised_and_says_so(sample_config, migration_state):
+    m = _migrator(sample_config, migration_state)
+    src, dest = _raisable(m)
+    m.migrate_slice = Mock(side_effect=lambda s, d, w: Reconciliation("src", DEST, w.label(), 1, 0, 0, 0, 1))
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        m.migrate_session(src, now=NOW)
+    m.restore_tier.assert_not_called()
+    assert any(i.code == "dest_tier_left_raised" and "blocked runs" in i.summary
+               for i in migration_state.issue_log)
+
+
+def test_a_tier_we_never_raised_is_never_touched(sample_config, migration_state):
+    m = _migrator(sample_config, migration_state)
+    m.resolve_dest_session = Mock(return_value={"id": DEST, "trace_tier": "longlived"})
+    m.restore_tier = Mock()
+    m.migrate_slice = Mock(side_effect=RuntimeError("boom"))
+    with pytest.raises(RuntimeError):
+        m.migrate_session({"id": "src", "name": "p", "trace_tier": "shortlived"}, now=NOW)
+    m.restore_tier.assert_not_called()
+    assert not any(i.code == "dest_tier_left_raised" for i in migration_state.issue_log)

--- a/tests/test_trace_migrator.py
+++ b/tests/test_trace_migrator.py
@@ -5,14 +5,23 @@ diff/ingest/confirm round trip, blob handling and failure isolation. Everything
 expressible as a function of its arguments is in ``tests/unit/test_trace_domain.py``.
 """
 
+import io
 from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
 import pytest
 
-from langsmith_migrator.core.api_client import EnhancedAPIClient
-from langsmith_migrator.core.migrators.trace import _CANARY_SESSION, TraceMigrator, TracePreflightError
+from langsmith_migrator.core.api_client import APIError, EnhancedAPIClient
+from langsmith_migrator.core.migrators.trace import (
+    _CANARY_SESSION,
+    _ID_CHUNK,
+    _ID_CHUNK_MIN,
+    _PAGE_LIMIT,
+    TraceMigrator,
+    TracePreflightError,
+)
 from langsmith_migrator.core.trace_domain import Reconciliation, Window
+from langsmith_migrator.core.trace_frames import DEFAULT_COMPRESS_LEVEL, CompiledFrame
 
 NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
 WINDOW = Window(NOW - timedelta(days=1), NOW)
@@ -87,13 +96,99 @@ def test_short_lived_runs_are_filtered_client_side(sample_config):
     assert m.long_lived_run_ids(m.source, "src", WINDOW) == {"keep"}
 
 
+def test_pages_are_requested_at_the_page_limit(sample_config):
+    m = _migrator(sample_config)
+    m.source.post.side_effect = _pages([])
+    m.long_lived_run_ids(m.source, "src", WINDOW)
+    assert m.source.post.call_args[0][1]["limit"] == _PAGE_LIMIT
+
+
+def test_a_deployment_that_pages_smaller_is_obeyed_and_remembered(sample_config):
+    m = _migrator(sample_config)
+    reject = APIError("API request failed: 400 - Limit exceeds maximum allowed value of 250", status_code=400)
+    m.source.post.side_effect = [reject] + _pages([_run("a")])
+    assert m.long_lived_run_ids(m.source, "src", WINDOW) == {"a"}
+    assert m.source.post.call_args[0][1]["limit"] == 250
+    # Adopted for the rest of the run, so the rejection is paid once.
+    assert m._page_limit["source"] == 250
+    assert m._page_limit["dest"] == _PAGE_LIMIT
+
+
+def test_a_400_that_is_not_about_the_limit_still_raises(sample_config):
+    m = _migrator(sample_config)
+    m.source.post.side_effect = APIError("API request failed: 400 - bad filter", status_code=400)
+    with pytest.raises(APIError):
+        m.long_lived_run_ids(m.source, "src", WINDOW)
+
+
+def test_id_chunks_never_exceed_the_page_limit(sample_config):
+    """An id-filtered query must stay self-consistent, whatever the backend tolerates."""
+    m = _migrator(sample_config)
+    m._page_limit["source"] = 2
+    m.source.post.side_effect = _pages([_run("a"), _run("b")]) + _pages([_run("c")])
+    fetched = [r["id"] for r in m.fetch_runs(m.source, "src", WINDOW, ["a", "b", "c"])]
+    assert sorted(fetched) == ["a", "b", "c"]
+    for call in m.source.post.call_args_list:
+        assert len(call[0][1]["id"]) <= 2
+
+
 def test_payload_fetch_is_chunked_without_changing_the_result(sample_config):
     m = _migrator(sample_config)
-    with patch("langsmith_migrator.core.migrators.trace._ID_CHUNK", 2):
-        m.source.post.side_effect = _pages([_run("a"), _run("b")]) + _pages([_run("c")])
-        fetched = [r["id"] for r in m.fetch_runs(m.source, "src", WINDOW, ["a", "b", "c"])]
+    m._id_chunk = 2
+    m.source.post.side_effect = _pages([_run("a"), _run("b")]) + _pages([_run("c")])
+    fetched = [r["id"] for r in m.fetch_runs(m.source, "src", WINDOW, ["a", "b", "c"])]
     assert sorted(fetched) == ["a", "b", "c"]
-    assert [len(call[0][1]["id"]) for call in m.source.post.call_args_list] == [2, 1]
+
+
+def test_an_oversized_response_halves_the_chunk_and_retries(sample_config):
+    """A heavy project's payloads make 500 IDs a ~65 MB response the gateway
+    refuses with a 502; the size is the problem, so shrink rather than fail."""
+    m = _migrator(sample_config)
+    m._id_chunk = 100
+    ids = [str(i) for i in range(100)]
+    too_big = APIError("API request failed: 502 - <html>...", status_code=502)
+    m.source.post.side_effect = [too_big] + _pages([_run(i) for i in ids[:50]]) + _pages(
+        [_run(i) for i in ids[50:]]
+    )
+    fetched = [r["id"] for r in m.fetch_runs(m.source, "src", WINDOW, ids)]
+    assert fetched == ids
+    assert m._id_chunk == 50  # remembered for the rest of the run
+    for call in m.source.post.call_args_list[1:]:
+        assert len(call[0][1]["id"]) <= 50
+
+
+def test_a_chunk_already_at_the_floor_gives_up(sample_config):
+    m = _migrator(sample_config)
+    m._id_chunk = _ID_CHUNK_MIN
+    m.source.post.side_effect = APIError("API request failed: 502 - <html>", status_code=502)
+    with pytest.raises(APIError):
+        list(m.fetch_runs(m.source, "src", WINDOW, ["a"]))
+
+
+def test_a_non_size_error_is_not_treated_as_too_large(sample_config):
+    m = _migrator(sample_config)
+    m.source.post.side_effect = APIError("API request failed: 400 - bad select", status_code=400)
+    with pytest.raises(APIError):
+        list(m.fetch_runs(m.source, "src", WINDOW, ["a"]))
+    assert m._id_chunk == _ID_CHUNK
+
+
+def test_a_failed_chunk_does_not_double_yield_what_it_had_produced(sample_config):
+    """The retry re-requests the whole chunk, so nothing may have escaped yet."""
+    m = _migrator(sample_config)
+    m._id_chunk = 100
+    ids = [str(i) for i in range(100)]
+    # first attempt yields a page, then dies on the second page of the chunk
+    m.source.post.side_effect = [
+        {"runs": [_run(ids[0])], "cursors": {"next": "c0"}},
+        APIError("API request failed: 502 - <html>", status_code=502),
+        *_pages([_run(i) for i in ids[:50]]),
+        *_pages([_run(i) for i in ids[50:]]),
+    ]
+    fetched = [r["id"] for r in m.fetch_runs(m.source, "src", WINDOW, ids)]
+    assert fetched == ids, "the abandoned page leaked into the result"
+    # the whole chunk is re-requested at half size, not resumed mid-chunk
+    assert [len(c[0][1]["id"]) for c in m.source.post.call_args_list] == [100, 100, 50, 50]
 
 
 # --------------------------------------------------------------------------
@@ -104,7 +199,11 @@ def _wire_slice(m, source_runs, dest_ids, *, confirmed=None):
 
     The payload fetch honours the request's ``id`` filter, as the real endpoint
     does, so a test can tell "fetched" from "ingested".
+
+    Compression is off here: these tests are about the diff/verify round trip,
+    and frame compilation needs a real SDK client. It has its own tests.
     """
+    m.compress_level = None
     def source_query(_endpoint, body):
         wanted = set(body.get("id") or [])
         runs = [r for r in source_runs if not wanted or r["id"] in wanted]
@@ -122,7 +221,7 @@ def test_only_the_difference_is_ingested(sample_config):
     m = _migrator(sample_config, verify=False)
     _wire_slice(m, [_run("a"), _run("b"), _run("c")], ["b"])
     sent = []
-    m.ingest = lambda batch: sent.extend(batch) or []
+    m.ingest = lambda batch, frame=None: sent.extend(batch) or []
 
     report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
     assert {p["id"] for p in sent} == {"a", "c"}
@@ -180,6 +279,7 @@ def test_a_run_held_by_another_project_says_so(sample_config, migration_state):
 
 def test_ingest_queue_lag_is_tolerated(sample_config):
     m = _migrator(sample_config)
+    m.compress_level = None  # ingest is mocked; see _wire_slice
     source_page = {"runs": [_run("a")], "cursors": {}}
     m.source.post.side_effect = [source_page, source_page]
     m.dest.post.side_effect = [
@@ -198,13 +298,14 @@ def test_no_verify_still_computes_the_pre_diff(sample_config):
     m = _migrator(sample_config, verify=False)
     _wire_slice(m, [_run("a"), _run("b")], ["a"])
     sent = []
-    m.ingest = lambda batch: sent.extend(batch) or []
+    m.ingest = lambda batch, frame=None: sent.extend(batch) or []
     m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
     assert [p["id"] for p in sent] == ["b"]  # the diff is the work-list either way
 
 
 def test_sets_from_two_sessions_are_never_merged(sample_config):
     m = _migrator(sample_config, verify=False)
+    m.compress_level = None  # ingest is mocked; see _wire_slice
     m.source.post.side_effect = [
         {"runs": [_run("a")], "cursors": {}}, {"runs": [_run("a")], "cursors": {}},
         {"runs": [_run("b")], "cursors": {}}, {"runs": [_run("b")], "cursors": {}},
@@ -221,7 +322,7 @@ def test_sets_from_two_sessions_are_never_merged(sample_config):
 # Failure isolation
 # --------------------------------------------------------------------------
 def test_a_bad_run_is_isolated_by_binary_split(sample_config):
-    m = _migrator(sample_config)
+    m = _migrator(sample_config, compress_level=None)
     bad = "b"
 
     def ingest(create):
@@ -236,7 +337,7 @@ def test_a_bad_run_is_isolated_by_binary_split(sample_config):
 def test_a_single_run_conflict_never_reaches_us_as_an_error(sample_config):
     # The SDK breaks out of its retry loop on 409 without invoking the error
     # callback, so a replay reads as success.
-    m = _migrator(sample_config)
+    m = _migrator(sample_config, compress_level=None)
     m.dest_ls_client.multipart_ingest.return_value = None
     assert m.ingest([{"id": "a"}]) == []
 
@@ -246,6 +347,83 @@ def test_dry_run_sends_nothing(sample_config):
     m = _migrator(sample_config)
     assert m.ingest([{"id": "a"}]) == []
     m.dest_ls_client.multipart_ingest.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Ingest compression
+# --------------------------------------------------------------------------
+def _frame(run_ids, raw=1000, comp=100):
+    return CompiledFrame(run_ids=tuple(run_ids), stream=io.BytesIO(b"z"), sizes=(raw, comp))
+
+
+def test_the_body_is_compressed_by_default(sample_config, capsys):
+    m = _migrator(sample_config)
+    assert m.compress_level == DEFAULT_COMPRESS_LEVEL
+    with patch("langsmith_migrator.core.migrators.trace.compile_frame") as compile_:
+        compile_.side_effect = lambda client, payloads, level: _frame([str(p["id"]) for p in payloads])
+        m._ingest_responses.append((202, ""))
+        assert m.ingest([{"id": "a", "trace_id": "t", "dotted_order": "o"}]) == []
+    m.dest_ls_client._send_compressed_multipart_req.assert_called_once()
+    m.dest_ls_client.multipart_ingest.assert_not_called()
+    # the ratio is worth seeing: it is the whole point of the option
+    assert "10.0x" in capsys.readouterr().out
+
+
+def test_no_compress_upload_uses_the_sdk_path(sample_config):
+    m = _migrator(sample_config, compress_level=None)
+    m.dest_ls_client.multipart_ingest.side_effect = lambda create: m._ingest_responses.append((202, ""))
+    assert m.ingest([{"id": "a", "trace_id": "t"}]) == []
+    m.dest_ls_client._send_compressed_multipart_req.assert_not_called()
+
+
+def test_a_missing_sdk_internal_degrades_to_uncompressed(sample_config):
+    with patch("langsmith_migrator.core.migrators.trace.unavailable_reason", return_value="moved"):
+        m = _migrator(sample_config)
+    assert m.compress_level is None
+    assert m.compress_unavailable == "moved"
+
+
+def test_a_split_recompiles_rather_than_reusing_the_batch_frame(sample_config):
+    """The pre-built frame covers the whole batch, so each half needs its own."""
+    m = _migrator(sample_config)
+    payloads = [{"id": c, "trace_id": "t", "dotted_order": f"o{c}"} for c in "abcd"]
+    compiled = []
+
+    def fake_compile(client, batch, level):
+        compiled.append(tuple(str(p["id"]) for p in batch))
+        return _frame([str(p["id"]) for p in batch])
+
+    def send(stream, sizes, attempts=1):
+        # only the batch still containing "b" fails
+        if "b" in compiled[-1]:
+            m._ingest_errors.append(RuntimeError("nope"))
+
+    with patch("langsmith_migrator.core.migrators.trace.compile_frame", side_effect=fake_compile):
+        m.dest_ls_client._send_compressed_multipart_req.side_effect = send
+        failures = m.ingest(payloads)
+    assert failures == [("b", "nope")]
+    # a frame per attempted batch, never the parent's frame re-sent
+    assert compiled[0] == ("a", "b", "c", "d")
+    assert ("b",) in compiled
+
+
+def test_a_frame_that_does_not_match_the_batch_is_rebuilt(sample_config):
+    m = _migrator(sample_config)
+    stale = _frame(["x"])
+    with patch("langsmith_migrator.core.migrators.trace.compile_frame") as compile_:
+        compile_.side_effect = lambda client, payloads, level: _frame([str(p["id"]) for p in payloads])
+        m._ingest_responses.append((202, ""))
+        m._send([{"id": "a", "trace_id": "t", "dotted_order": "o"}], frame=stale)
+    compile_.assert_called_once()
+
+
+def test_a_matching_prebuilt_frame_is_sent_as_is(sample_config):
+    m = _migrator(sample_config)
+    ready = _frame(["a"])
+    with patch("langsmith_migrator.core.migrators.trace.compile_frame") as compile_:
+        m._send([{"id": "a", "trace_id": "t", "dotted_order": "o"}], frame=ready)
+    compile_.assert_not_called()
+    assert m.dest_ls_client._send_compressed_multipart_req.call_args[0][0] is ready.stream
 
 
 # --------------------------------------------------------------------------
@@ -414,7 +592,7 @@ def test_a_tier_permission_failure_blocks_the_session(sample_config):
 
 
 def test_the_tier_is_not_restored_while_a_session_is_incomplete(sample_config):
-    m = _migrator(sample_config, verify=False)
+    m = _migrator(sample_config, verify=False, prefetch_windows=1)
     m.resolve_dest_session = Mock(return_value={"id": DEST, "trace_tier": "longlived"})
     m.restore_tier = Mock()
     m.migrate_slice = Mock(side_effect=lambda s, d, w: __import__(
@@ -464,7 +642,7 @@ def test_each_preflight_writes_its_own_canary(sample_config):
     """
     m = _migrator(sample_config, max_age_days=180)
     sent = []
-    m.ingest = lambda batch: sent.extend(batch) or []
+    m.ingest = lambda batch, frame=None: sent.extend(batch) or []
     m.dest.get.side_effect = _dest_get(lambda: {"start_time": sent[-1]["start_time"]})
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
         m.canary()
@@ -681,7 +859,7 @@ def test_each_query_page_reports_runs_traces_and_size(sample_config, capsys):
 
 
 def test_the_multipart_write_is_reported_prominently(sample_config, capsys):
-    m = _migrator(sample_config)
+    m = _migrator(sample_config, compress_level=None)
     m.dest_ls_client.multipart_ingest.return_value = None
     m.ingest([{"id": "a", "trace_id": "t1"}, {"id": "b", "trace_id": "t1"}, {"id": "c", "trace_id": "t2"}])
     out = capsys.readouterr().out
@@ -763,7 +941,7 @@ def _raisable(m, source_tier="shortlived"):
 
 
 def test_a_raised_tier_is_restored_after_a_clean_migration(sample_config):
-    m = _migrator(sample_config)
+    m = _migrator(sample_config, prefetch_windows=1)
     src, dest = _raisable(m)
     m.migrate_slice = Mock(side_effect=lambda s, d, w: Reconciliation("src", DEST, w.label(), 0, 0, 0, 0, 0))
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
@@ -774,7 +952,7 @@ def test_a_raised_tier_is_restored_after_a_clean_migration(sample_config):
 def test_a_raised_tier_is_settled_even_when_the_migration_raises(sample_config, migration_state):
     # Walking away here would leave the project long-lived indefinitely,
     # changing retention for traffic unrelated to this migration.
-    m = _migrator(sample_config, migration_state)
+    m = _migrator(sample_config, migration_state, prefetch_windows=1)
     src, dest = _raisable(m)
     m.migrate_slice = Mock(side_effect=RuntimeError("source query blew up"))
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
@@ -789,7 +967,7 @@ def test_a_raised_tier_is_settled_even_when_the_migration_raises(sample_config, 
 
 
 def test_an_incomplete_migration_leaves_the_tier_raised_and_says_so(sample_config, migration_state):
-    m = _migrator(sample_config, migration_state)
+    m = _migrator(sample_config, migration_state, prefetch_windows=1)
     src, dest = _raisable(m)
     m.migrate_slice = Mock(side_effect=lambda s, d, w: Reconciliation("src", DEST, w.label(), 1, 0, 0, 0, 1))
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
@@ -800,7 +978,7 @@ def test_an_incomplete_migration_leaves_the_tier_raised_and_says_so(sample_confi
 
 
 def test_a_tier_we_never_raised_is_never_touched(sample_config, migration_state):
-    m = _migrator(sample_config, migration_state)
+    m = _migrator(sample_config, migration_state, prefetch_windows=1)
     m.resolve_dest_session = Mock(return_value={"id": DEST, "trace_tier": "longlived"})
     m.restore_tier = Mock()
     m.migrate_slice = Mock(side_effect=RuntimeError("boom"))
@@ -814,6 +992,7 @@ def test_a_tier_we_never_raised_is_never_touched(sample_config, migration_state)
 # The watermark is a completeness claim, so it needs real verification
 # --------------------------------------------------------------------------
 def _one_run_slice(m):
+    m.compress_level = None  # ingest is mocked; see _wire_slice
     page = {"runs": [_run("a")], "cursors": {}}
     m.source.post.side_effect = [page, page]
     m.dest.post.side_effect = [{"runs": [], "cursors": {}}] * 6
@@ -838,6 +1017,7 @@ def test_no_verify_claims_no_watermark(sample_config):
 
 def test_a_verified_run_does_claim_a_watermark(sample_config):
     m = _migrator(sample_config)
+    m.compress_level = None  # ingest is mocked; see _wire_slice
     page = {"runs": [_run("a")], "cursors": {}}
     m.source.post.side_effect = [page, page]
     m.dest.post.side_effect = [
@@ -856,7 +1036,7 @@ def test_a_verified_run_does_claim_a_watermark(sample_config):
 # --------------------------------------------------------------------------
 def test_a_409_fails_every_run_in_the_request(sample_config):
     """409 rejects the whole request, so it is neither success nor one bad run."""
-    m = _migrator(sample_config)
+    m = _migrator(sample_config, compress_level=None, verify=False)
     m.dest_ls_client.multipart_ingest.return_value = None
     m._ingest_responses.append((409, '{"error":"Run create payload already received."}'))
     original = m._ingest_responses[:]
@@ -870,8 +1050,30 @@ def test_a_409_fails_every_run_in_the_request(sample_config):
     assert m.dest_ls_client.multipart_ingest.call_count == 1
 
 
-def test_a_swallowed_non_2xx_is_still_a_failure(sample_config):
+def test_a_409_defers_to_verification_when_it_will_run(sample_config, capsys):
+    """A 409 cannot distinguish "already in another project" from "our own
+    earlier attempt landed"; only the destination can, so do not pre-judge."""
+    m = _migrator(sample_config, compress_level=None)
+    original = [(409, '{"error":"Run create payload already received."}')]
+    m.dest_ls_client.multipart_ingest.side_effect = lambda create: m._ingest_responses.extend(original)
+    assert m.ingest([{"id": "a", "trace_id": "t"}, {"id": "b", "trace_id": "t"}]) == []
+    assert "leaving the verdict to verification" in capsys.readouterr().out
+    # not split into halves either: the rejection applies to the whole request
+    assert m.dest_ls_client.multipart_ingest.call_count == 1
+
+
+def test_the_compressed_send_never_blind_retries(sample_config):
+    """Ingest is not idempotent, so an unknown outcome must not be re-sent."""
     m = _migrator(sample_config)
+    with patch("langsmith_migrator.core.migrators.trace.compile_frame") as compile_:
+        compile_.side_effect = lambda client, payloads, level: _frame([str(p["id"]) for p in payloads])
+        m._ingest_responses.append((202, ""))
+        m.ingest([{"id": "a", "trace_id": "t", "dotted_order": "o"}])
+    assert m.dest_ls_client._send_compressed_multipart_req.call_args.kwargs["attempts"] == 1
+
+
+def test_a_swallowed_non_2xx_is_still_a_failure(sample_config):
+    m = _migrator(sample_config, compress_level=None)
     original = [(503, "Service unavailable")]
     m.dest_ls_client.multipart_ingest.side_effect = lambda create: m._ingest_responses.extend(original)
     failures = m.ingest([{"id": "solo", "trace_id": "t"}])
@@ -879,7 +1081,7 @@ def test_a_swallowed_non_2xx_is_still_a_failure(sample_config):
 
 
 def test_a_clean_202_is_success(sample_config):
-    m = _migrator(sample_config)
+    m = _migrator(sample_config, compress_level=None)
     m.dest_ls_client.multipart_ingest.side_effect = lambda create: m._ingest_responses.append((202, ""))
     assert m.ingest([{"id": "a", "trace_id": "t"}]) == []
 
@@ -897,7 +1099,7 @@ def test_an_ingest_rejection_is_reported_once_per_cause(sample_config, migration
     m = _migrator(sample_config, migration_state)
     runs = [_run(c, trace="t1", order=f"A.{c}") for c in "abcde"]
     _wire_slice(m, runs, [])
-    m.ingest = lambda batch: [(str(p["id"]), 'HTTP 409: {"error":"already received"}') for p in batch]
+    m.ingest = lambda batch, frame=None: [(str(p["id"]), 'HTTP 409: {"error":"already received"}') for p in batch]
 
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
         report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
@@ -914,7 +1116,7 @@ def test_distinct_causes_are_reported_separately(sample_config, migration_state)
     m = _migrator(sample_config, migration_state)
     runs = [_run(c, trace="t1", order=f"A.{c}") for c in "ab"]
     _wire_slice(m, runs, [])
-    m.ingest = lambda batch: [(str(p["id"]), f"HTTP {409 if p['id'] == 'a' else 503}") for p in batch]
+    m.ingest = lambda batch, frame=None: [(str(p["id"]), f"HTTP {409 if p['id'] == 'a' else 503}") for p in batch]
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
         m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
     assert len({r for r in m.blocked_reasons if "refused" in r}) == 2
@@ -924,7 +1126,7 @@ def test_the_migrator_records_no_remediation_advice(migration_state, sample_conf
     """Every issue states what happened; none prescribes what to do."""
     m = _migrator(sample_config, migration_state)
     _wire_slice(m, [_run("a")], [])
-    m.ingest = lambda batch: [("a", "HTTP 409")]
+    m.ingest = lambda batch, frame=None: [("a", "HTTP 409")]
     m.dest.get.return_value = None
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
         m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)

--- a/tests/test_trace_migrator.py
+++ b/tests/test_trace_migrator.py
@@ -1,0 +1,679 @@
+"""Migrator-shell tests for long-lived trace migration.
+
+Only the parts that genuinely need a client live here - pagination, the
+diff/ingest/confirm round trip, blob handling and failure isolation. Everything
+expressible as a function of its arguments is in ``tests/unit/test_trace_domain.py``.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock, patch
+
+import pytest
+
+from langsmith_migrator.core.api_client import EnhancedAPIClient
+from langsmith_migrator.core.migrators.trace import TraceMigrator, TracePreflightError
+from langsmith_migrator.core.trace_domain import Window
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+WINDOW = Window(NOW - timedelta(days=1), NOW)
+DEST = "dest-session"
+
+
+def _client() -> Mock:
+    client = Mock(spec=EnhancedAPIClient)
+    client.session = Mock()
+    client.session.headers = {}
+    return client
+
+
+def _migrator(sample_config, state=None, **kwargs):
+    with patch("langsmith_migrator.core.migrators.trace.Client"):
+        migrator = TraceMigrator(_client(), _client(), state, sample_config, **kwargs)
+    migrator.dest_ls_client = Mock()
+    migrator.dest_ls_client.info.batch_ingest_config = {"size_limit": 100, "size_limit_bytes": 20_000_000}
+    return migrator
+
+
+def _run(rid, trace=None, order=None, **kw):
+    run = {
+        "id": rid,
+        "trace_id": trace or rid,
+        "name": "n",
+        "run_type": "chain",
+        "start_time": "2026-08-25T10:00:00",
+        "dotted_order": order or f"20260825T100000000000Z{rid}",
+        "session_id": "src-session",
+        "trace_tier": "longlived",
+        "inputs": {"i": rid},
+    }
+    run.update(kw)
+    return run
+
+
+def _pages(*pages):
+    """A ``/runs/query`` side effect that walks cursors then stops."""
+    responses = []
+    for index, runs in enumerate(pages):
+        last = index == len(pages) - 1
+        responses.append({"runs": runs, "cursors": {} if last else {"next": f"c{index}"}})
+    return responses
+
+
+# --------------------------------------------------------------------------
+# Query shape
+# --------------------------------------------------------------------------
+def test_query_paginates_across_cursors(sample_config):
+    m = _migrator(sample_config)
+    m.source.post.side_effect = _pages([_run("a")], [_run("b")], [_run("c")])
+    assert m.long_lived_run_ids(m.source, "src", WINDOW) == {"a", "b", "c"}
+    assert m.source.post.call_args_list[1][0][1]["cursor"] == "c0"
+
+
+def test_query_is_scoped_to_one_session_with_an_explicit_lower_bound(sample_config):
+    m = _migrator(sample_config)
+    m.source.post.side_effect = _pages([])
+    m.long_lived_run_ids(m.source, "only-this-one", WINDOW)
+    body = m.source.post.call_args[0][1]
+    assert body["session"] == ["only-this-one"]
+    assert body["start_time"] < WINDOW.start.isoformat()  # explicit, with skew buffer
+    assert "lt(start_time" in body["trace_filter"]
+
+
+def test_short_lived_runs_are_filtered_client_side(sample_config):
+    # The V1 endpoint rejects trace_tier inside trace_filter but returns it on
+    # every run, so the predicate has to live here.
+    m = _migrator(sample_config)
+    m.source.post.side_effect = _pages([_run("keep"), _run("drop", trace_tier="shortlived")])
+    assert m.long_lived_run_ids(m.source, "src", WINDOW) == {"keep"}
+
+
+def test_payload_fetch_is_chunked_without_changing_the_result(sample_config):
+    m = _migrator(sample_config)
+    with patch("langsmith_migrator.core.migrators.trace._ID_CHUNK", 2):
+        m.source.post.side_effect = _pages([_run("a"), _run("b")]) + _pages([_run("c")])
+        fetched = [r["id"] for r in m.fetch_runs("src", WINDOW, ["a", "b", "c"])]
+    assert sorted(fetched) == ["a", "b", "c"]
+    assert [len(call[0][1]["id"]) for call in m.source.post.call_args_list] == [2, 1]
+
+
+# --------------------------------------------------------------------------
+# Diff, ingest, confirm
+# --------------------------------------------------------------------------
+def _wire_slice(m, source_runs, dest_ids, *, confirmed=None):
+    """Source population -> dest diff -> payload fetch -> confirm.
+
+    The payload fetch honours the request's ``id`` filter, as the real endpoint
+    does, so a test can tell "fetched" from "ingested".
+    """
+    def source_query(_endpoint, body):
+        wanted = set(body.get("id") or [])
+        runs = [r for r in source_runs if not wanted or r["id"] in wanted]
+        return {"runs": runs, "cursors": {}}
+
+    m.source.post.side_effect = source_query
+    confirmed = source_runs if confirmed is None else confirmed
+    m.dest.post.side_effect = [
+        {"runs": [_run(i) for i in dest_ids], "cursors": {}},
+        *[{"runs": confirmed, "cursors": {}} for _ in range(6)],
+    ]
+
+
+def test_only_the_difference_is_ingested(sample_config):
+    m = _migrator(sample_config, verify=False)
+    _wire_slice(m, [_run("a"), _run("b"), _run("c")], ["b"])
+    sent = []
+    m.ingest = lambda batch: sent.extend(batch) or []
+
+    report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+    assert {p["id"] for p in sent} == {"a", "c"}
+    assert (report.source_total, report.ingested, report.already_present) == (3, 2, 1)
+
+
+def test_runs_the_destination_already_holds_are_not_re_sent(sample_config):
+    m = _migrator(sample_config, verify=False)
+    _wire_slice(m, [_run("a")], ["a"])
+    m.ingest = Mock(return_value=[])
+    report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+    m.ingest.assert_not_called()
+    assert (report.ingested, report.already_present) == (0, 1)
+
+
+def test_extra_runs_on_the_destination_are_informational(sample_config):
+    m = _migrator(sample_config, verify=False)
+    _wire_slice(m, [_run("a")], ["a", "stranger"])
+    m.ingest = Mock(return_value=[])
+    report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+    assert report.extra_on_dest == 1 and report.blocked == 0
+
+
+def test_a_run_that_never_appears_is_blocked(sample_config, migration_state):
+    m = _migrator(sample_config, migration_state)
+    _wire_slice(m, [_run("a")], [], confirmed=[])
+    m.ingest = Mock(return_value=[])
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+    assert (report.blocked, report.ingested) == (1, 0)
+    assert any(i.code == "run_not_ingested" for i in migration_state.issue_log)
+
+
+def test_ingest_queue_lag_is_tolerated(sample_config):
+    m = _migrator(sample_config)
+    source_page = {"runs": [_run("a")], "cursors": {}}
+    m.source.post.side_effect = [source_page, source_page]
+    m.dest.post.side_effect = [
+        {"runs": [], "cursors": {}},          # pre-diff: missing
+        {"runs": [], "cursors": {}},          # confirm 1: still not readable
+        {"runs": [_run("a")], "cursors": {}},  # confirm 2: readable
+        {"runs": [_run("a")], "cursors": {}},  # content sample
+    ]
+    m.ingest = Mock(return_value=[])
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+    assert (report.ingested, report.blocked) == (1, 0)
+
+
+def test_no_verify_still_computes_the_pre_diff(sample_config):
+    m = _migrator(sample_config, verify=False)
+    _wire_slice(m, [_run("a"), _run("b")], ["a"])
+    sent = []
+    m.ingest = lambda batch: sent.extend(batch) or []
+    m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+    assert [p["id"] for p in sent] == ["b"]  # the diff is the work-list either way
+
+
+def test_sets_from_two_sessions_are_never_merged(sample_config):
+    m = _migrator(sample_config, verify=False)
+    m.source.post.side_effect = [
+        {"runs": [_run("a")], "cursors": {}}, {"runs": [_run("a")], "cursors": {}},
+        {"runs": [_run("b")], "cursors": {}}, {"runs": [_run("b")], "cursors": {}},
+    ]
+    m.dest.post.side_effect = [{"runs": [], "cursors": {}}, {"runs": [], "cursors": {}}]
+    m.ingest = Mock(return_value=[])
+    first = m.migrate_slice({"id": "s1"}, {"id": "d1"}, WINDOW)
+    second = m.migrate_slice({"id": "s2"}, {"id": "d2"}, WINDOW)
+    assert (first.source_total, second.source_total) == (1, 1)
+    assert (first.dest_session_id, second.dest_session_id) == ("d1", "d2")
+
+
+# --------------------------------------------------------------------------
+# Failure isolation
+# --------------------------------------------------------------------------
+def test_a_bad_run_is_isolated_by_binary_split(sample_config):
+    m = _migrator(sample_config)
+    bad = "b"
+
+    def ingest(create):
+        if any(p["id"] == bad for p in create):
+            m._ingest_errors.append(RuntimeError("nope"))
+
+    m.dest_ls_client.multipart_ingest.side_effect = lambda create: ingest(create)
+    failures = m.ingest([{"id": c} for c in "abcd"])
+    assert failures == [("b", "nope")]
+
+
+def test_a_single_run_conflict_never_reaches_us_as_an_error(sample_config):
+    # The SDK breaks out of its retry loop on 409 without invoking the error
+    # callback, so a replay reads as success.
+    m = _migrator(sample_config)
+    m.dest_ls_client.multipart_ingest.return_value = None
+    assert m.ingest([{"id": "a"}]) == []
+
+
+def test_dry_run_sends_nothing(sample_config):
+    sample_config.migration.dry_run = True
+    m = _migrator(sample_config)
+    assert m.ingest([{"id": "a"}]) == []
+    m.dest_ls_client.multipart_ingest.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Blobs
+# --------------------------------------------------------------------------
+def _blob_response(body=b"bytes", content_type="text/plain"):
+    response = Mock()
+    response.__enter__ = Mock(return_value=response)
+    response.__exit__ = Mock(return_value=False)
+    response.headers = {"Content-Type": content_type}
+    response.iter_content = Mock(return_value=[body])
+    response.raise_for_status = Mock()
+    return response
+
+
+def test_attachments_are_fetched_through_the_configured_session(sample_config):
+    m = _migrator(sample_config)
+    m._source_blob_host = "source.api.test.com"
+    m.source.session.get.return_value = _blob_response(b"attachment-bytes")
+
+    run = _run("a", s3_urls={"attachment.note": {"presigned_url": "https://source.api.test.com/public/download?jwt=x"}})
+    overrides, issues = m.materialise(run)
+
+    assert overrides["attachments"] == {"note": ("text/plain", b"attachment-bytes")}
+    assert issues == []
+    # not a bare requests.get: the tool's own session, and no redirect chasing
+    assert m.source.session.get.call_args.kwargs["allow_redirects"] is False
+
+
+def test_an_off_host_blob_url_is_refused(sample_config):
+    m = _migrator(sample_config)
+    m._source_blob_host = "source.api.test.com"
+    run = _run("a", s3_urls={"attachment.note": {"presigned_url": "https://evil.example.com/blob"}})
+    _, issues = m.materialise(run)
+    assert issues == ["attachment_host_rejected"]
+    m.source.session.get.assert_not_called()
+
+
+def test_a_failed_blob_fetch_is_explicit_not_a_placeholder(sample_config):
+    m = _migrator(sample_config)
+    m._source_blob_host = "source.api.test.com"
+    m.source.session.get.side_effect = RuntimeError("network down")
+    run = _run("a", s3_urls={"attachment.note": {"presigned_url": "https://source.api.test.com/x"}})
+    overrides, issues = m.materialise(run)
+    assert issues == ["attachment_fetch_failed"]
+    assert "attachments" not in overrides
+
+
+def test_skip_attachments_degrades_rather_than_pretending(sample_config):
+    m = _migrator(sample_config, skip_attachments=True)
+    m._source_blob_host = "source.api.test.com"
+    run = _run("a", s3_urls={"attachment.note": {"presigned_url": "https://source.api.test.com/x"}})
+    overrides, issues = m.materialise(run)
+    assert issues == ["attachments_skipped"]
+    assert "attachments" not in overrides
+    # the repair is named, and it is never "pass --skip-attachments again"
+    assert m.fidelity_reduced == {"without --skip-attachments"}
+
+
+def test_offloaded_inputs_are_re_inlined_only_when_absent(sample_config):
+    m = _migrator(sample_config)
+    m._source_blob_host = "source.api.test.com"
+    m.source.session.get.return_value = _blob_response(b'{"q": "from-blob"}', "application/json")
+
+    offloaded = _run("a", inputs=None, inputs_s3_urls={"ROOT": {"presigned_url": "https://source.api.test.com/b"}})
+    assert m.materialise(offloaded)[0]["inputs"] == {"q": "from-blob"}
+
+    # the query API usually resolves the payload itself; do not re-fetch it
+    m.source.session.get.reset_mock()
+    inline = _run("a", inputs={"q": "inline"}, inputs_s3_urls={"ROOT": {"presigned_url": "https://source.api.test.com/b"}})
+    assert m.materialise(inline)[0] == {}
+    m.source.session.get.assert_not_called()
+
+
+def test_a_blob_larger_than_the_budget_is_refused(sample_config):
+    m = _migrator(sample_config, max_field_bytes=4)
+    m._source_blob_host = "source.api.test.com"
+    m.source.session.get.return_value = _blob_response(b"far too many bytes")
+    run = _run("a", inputs=None, inputs_s3_urls={"ROOT": {"presigned_url": "https://source.api.test.com/b"}})
+    assert m.materialise(run)[1] == ["attachment_fetch_failed"]
+
+
+# --------------------------------------------------------------------------
+# Oversized payloads
+# --------------------------------------------------------------------------
+def test_a_payload_over_the_field_limit_is_degraded_before_sending(sample_config, migration_state):
+    m = _migrator(sample_config, migration_state, max_field_bytes=50, verify=False)
+    _wire_slice(m, [_run("a", inputs={"big": "x" * 500})], [])
+    m.ingest = Mock(return_value=[])
+
+    report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+    # The backend would accept it and store a placeholder, so it must not be
+    # reported as migrated.
+    assert (report.degraded, report.ingested) == (1, 0)
+    m.ingest.assert_not_called()
+    assert any(i.code == "payload_oversized_for_destination" for i in migration_state.issue_log)
+
+
+# --------------------------------------------------------------------------
+# Session mapping and tier
+# --------------------------------------------------------------------------
+def test_the_source_session_id_is_attempted_on_create(sample_config):
+    m = _migrator(sample_config)
+    m.dest.get_paginated.return_value = []
+    m.dest.post.return_value = {"id": "src-1", "trace_tier": "longlived"}
+    resolved = m.resolve_dest_session({"id": "src-1", "name": "proj"})
+    assert m.dest.post.call_args[0][1]["id"] == "src-1"
+    assert m.dest.post.call_args[0][1]["trace_tier"] == "longlived"
+    assert resolved["id"] == "src-1"
+
+
+def test_a_rejected_source_id_is_retried_without_one(sample_config):
+    m = _migrator(sample_config)
+    m.dest.get_paginated.return_value = []
+    m.dest.post.side_effect = [RuntimeError("id taken"), {"id": "fresh", "trace_tier": "longlived"}]
+    resolved = m.resolve_dest_session({"id": "src-1", "name": "proj"})
+    assert resolved["id"] == "fresh"
+    assert "id" not in m.dest.post.call_args[0][1]
+
+
+def test_an_existing_destination_session_is_matched_by_name(sample_config):
+    m = _migrator(sample_config)
+    m.dest.get_paginated.return_value = [{"id": "other-id", "name": "proj", "trace_tier": "longlived"}]
+    resolved = m.resolve_dest_session({"id": "src-1", "name": "proj"})
+    assert resolved["id"] == "other-id"  # identity is a coincidence, not a requirement
+    m.dest.post.assert_not_called()
+
+
+def test_an_operator_mapping_wins_over_name_matching(sample_config):
+    m = _migrator(sample_config, project_id_map={"src-1": "chosen"})
+    m.dest.get.return_value = {"id": "chosen", "trace_tier": "longlived"}
+    assert m.resolve_dest_session({"id": "src-1", "name": "proj"})["id"] == "chosen"
+
+
+def test_an_ambiguous_destination_name_is_skipped(sample_config):
+    m = _migrator(sample_config)
+    m.dest.get_paginated.return_value = [
+        {"id": "a", "name": "proj"}, {"id": "b", "name": "proj"},
+    ]
+    assert m.resolve_dest_session({"id": "src-1", "name": "proj"}) is None
+
+
+def test_into_session_suffix_targets_a_separate_session(sample_config):
+    m = _migrator(sample_config, into_session_suffix="-migrated")
+    m.dest.get_paginated.return_value = [{"id": "live", "name": "proj", "trace_tier": "shortlived"}]
+    m.dest.post.return_value = {"id": "copy", "trace_tier": "longlived"}
+    resolved = m.resolve_dest_session({"id": "src-1", "name": "proj"})
+    assert m.dest.post.call_args[0][1]["name"] == "proj-migrated"
+    assert resolved["id"] == "copy"  # the live session's tier is untouched
+
+
+def test_a_short_lived_session_is_raised_and_re_read_before_ingesting(sample_config):
+    m = _migrator(sample_config)
+    session = {"id": "d1", "trace_tier": "shortlived"}
+    # a stale cached lookup would write blobs under the short-lived prefix
+    m.dest.get.side_effect = [{"trace_tier": "shortlived"}, {"trace_tier": "longlived"}]
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        m.ensure_long_lived(session)
+    assert session["trace_tier"] == "longlived"
+    m.dest.patch.assert_called_once_with("/sessions/d1", {"trace_tier": "longlived"})
+
+
+def test_a_tier_permission_failure_blocks_the_session(sample_config):
+    m = _migrator(sample_config)
+    m.dest.patch.side_effect = RuntimeError("403 Forbidden")
+    with pytest.raises(TracePreflightError, match="trace_tier_permission_denied"):
+        m.ensure_long_lived({"id": "d1", "trace_tier": "shortlived"})
+
+
+def test_the_tier_is_not_restored_while_a_session_is_incomplete(sample_config):
+    m = _migrator(sample_config, verify=False)
+    m.resolve_dest_session = Mock(return_value={"id": DEST, "trace_tier": "longlived"})
+    m.restore_tier = Mock()
+    m.migrate_slice = Mock(side_effect=lambda s, d, w: __import__(
+        "langsmith_migrator.core.trace_domain", fromlist=["SliceReconciliation"]
+    ).SliceReconciliation("src", DEST, w.label(), 1, 0, 0, 0, 1))
+    m.migrate_session({"id": "src", "name": "p", "trace_tier": "shortlived"}, now=NOW)
+    m.restore_tier.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Pre-flight canary
+# --------------------------------------------------------------------------
+def test_the_canary_blocks_when_the_timestamp_is_rewritten(sample_config, migration_state):
+    m = _migrator(sample_config, migration_state, max_age_days=180)
+    m.dest.get_paginated.return_value = [{"id": "scratch", "name": "langsmith-migrator-canary"}]
+    m.ingest = Mock(return_value=[])
+    m.dest.get.return_value = {"start_time": datetime.now(timezone.utc).isoformat()}
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        with pytest.raises(TracePreflightError, match="historical_ingest_rejected"):
+            m.canary()
+    assert any(i.code == "historical_ingest_rejected" for i in migration_state.issue_log)
+
+
+def test_the_canary_blocks_when_the_run_never_appears(sample_config, migration_state):
+    m = _migrator(sample_config, migration_state, max_age_days=180)
+    m.dest.get_paginated.return_value = [{"id": "scratch", "name": "langsmith-migrator-canary"}]
+    m.ingest = Mock(return_value=[])
+    m.dest.get.return_value = None
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        with pytest.raises(TracePreflightError):
+            m.canary()
+
+
+def test_repeated_preflights_reuse_one_canary_identity(sample_config):
+    m = _migrator(sample_config, max_age_days=180)
+    m.dest.get_paginated.return_value = [{"id": "scratch", "name": "langsmith-migrator-canary"}]
+    sent = []
+    m.ingest = lambda batch: sent.extend(batch) or []
+    m.dest.get.side_effect = lambda path: {"start_time": sent[-1]["start_time"]}
+    with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
+        m.canary()
+        m.canary()
+    # same id AND same start_time: start_time is part of the dedup key, so a
+    # drifted stamp would add a row instead of replacing one
+    assert sent[0]["id"] == sent[1]["id"]
+    assert sent[0]["start_time"] == sent[1]["start_time"]
+    assert sent[0]["session_id"] == "scratch"  # never a migration target
+
+
+def test_dry_run_skips_the_canary_entirely(sample_config):
+    sample_config.migration.dry_run = True
+    m = _migrator(sample_config)
+    m.canary()
+    m.dest.post.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Timestamps
+# --------------------------------------------------------------------------
+def test_no_time_shifting_code_is_reachable_from_this_module():
+    from pathlib import Path
+
+    import langsmith_migrator.core.migrators.trace as module
+
+    assert "time_shift" not in Path(module.__file__).read_text()
+
+
+# --------------------------------------------------------------------------
+# Deferred operator upgrade
+# --------------------------------------------------------------------------
+def test_the_upgrade_list_is_emitted_even_when_the_diff_is_empty(sample_config, migration_state):
+    # Built from the diff instead, a re-run of a finished migration would emit
+    # nothing at all.
+    m = _migrator(sample_config, migration_state, emit_upgrade_list="/tmp/x.csv", verify=False)
+    root, child = _run("t1"), _run("c1", trace="t1", order="A.B")
+    _wire_slice(m, [root, child], ["t1", "c1"])
+    m.ingest = Mock(return_value=[])
+
+    report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+    assert m.ingest.call_count == 0 and report.already_present == 2
+    assert m.upgrade_rows == [(DEST, "t1", root["start_time"])]  # roots only
+    assert any(i.code == "longlived_pending_operator_upgrade" for i in migration_state.issue_log)
+
+
+def test_the_destination_query_drops_the_tier_filter_for_a_deferred_upgrade(sample_config):
+    # The projects were left short-lived, so filtering on tier would read every
+    # already-migrated run as missing.
+    m = _migrator(sample_config, emit_upgrade_list="/tmp/x.csv", verify=False)
+    source_page = {"runs": [_run("a")], "cursors": {}}
+    m.source.post.side_effect = [source_page, source_page]
+    m.dest.post.side_effect = [{"runs": [_run("a", trace_tier="shortlived")], "cursors": {}}]
+    report = m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
+    assert report.already_present == 1
+
+
+def test_a_deferred_upgrade_leaves_the_session_tier_alone(sample_config):
+    m = _migrator(sample_config, emit_upgrade_list="/tmp/x.csv")
+    m.ensure_long_lived({"id": "d1", "trace_tier": "shortlived"})
+    m.dest.patch.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Source and destination capability fallbacks
+# --------------------------------------------------------------------------
+def test_a_rejected_select_falls_back_to_no_projection_once(sample_config, migration_state):
+    m = _migrator(sample_config, migration_state)
+    rejection = RuntimeError("422 body.select.3: Input should be 'id', 'name', ...")
+    m.source.post.side_effect = [rejection, {"runs": [_run("a")], "cursors": {}}, {"runs": [_run("b")], "cursors": {}}]
+
+    assert m.long_lived_run_ids(m.source, "src", WINDOW) == {"a"}
+    # retried without the projection, and the fallback is remembered, not re-probed
+    assert "select" not in m.source.post.call_args_list[1][0][1]
+    assert m.long_lived_run_ids(m.source, "src", WINDOW) == {"b"}
+    assert "select" not in m.source.post.call_args_list[2][0][1]
+    assert [i.code for i in migration_state.issue_log].count("run_query_select_unsupported") == 1
+
+
+def test_an_unrelated_query_failure_is_not_swallowed(sample_config):
+    m = _migrator(sample_config)
+    m.source.post.side_effect = RuntimeError("503 Service unavailable")
+    with pytest.raises(RuntimeError, match="503"):
+        m.long_lived_run_ids(m.source, "src", WINDOW)
+
+
+def test_a_forbidden_session_create_is_a_tier_permission_blocker(sample_config):
+    # PROJECTS_INCREASE_TRACE_TIER is checked on create too, not only on update.
+    m = _migrator(sample_config)
+    m.dest.get_paginated.return_value = []
+    m.dest.post.side_effect = RuntimeError("403 Forbidden")
+    with pytest.raises(TracePreflightError, match="trace_tier_permission_denied"):
+        m.resolve_dest_session({"id": "src-1", "name": "proj"})
+
+
+# --------------------------------------------------------------------------
+# The write contract is pinned deliberately
+# --------------------------------------------------------------------------
+def test_the_ingest_field_set_matches_the_backend_contract():
+    """Golden fixture for ``smith-go/runs/runs.go`` ``type Run struct``.
+
+    The backend drops anything it does not declare, silently. If an SDK or
+    backend bump changes that struct, this test is the place that notices -
+    update it against the Go source, not against whatever the SDK happens to
+    accept.
+    """
+    from dataclasses import fields
+
+    from langsmith_migrator.core.trace_domain import RunIngestPayload
+
+    assert {f.name for f in fields(RunIngestPayload)} == {
+        "id", "trace_id", "parent_run_id", "dotted_order", "session_id",
+        "name", "run_type", "start_time", "end_time", "status",
+        "inputs", "outputs", "extra", "error", "serialized", "events", "tags",
+        "attachments",
+    }
+
+
+# --------------------------------------------------------------------------
+# A transient source failure must not look like "no such project"
+# --------------------------------------------------------------------------
+def test_a_missing_source_session_resolves_to_none(sample_config):
+    from langsmith_migrator.core.api_client import NotFoundError
+
+    m = _migrator(sample_config)
+    m.source.get.side_effect = NotFoundError("404 Not Found")
+    assert m.get_source_session("no-such-id") is None
+
+
+def test_a_transient_source_failure_is_raised_not_swallowed(sample_config):
+    # Swallowing it made a 429 indistinguishable from a mistyped name, and the
+    # command exited zero having migrated nothing.
+    from langsmith_migrator.core.api_client import APIError
+
+    m = _migrator(sample_config)
+    m.source.get.side_effect = APIError("429 Rate limit exceeded")
+    with pytest.raises(APIError, match="429"):
+        m.get_source_session("11111111-1111-1111-1111-111111111111")
+
+
+def test_an_experiment_session_is_never_a_trace_target(sample_config):
+    m = _migrator(sample_config)
+    m.source.get.return_value = {"id": "x", "reference_dataset_id": "ds-1"}
+    assert m.get_source_session("x") is None
+
+
+# --------------------------------------------------------------------------
+# --project accepts a name as well as an ID
+# --------------------------------------------------------------------------
+def test_a_project_name_is_resolved_through_the_endpoint_not_a_full_walk(sample_config):
+    m = _migrator(sample_config)
+    m.source.get.return_value = [{"id": "p1", "name": "evaluators"}]
+    session, reason = m.find_source_session("evaluators")
+    assert (session["id"], reason) == ("p1", "name")
+    # the endpoint filters; enumerating tens of thousands of sessions would not scale
+    assert m.source.get.call_args.kwargs["params"] == {"name": "evaluators", "reference_free": "true"}
+    m.source.get_paginated.assert_not_called()
+
+
+def test_an_id_wins_over_a_name_lookup(sample_config):
+    the_id = "0fffee47-dd97-46f6-ae24-8866e2b8b9d9"
+    m = _migrator(sample_config)
+    m.source.get.return_value = {"id": the_id, "name": "whatever"}
+    assert m.find_source_session(the_id) == ({"id": the_id, "name": "whatever"}, "id")
+    assert m.source.get.call_args[0][0] == f"/sessions/{the_id}"
+
+
+def test_an_unknown_uuid_falls_through_to_the_name_lookup(sample_config):
+    from langsmith_migrator.core.api_client import NotFoundError
+
+    m = _migrator(sample_config)
+    m.source.get.side_effect = [NotFoundError("404"), [{"id": "p1", "name": "named-like-a-uuid"}]]
+    assert m.find_source_session("00000000-0000-0000-0000-000000000000")[1] == "name"
+
+
+def test_a_duplicated_project_name_is_reported_as_ambiguous(sample_config):
+    m = _migrator(sample_config)
+    m.source.get.return_value = [{"id": "a", "name": "dup"}, {"id": "b", "name": "dup"}]
+    assert m.find_source_session("dup") == (None, "ambiguous")
+
+
+def test_an_experiment_session_is_not_matched_by_name(sample_config):
+    m = _migrator(sample_config)
+    m.source.get.return_value = [{"id": "x", "name": "n", "reference_dataset_id": "ds"}]
+    assert m.find_source_session("n") == (None, "missing")
+
+
+def test_a_non_uuid_project_value_skips_the_id_endpoint_entirely(sample_config):
+    # /sessions/<non-uuid> answers 422, not 404, so attempting it and then
+    # sniffing the error to recover would be both slower and more fragile.
+    m = _migrator(sample_config)
+    m.source.get.return_value = [{"id": "p1", "name": "evaluators"}]
+    session, reason = m.find_source_session("evaluators")
+    assert (session["id"], reason) == ("p1", "name")
+    assert m.source.get.call_count == 1
+    assert m.source.get.call_args[0][0] == "/sessions"
+
+
+# --------------------------------------------------------------------------
+# Progress reporting
+# --------------------------------------------------------------------------
+def test_each_query_page_reports_runs_traces_and_size(sample_config, capsys):
+    sample_config.migration.verbose = True
+    m = _migrator(sample_config)
+    m.source.post.side_effect = _pages(
+        [_run("a", trace="t1"), _run("b", trace="t1"), _run("c", trace="t2")], [_run("d", trace="t3")]
+    )
+    list(m._query_runs(m.source, "src", WINDOW, select=["id"]))
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if "query source" in ln]
+    assert len(lines) == 2
+    assert "runs" in lines[0] and "traces" in lines[0]
+    assert "3" in lines[0] and "2" in lines[0]  # 3 runs across 2 traces
+    assert "total" in lines[1]
+    # a wrapped progress line is worse than a terse one
+    assert all(len(ln) <= 80 for ln in lines), lines
+
+
+def test_the_multipart_write_is_reported_prominently(sample_config, capsys):
+    m = _migrator(sample_config)
+    m.dest_ls_client.multipart_ingest.return_value = None
+    m.ingest([{"id": "a", "trace_id": "t1"}, {"id": "b", "trace_id": "t1"}, {"id": "c", "trace_id": "t2"}])
+    out = capsys.readouterr().out
+    # the one step that writes must not read like another query log line
+    assert "MULTIPART INGEST" in out
+    assert "runs 3" in out and "traces 2" in out
+
+
+def test_query_pages_are_silent_without_verbose(sample_config, capsys):
+    m = _migrator(sample_config)
+    m.source.post.side_effect = _pages([_run("a")])
+    list(m._query_runs(m.source, "src", WINDOW, select=["id"]))
+    assert "query source" not in capsys.readouterr().out
+
+
+def test_reported_size_counts_attachment_bytes(sample_config):
+    small = TraceMigrator._shape([{"id": "a", "trace_id": "t"}])[2]
+    big = TraceMigrator._shape([{"id": "a", "trace_id": "t", "attachments": {"n": ("text/plain", b"x" * 5000)}}])[2]
+    assert big - small >= 5000
+
+
+def test_human_sizes_are_readable():
+    assert TraceMigrator._human(512) == "512 B"
+    assert TraceMigrator._human(1536) == "1.5 KB"
+    assert TraceMigrator._human(5 * 1024 * 1024) == "5.0 MB"

--- a/tests/test_trace_prefetch.py
+++ b/tests/test_trace_prefetch.py
@@ -1,0 +1,250 @@
+"""Look-ahead retrieval must not weaken the ordering guarantee.
+
+Concurrent preparation is only safe because committing stays serial and
+oldest-first: that is what makes "a failure leaves no gap" true, and what lets
+a clean window print a watermark. These tests pin that, not the speedup.
+"""
+
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock, patch
+
+import pytest
+
+from langsmith_migrator.core.api_client import EnhancedAPIClient
+from langsmith_migrator.core.migrators.trace import SlicePrepared, TraceMigrator
+from langsmith_migrator.core.trace_domain import Reconciliation, Window, plan_slice
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+def _client():
+    client = Mock(spec=EnhancedAPIClient)
+    client.session = Mock()
+    client.session.headers = {}
+    return client
+
+
+def _migrator(sample_config, **kwargs):
+    with patch("langsmith_migrator.core.migrators.trace.Client"):
+        m = TraceMigrator(_client(), _client(), None, sample_config, **kwargs)
+    m.dest_ls_client = Mock()
+    m.resolve_dest_session = Mock(return_value={"id": "dst", "trace_tier": "longlived"})
+    m.ensure_long_lived = Mock()
+    m.restore_tier = Mock()
+    return m
+
+
+def _empty(window):
+    return SlicePrepared(window, "src", "dst", plan_slice(set(), set()), [])
+
+
+def _labels(n_windows):
+    """Window labels in the order they must be committed."""
+    from langsmith_migrator.core.trace_domain import iter_windows
+
+    return [w.label() for w in iter_windows(NOW - timedelta(days=n_windows), NOW, 1.0)]
+
+
+def _drive(m, n_windows=6):
+    """Walk n windows of one day each, recording commit order."""
+    end = NOW
+    m.range_start = end - timedelta(days=n_windows)
+    m._resolved_start = m.range_start
+    m.window_days = 1.0
+    return m.migrate_session({"id": "src", "name": "p", "trace_tier": "longlived"}, now=end)
+
+
+# --------------------------------------------------------------------------
+# Ordering
+# --------------------------------------------------------------------------
+def test_commits_run_in_window_order_however_preparation_finishes(sample_config):
+    """The slowest window to prepare must still commit in its own place."""
+    m = _migrator(sample_config, prefetch_windows=4)
+    labels = _labels(6)
+    order = []
+
+    def prepare(_s, _d, window):
+        # earliest windows made slowest, so completion order fights commit order
+        time.sleep(0.04 * (len(labels) - labels.index(window.label())))
+        return _empty(window)
+
+    m.prepare_slice = Mock(side_effect=prepare)
+    m.commit_slice = Mock(side_effect=lambda p: order.append(p.window.label()) or
+                          Reconciliation("src", "dst", p.window.label(), 0, 0, 0, 0, 0))
+    _drive(m)
+    assert order == labels
+
+
+def test_preparation_is_actually_concurrent(sample_config):
+    m = _migrator(sample_config, prefetch_windows=4)
+    live, peak = [], []
+    lock = threading.Lock()
+
+    def prepare(_s, _d, window):
+        with lock:
+            live.append(1)
+            peak.append(len(live))
+        time.sleep(0.05)
+        with lock:
+            live.pop()
+        return _empty(window)
+
+    m.prepare_slice = Mock(side_effect=prepare)
+    m.commit_slice = Mock(side_effect=lambda p: Reconciliation("src", "dst", p.window.label(), 0, 0, 0, 0, 0))
+    _drive(m)
+    assert max(peak) > 1, "windows were prepared one at a time"
+
+
+def test_look_ahead_is_bounded_by_prefetch_windows(sample_config):
+    """Unbounded look-ahead would buffer the whole range in memory.
+
+    The bound is prefetch_windows in flight plus the one being committed: the
+    next window is submitted before the commit so readers stay busy during it.
+    """
+    m = _migrator(sample_config, prefetch_windows=2)
+    prepared, committed = [], []
+
+    def prepare(_s, _d, window):
+        prepared.append(window.label())
+        return _empty(window)
+
+    def commit(p):
+        # never more than prefetch_windows ahead of what has been committed
+        assert len(prepared) - len(committed) <= 3, (len(prepared), len(committed))
+        committed.append(p.window.label())
+        return Reconciliation("src", "dst", p.window.label(), 0, 0, 0, 0, 0)
+
+    m.prepare_slice = Mock(side_effect=prepare)
+    m.commit_slice = Mock(side_effect=commit)
+    _drive(m, n_windows=8)
+    assert len(committed) == 8
+
+
+# --------------------------------------------------------------------------
+# Failure leaves a clean prefix, not a hole
+# --------------------------------------------------------------------------
+def test_a_failure_commits_every_earlier_window_and_nothing_after(sample_config):
+    m = _migrator(sample_config, prefetch_windows=4)
+    committed = []
+
+    def commit(p):
+        if len(committed) == 2:
+            raise RuntimeError("ingest died")
+        committed.append(p.window.label())
+        return Reconciliation("src", "dst", p.window.label(), 0, 0, 0, 0, 0)
+
+    m.prepare_slice = Mock(side_effect=lambda s, d, w: _empty(w))
+    m.commit_slice = Mock(side_effect=commit)
+    with pytest.raises(RuntimeError, match="ingest died"):
+        _drive(m, n_windows=6)
+    assert len(committed) == 2  # a prefix, in order, with no gap after it
+
+
+def test_a_preparation_failure_surfaces_at_its_own_window(sample_config):
+    """A worker exception must not be swallowed, nor reordered past its window."""
+    m = _migrator(sample_config, prefetch_windows=4)
+    labels = _labels(6)
+    committed = []
+
+    def prepare(_s, _d, window):
+        # keyed to the window, not to arrival order: with N readers, which
+        # window starts third is not deterministic
+        if window.label() == labels[2]:
+            raise RuntimeError("source query blew up")
+        return _empty(window)
+
+    m.prepare_slice = Mock(side_effect=prepare)
+    m.commit_slice = Mock(side_effect=lambda p: committed.append(p.window.label()) or
+                          Reconciliation("src", "dst", p.window.label(), 0, 0, 0, 0, 0))
+    with pytest.raises(RuntimeError, match="source query blew up"):
+        _drive(m, n_windows=6)
+    # the two earlier windows are committed; the walk stops at the one that failed
+    assert committed == labels[:2]
+
+
+def test_a_raised_tier_is_still_accounted_for_when_a_prefetched_walk_fails(sample_config):
+    """A raise left in place silently changes a project's retention.
+
+    An unfinished walk deliberately keeps the tier raised so a re-run can still
+    ingest long-lived - but it must say so. That accounting lives in a
+    ``finally`` and has to survive the executor.
+    """
+    m = _migrator(sample_config, prefetch_windows=4, restore_session_tier=True)
+    dest = {"id": "dst", "trace_tier": "shortlived"}
+    m.resolve_dest_session = Mock(return_value=dest)
+    # the real one mutates the dict on a genuine raise; that is the signal
+    # _settle_tier reads to mean "we raised this"
+    m.ensure_long_lived = Mock(side_effect=lambda s: s.update(trace_tier="longlived"))
+    m.record_issue = Mock()
+    m.prepare_slice = Mock(side_effect=RuntimeError("boom"))
+    with pytest.raises(RuntimeError, match="boom"):
+        _drive(m)
+    m.ensure_long_lived.assert_called_once()
+    codes = [c.args[1] for c in m.record_issue.call_args_list]
+    assert "dest_tier_left_raised" in codes
+    m.restore_tier.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Serial parity
+# --------------------------------------------------------------------------
+def test_prefetch_one_uses_the_plain_serial_seam(sample_config):
+    m = _migrator(sample_config, prefetch_windows=1)
+    m.migrate_slice = Mock(side_effect=lambda s, d, w: Reconciliation("src", "dst", w.label(), 0, 0, 0, 0, 0))
+    _drive(m, n_windows=3)
+    assert m.migrate_slice.call_count == 3
+
+
+def test_prefetch_is_never_below_one(sample_config):
+    assert _migrator(sample_config, prefetch_windows=0).prefetch_windows == 1
+
+
+# --------------------------------------------------------------------------
+# The parallel half must not touch shared state
+# --------------------------------------------------------------------------
+def test_prepare_slice_records_no_issues_and_no_state(sample_config):
+    """Findings must travel in the value object, not be written from a worker."""
+    m = _migrator(sample_config, compress_level=None)
+    m.record_issue = Mock(side_effect=AssertionError("prepare_slice wrote an issue"))
+    m.persist_state = Mock(side_effect=AssertionError("prepare_slice wrote state"))
+    m.source.post.side_effect = [{"runs": [], "cursors": {}}]
+    prepared = m.prepare_slice({"id": "src"}, {"id": "dst"}, Window(NOW - timedelta(days=1), NOW))
+    assert prepared.population == []
+    m.record_issue.assert_not_called()
+    m.persist_state.assert_not_called()
+
+
+def test_the_upgrade_list_issue_is_deferred_to_commit(sample_config):
+    m = _migrator(sample_config, compress_level=None, emit_upgrade_list="/tmp/x.csv")
+    run = {
+        "id": "a", "trace_id": "a", "start_time": "2026-08-25T10:00:00",
+        "trace_tier": "longlived", "name": "n", "run_type": "chain",
+        "dotted_order": "20260825T100000000000Za", "inputs": {"i": 1},
+    }
+    m.source.post.side_effect = lambda _e, _b: {"runs": [run], "cursors": {}}
+    m.dest.post.side_effect = lambda _e, _b: {"runs": [], "cursors": {}}
+    m.record_issue = Mock(side_effect=AssertionError("recorded from the worker half"))
+    prepared = m.prepare_slice({"id": "src"}, {"id": "dst"}, Window(NOW - timedelta(days=1), NOW))
+    # carried as data...
+    assert prepared.upgrade_rows == [("dst", "a", "2026-08-25T10:00:00")]
+    assert [code for _, code, _, _ in prepared.issues] == ["longlived_pending_operator_upgrade"]
+    # ...and only replayed on the main thread
+    m.record_issue = Mock()
+    m.verify = False
+    m.ingest = Mock(return_value=[])
+    m.commit_slice(prepared)
+    m.record_issue.assert_called_once()
+    assert m.upgrade_rows == prepared.upgrade_rows
+
+
+def test_ingest_refuses_to_run_off_the_main_thread(sample_config):
+    """Serial, ordered ingest is load-bearing; a stray thread must not slip in."""
+    m = _migrator(sample_config, compress_level=None)
+    m.dest_ls_client.multipart_ingest.return_value = None
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(1) as pool:
+        with pytest.raises(AssertionError, match="main thread"):
+            pool.submit(m.ingest, [{"id": "a", "trace_id": "t"}]).result()

--- a/tests/unit/test_trace_domain.py
+++ b/tests/unit/test_trace_domain.py
@@ -1,0 +1,286 @@
+"""Pure-core tests for long-lived trace migration.
+
+No HTTP and no implicit clock: everything here is a function of its arguments,
+which is the point of keeping the domain separate from the migrator shell.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from langsmith_migrator.core.trace_domain import (
+    RUN_QUERY_SELECT,
+    SKEW_BUFFER,
+    RunIngestPayload,
+    SessionReconciliation,
+    SliceReconciliation,
+    Window,
+    batch_traces,
+    digest_mismatches,
+    group_into_traces,
+    is_long_lived,
+    iter_windows,
+    payload_digest,
+    plan_slice,
+    resolve_window_bounds,
+    to_ingest_payload,
+)
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+def _run(**kw):
+    base = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "trace_id": "11111111-1111-1111-1111-111111111111",
+        "name": "root",
+        "run_type": "chain",
+        "start_time": "2026-08-20T10:00:00",
+        "end_time": "2026-08-20T10:00:05",
+        "dotted_order": "20260820T100000000000Z11111111-1111-1111-1111-111111111111",
+        "status": "success",
+        "session_id": "SOURCE-SESSION",
+        "inputs": {"q": 1},
+        "outputs": {"a": 2},
+        "trace_tier": "longlived",
+    }
+    base.update(kw)
+    return base
+
+
+# --------------------------------------------------------------------------
+# Windows
+# --------------------------------------------------------------------------
+def test_windows_are_half_open_and_oldest_first():
+    windows = list(iter_windows(NOW, max_age_days=3, window_days=1))
+    assert [w.start for w in windows] == sorted(w.start for w in windows)
+    assert windows[0].start == NOW - timedelta(days=3)
+    assert windows[-1].end == NOW
+    # abutting, so no gap and no overlap
+    for earlier, later in zip(windows, windows[1:]):
+        assert earlier.end == later.start
+
+
+def test_final_window_is_clipped_to_now():
+    windows = list(iter_windows(NOW, max_age_days=2.5, window_days=1))
+    assert windows[-1].end == NOW
+    assert sum((w.end - w.start).total_seconds() for w in windows) == pytest.approx(2.5 * 86400)
+
+
+def test_window_size_does_not_change_which_instants_are_covered():
+    coarse = list(iter_windows(NOW, 4, 4))
+    fine = list(iter_windows(NOW, 4, 0.5))
+    assert (coarse[0].start, coarse[-1].end) == (fine[0].start, fine[-1].end)
+
+
+@pytest.mark.parametrize("bad", [(0, 1), (1, 0), (-1, 1)])
+def test_nonpositive_range_or_window_is_rejected(bad):
+    with pytest.raises(ValueError):
+        list(iter_windows(NOW, *bad))
+
+
+def test_bounds_carry_no_run_level_upper_bound_and_a_skew_buffer():
+    window = Window(NOW - timedelta(days=1), NOW)
+    trace_filter, run_start = resolve_window_bounds(window)
+
+    # The upper bound lives only on the trace root: a run-level one would
+    # truncate children that start after their trace's window.
+    assert "lt(start_time" in trace_filter
+    assert trace_filter.count("start_time") == 2
+    assert run_start == (window.start - SKEW_BUFFER).isoformat()
+    assert run_start < window.start.isoformat()
+
+
+# --------------------------------------------------------------------------
+# Read/write contract
+# --------------------------------------------------------------------------
+def test_select_is_derived_from_the_write_contract():
+    for name in ("id", "trace_id", "dotted_order", "status", "serialized", "session_id"):
+        assert name in RUN_QUERY_SELECT
+    # blob references and the tier are needed to build a payload, never to send one
+    for name in ("inputs_s3_urls", "outputs_s3_urls", "s3_urls", "trace_tier"):
+        assert name in RUN_QUERY_SELECT
+    # attachments are not projectable by the query API
+    assert "attachments" not in RUN_QUERY_SELECT
+
+
+def test_adding_a_write_contract_field_selects_it_with_no_second_edit():
+    from dataclasses import fields
+
+    writable = {f.name for f in fields(RunIngestPayload)} - {"attachments"}
+    assert writable <= set(RUN_QUERY_SELECT)
+
+
+def test_identity_and_timestamps_are_preserved_verbatim():
+    run = _run(parent_run_id="22222222-2222-2222-2222-222222222222")
+    payload, _ = to_ingest_payload(run, "DEST-SESSION")
+    for field in ("id", "trace_id", "parent_run_id", "dotted_order", "start_time", "end_time"):
+        assert getattr(payload, field) == run[field]
+
+
+def test_session_is_rewritten_to_the_mapped_target():
+    payload, _ = to_ingest_payload(_run(), "DEST-SESSION")
+    assert payload.session_id == "DEST-SESSION"
+
+
+def test_read_only_fields_are_structurally_unsendable():
+    run = _run(
+        manifest_id="m",
+        app_path="/x",
+        feedback_stats={"a": 1},
+        total_tokens=5,
+        inputs_s3_urls={"ROOT": {"presigned_url": "https://x/y"}},
+        outputs_s3_urls={"ROOT": {"presigned_url": "https://x/y"}},
+        s3_urls={"extra": {"presigned_url": "https://x/y"}},
+    )
+    sent = to_ingest_payload(run, "DEST")[0].as_dict()
+    for leaked in ("manifest_id", "app_path", "feedback_stats", "total_tokens",
+                   "inputs_s3_urls", "outputs_s3_urls", "s3_urls", "trace_tier"):
+        assert leaked not in sent
+    assert sent["status"] == "success"  # the write contract does accept this one
+
+
+def test_reference_example_id_is_dropped_and_reported():
+    payload, dropped = to_ingest_payload(_run(reference_example_id="ex-1"), "DEST")
+    assert dropped == ("reference_example_id",)
+    assert "reference_example_id" not in payload.as_dict()
+
+
+def test_serialized_is_preserved_for_an_llm_run():
+    manifest = {"lc": 1, "name": "chat"}
+    payload, _ = to_ingest_payload(_run(run_type="llm", serialized=manifest), "DEST")
+    assert payload.serialized == manifest
+
+
+def test_offloaded_inputs_are_inlined_and_the_url_never_forwarded():
+    run = _run(inputs=None, inputs_s3_urls={"ROOT": {"presigned_url": "https://src/blob"}})
+    sent = to_ingest_payload(run, "DEST", {"inputs": {"q": "recovered"}})[0].as_dict()
+    assert sent["inputs"] == {"q": "recovered"}
+    assert "https://src/blob" not in str(sent)
+
+
+def test_unset_optionals_are_omitted_so_the_destination_keeps_its_defaults():
+    sent = to_ingest_payload(_run(end_time=None, tags=None), "DEST")[0].as_dict()
+    assert "end_time" not in sent and "tags" not in sent
+
+
+def test_the_dedup_key_reproduces_across_two_builds_of_the_same_run():
+    run = _run()
+    first = to_ingest_payload(run, "DEST")[0]
+    second = to_ingest_payload(run, "DEST")[0]
+    key = lambda p: (p.session_id, p.start_time, p.id)  # noqa: E731
+    assert key(first) == key(second)
+
+
+def test_tier_predicate_is_applied_to_the_run_body():
+    assert is_long_lived(_run())
+    assert not is_long_lived(_run(trace_tier="shortlived"))
+    assert not is_long_lived(_run(trace_tier=None))
+
+
+# --------------------------------------------------------------------------
+# Digests
+# --------------------------------------------------------------------------
+def test_digest_is_stable_under_key_reordering_and_changes_with_a_value():
+    a = payload_digest(_run(inputs={"x": 1, "y": 2}))
+    b = payload_digest(_run(inputs={"y": 2, "x": 1}))
+    c = payload_digest(_run(inputs={"x": 1, "y": 3}))
+    assert a == b
+    assert digest_mismatches(a, c) == ("inputs",)
+
+
+def test_digest_covers_the_manifest_only_for_llm_and_prompt_runs():
+    assert "serialized" in payload_digest(_run(run_type="llm", serialized={"a": 1}))
+    assert "serialized" not in payload_digest(_run(run_type="chain", serialized={"a": 1}))
+
+
+def test_digest_covers_attachment_names_and_sizes():
+    left = payload_digest(_run(), {"note": 21})
+    right = payload_digest(_run(), {"note": 22})
+    assert digest_mismatches(left, right) == ("attachments",)
+
+
+def test_digest_mismatch_names_fields_never_values():
+    fields = digest_mismatches(payload_digest(_run(inputs={"secret": "s3cret"})), payload_digest(_run()))
+    assert fields == ("inputs",)
+    assert "s3cret" not in str(fields)
+
+
+# --------------------------------------------------------------------------
+# Grouping and batching
+# --------------------------------------------------------------------------
+def _child(trace, suffix, parent_order):
+    return _run(
+        id=suffix, trace_id=trace, parent_run_id=trace, dotted_order=f"{parent_order}.{suffix}"
+    )
+
+
+def test_traces_group_with_parents_before_children():
+    root = _run(id="T1", trace_id="T1", dotted_order="A")
+    kids = [_child("T1", "c2", "A"), _child("T1", "c1", "A")]
+    (group,) = group_into_traces(kids + [root])
+    assert [r["id"] for r in group] == ["T1", "c1", "c2"]
+
+
+def test_a_trace_is_never_split_across_batches():
+    traces = [
+        [_run(id=f"t{t}r{r}", trace_id=f"t{t}", dotted_order=f"{t}{r}") for r in range(3)]
+        for t in range(4)
+    ]
+    batches = list(batch_traces(traces, max_runs=4, max_bytes=10**9, size_of=lambda r: 1))
+    assert [len(b) for b in batches] == [3, 3, 3, 3]
+    for batch in batches:
+        assert len({r["trace_id"] for r in batch}) == 1
+
+
+def test_an_oversized_single_trace_still_ships_whole():
+    traces = [[_run(id=f"r{i}", dotted_order=str(i)) for i in range(9)]]
+    (only,) = list(batch_traces(traces, max_runs=2, max_bytes=1, size_of=lambda r: 100))
+    assert len(only) == 9
+
+
+def test_batches_respect_the_advertised_byte_limit():
+    traces = [[_run(id=f"t{t}", trace_id=f"t{t}", dotted_order=str(t))] for t in range(4)]
+    batches = list(batch_traces(traces, max_runs=100, max_bytes=250, size_of=lambda r: 100))
+    assert [len(b) for b in batches] == [2, 2]
+
+
+# --------------------------------------------------------------------------
+# Diff and reconciliation
+# --------------------------------------------------------------------------
+def test_the_diff_is_the_work_list_and_the_skip_list():
+    plan = plan_slice({"a", "b", "c"}, {"b", "z"})
+    assert plan.to_ingest == {"a", "c"}
+    assert plan.already_present == {"b"}
+    assert plan.extra_on_dest == {"z"}  # informational only
+
+
+def test_a_run_already_on_the_destination_is_never_re_sent():
+    # A fully ingested run is immutable (its end_time is persisted), so
+    # re-sending it could not repair it even if we tried.
+    plan = plan_slice({"a", "b"}, {"a", "b"})
+    assert plan.to_ingest == set()
+    assert plan.already_present == {"a", "b"}
+
+
+def test_reconciliation_parts_must_account_for_the_source_total():
+    ok = SliceReconciliation("S", "D", "w", source_total=10, ingested=6, already_present=2, degraded=1, blocked=1)
+    assert ok.source_total == 10
+    with pytest.raises(ValueError):
+        SliceReconciliation("S", "D", "w", source_total=10, ingested=6, already_present=2, degraded=1, blocked=0)
+
+
+def test_session_reconciliation_sums_its_slices_and_reports_both_ids():
+    slices = [
+        SliceReconciliation("S", "D", "w1", 4, 4, 0, 0, 0),
+        SliceReconciliation("S", "D", "w2", 6, 3, 2, 1, 0),
+    ]
+    total = SessionReconciliation.of("S", "D", slices)
+    assert (total.source_total, total.ingested, total.already_present, total.degraded) == (10, 7, 2, 1)
+    assert (total.session_id, total.dest_session_id) == ("S", "D")
+    assert total.complete
+
+
+def test_a_session_with_blocked_runs_is_not_complete():
+    blocked = SessionReconciliation.of("S", "D", [SliceReconciliation("S", "D", "w", 2, 1, 0, 0, 1)])
+    assert not blocked.complete

--- a/tests/unit/test_trace_domain.py
+++ b/tests/unit/test_trace_domain.py
@@ -12,8 +12,7 @@ from langsmith_migrator.core.trace_domain import (
     RUN_QUERY_SELECT,
     SKEW_BUFFER,
     RunIngestPayload,
-    SessionReconciliation,
-    SliceReconciliation,
+    Reconciliation,
     Window,
     batch_traces,
     digest_mismatches,
@@ -264,23 +263,23 @@ def test_a_run_already_on_the_destination_is_never_re_sent():
 
 
 def test_reconciliation_parts_must_account_for_the_source_total():
-    ok = SliceReconciliation("S", "D", "w", source_total=10, ingested=6, already_present=2, degraded=1, blocked=1)
+    ok = Reconciliation("S", "D", "w", source_total=10, ingested=6, already_present=2, degraded=1, blocked=1)
     assert ok.source_total == 10
     with pytest.raises(ValueError):
-        SliceReconciliation("S", "D", "w", source_total=10, ingested=6, already_present=2, degraded=1, blocked=0)
+        Reconciliation("S", "D", "w", source_total=10, ingested=6, already_present=2, degraded=1, blocked=0)
 
 
 def test_session_reconciliation_sums_its_slices_and_reports_both_ids():
     slices = [
-        SliceReconciliation("S", "D", "w1", 4, 4, 0, 0, 0),
-        SliceReconciliation("S", "D", "w2", 6, 3, 2, 1, 0),
+        Reconciliation("S", "D", "w1", 4, 4, 0, 0, 0),
+        Reconciliation("S", "D", "w2", 6, 3, 2, 1, 0),
     ]
-    total = SessionReconciliation.of("S", "D", slices)
+    total = Reconciliation.of("S", "D", slices)
     assert (total.source_total, total.ingested, total.already_present, total.degraded) == (10, 7, 2, 1)
     assert (total.session_id, total.dest_session_id) == ("S", "D")
     assert total.complete
 
 
 def test_a_session_with_blocked_runs_is_not_complete():
-    blocked = SessionReconciliation.of("S", "D", [SliceReconciliation("S", "D", "w", 2, 1, 0, 0, 1)])
+    blocked = Reconciliation.of("S", "D", [Reconciliation("S", "D", "w", 2, 1, 0, 0, 1)])
     assert not blocked.complete

--- a/tests/unit/test_trace_domain.py
+++ b/tests/unit/test_trace_domain.py
@@ -51,7 +51,7 @@ def _run(**kw):
 # Windows
 # --------------------------------------------------------------------------
 def test_windows_are_half_open_and_oldest_first():
-    windows = list(iter_windows(NOW, max_age_days=3, window_days=1))
+    windows = list(iter_windows(NOW - timedelta(days=3), NOW, window_days=1))
     assert [w.start for w in windows] == sorted(w.start for w in windows)
     assert windows[0].start == NOW - timedelta(days=3)
     assert windows[-1].end == NOW
@@ -61,21 +61,57 @@ def test_windows_are_half_open_and_oldest_first():
 
 
 def test_final_window_is_clipped_to_now():
-    windows = list(iter_windows(NOW, max_age_days=2.5, window_days=1))
+    windows = list(iter_windows(NOW - timedelta(days=2.5), NOW, window_days=1))
     assert windows[-1].end == NOW
     assert sum((w.end - w.start).total_seconds() for w in windows) == pytest.approx(2.5 * 86400)
 
 
 def test_window_size_does_not_change_which_instants_are_covered():
-    coarse = list(iter_windows(NOW, 4, 4))
-    fine = list(iter_windows(NOW, 4, 0.5))
+    coarse = list(iter_windows(NOW - timedelta(days=4), NOW, 4))
+    fine = list(iter_windows(NOW - timedelta(days=4), NOW, 0.5))
     assert (coarse[0].start, coarse[-1].end) == (fine[0].start, fine[-1].end)
 
 
-@pytest.mark.parametrize("bad", [(0, 1), (1, 0), (-1, 1)])
-def test_nonpositive_range_or_window_is_rejected(bad):
+@pytest.mark.parametrize(
+    "start, end, window",
+    [
+        (NOW, NOW, 1),                      # empty range
+        (NOW - timedelta(days=1), NOW, 0),  # zero window
+        (NOW, NOW - timedelta(days=1), 1),  # inverted range
+    ],
+)
+def test_an_empty_or_inverted_range_is_rejected(start, end, window):
     with pytest.raises(ValueError):
-        list(iter_windows(NOW, *bad))
+        list(iter_windows(start, end, window))
+
+
+@pytest.mark.parametrize("max_age_days", [0, -1, None])
+def test_resolve_range_start_rejects_a_nonpositive_age(max_age_days):
+    from langsmith_migrator.core.trace_domain import resolve_range_start
+
+    with pytest.raises(ValueError):
+        resolve_range_start(NOW, max_age_days, None)
+
+
+def test_an_absolute_stamp_wins_over_a_relative_age():
+    """The whole point: an absolute bound cannot drift as the clock moves."""
+    from langsmith_migrator.core.trace_domain import resolve_range_start
+
+    stamp = datetime(2026, 8, 20, 6, 0, tzinfo=timezone.utc)
+    assert resolve_range_start(NOW, 180.0, stamp) == stamp
+    # evaluated an hour later, the same stamp still means the same instant
+    assert resolve_range_start(NOW + timedelta(hours=1), 180.0, stamp) == stamp
+    # whereas the relative age does not
+    a = resolve_range_start(NOW, 1.0, None)
+    b = resolve_range_start(NOW + timedelta(hours=1), 1.0, None)
+    assert a != b
+
+
+def test_a_naive_stamp_is_read_as_utc():
+    from langsmith_migrator.core.trace_domain import resolve_range_start
+
+    naive = datetime(2026, 8, 20, 6, 0)
+    assert resolve_range_start(NOW, None, naive) == datetime(2026, 8, 20, 6, 0, tzinfo=timezone.utc)
 
 
 def test_bounds_carry_no_run_level_upper_bound_and_a_skew_buffer():
@@ -283,3 +319,68 @@ def test_session_reconciliation_sums_its_slices_and_reports_both_ids():
 def test_a_session_with_blocked_runs_is_not_complete():
     blocked = Reconciliation.of("S", "D", [Reconciliation("S", "D", "w", 2, 1, 0, 0, 1)])
     assert not blocked.complete
+
+
+# --------------------------------------------------------------------------
+# Verified watermark
+# --------------------------------------------------------------------------
+def test_bounds_span_only_the_runs_confirmed_complete():
+    from langsmith_migrator.core.trace_domain import verified_bounds
+
+    runs = [
+        _run(id="a", start_time="2026-08-20T10:00:00"),
+        _run(id="b", start_time="2026-08-21T10:00:00"),
+        _run(id="c", start_time="2026-08-22T10:00:00"),
+    ]
+    earliest, latest = verified_bounds(runs, {"a", "b"})
+    assert earliest.startswith("2026-08-20T10:00:00")
+    assert latest.startswith("2026-08-21T10:00:00")
+
+
+def test_bounds_are_none_when_nothing_is_complete():
+    from langsmith_migrator.core.trace_domain import verified_bounds
+
+    assert verified_bounds([_run(id="a")], set()) == (None, None)
+
+
+def test_bounds_order_by_instant_not_by_string():
+    from langsmith_migrator.core.trace_domain import verified_bounds
+
+    # Same instant, two encodings: naive-UTC sorts after the offset form as a
+    # string, so a string min/max would pick the wrong end.
+    runs = [
+        _run(id="a", start_time="2026-08-20T23:00:00+00:00"),
+        _run(id="b", start_time="2026-08-21T01:00:00"),
+    ]
+    earliest, _ = verified_bounds(runs, {"a", "b"})
+    assert earliest.startswith("2026-08-20T23:00:00")
+
+
+def test_an_unparsable_timestamp_is_skipped_not_fatal():
+    from langsmith_migrator.core.trace_domain import verified_bounds
+
+    runs = [_run(id="a", start_time="not-a-date"), _run(id="b", start_time="2026-08-21T10:00:00")]
+    earliest, latest = verified_bounds(runs, {"a", "b"})
+    assert earliest == latest and earliest.startswith("2026-08-21")
+
+
+def test_session_bounds_are_the_outer_envelope_of_its_slices():
+    slices = [
+        Reconciliation("S", "D", "w1", 1, 1, 0, 0, 0, earliest="2026-08-20T00:00:00", latest="2026-08-20T12:00:00"),
+        Reconciliation("S", "D", "w2", 1, 1, 0, 0, 0, earliest="2026-08-21T00:00:00", latest="2026-08-21T12:00:00"),
+        Reconciliation("S", "D", "w3", 1, 0, 0, 0, 1),  # dirty slice contributes nothing
+    ]
+    total = Reconciliation.of("S", "D", slices)
+    assert total.earliest == "2026-08-20T00:00:00"
+    assert total.latest == "2026-08-21T12:00:00"
+
+
+def test_verified_run_count_only_counts_clean_slices():
+    slices = [
+        Reconciliation("S", "D", "w1", 4, 4, 0, 0, 0, earliest="2026-08-20T00:00:00+00:00",
+                       latest="2026-08-20T12:00:00+00:00", verified_runs=4),
+        Reconciliation("S", "D", "w2", 3, 2, 0, 0, 1),  # dirty: contributes nothing
+    ]
+    total = Reconciliation.of("S", "D", slices)
+    assert total.verified_runs == 4
+    assert (total.earliest, total.latest) == ("2026-08-20T00:00:00+00:00", "2026-08-20T12:00:00+00:00")

--- a/tests/unit/test_trace_frames.py
+++ b/tests/unit/test_trace_frames.py
@@ -1,0 +1,134 @@
+"""Frame compilation: the multipart body must be identical to the SDK's own.
+
+These tests use the real langsmith Client so a moved SDK internal fails here
+rather than in production.
+"""
+
+import io
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+import pytest
+import zstandard
+from langsmith import Client
+from langsmith.client import _BOUNDARY
+
+from langsmith_migrator.core import trace_frames
+from langsmith_migrator.core.trace_frames import (
+    DEFAULT_COMPRESS_LEVEL,
+    compile_frame,
+    unavailable_reason,
+)
+
+
+@pytest.fixture
+def client():
+    return Client(
+        api_url="https://example.invalid",
+        api_key="k",
+        omit_traced_runtime_info=True,
+        auto_batch_tracing=False,
+    )
+
+
+def _payload(i=0, blob=200, attachments=None):
+    rid = str(uuid.uuid4())
+    run = {
+        "id": rid,
+        "trace_id": rid,
+        "dotted_order": f"20260826T120000000000Z{rid}",
+        "session_id": "11111111-1111-1111-1111-111111111111",
+        "name": f"r{i}",
+        "run_type": "chain",
+        "start_time": "2026-08-26T12:00:00+00:00",
+        "inputs": {"q": "repeatable text " * blob, "i": i},
+        "outputs": {"a": "answer text " * blob},
+    }
+    if attachments:
+        run["attachments"] = attachments
+    return run
+
+
+def _body(frame):
+    return zstandard.ZstdDecompressor().decompress(frame.stream.getvalue())
+
+
+def test_the_compiled_body_is_well_formed_multipart(client):
+    runs = [_payload(i) for i in range(4)]
+    frame = compile_frame(client, runs, DEFAULT_COMPRESS_LEVEL)
+    body = _body(frame)
+    assert body.startswith(f"--{_BOUNDARY}".encode())
+    # one part per run at minimum; inputs/outputs may be split out
+    assert body.count(f"--{_BOUNDARY}".encode()) - 1 >= len(runs)
+    assert frame.run_ids == tuple(str(r["id"]) for r in runs)
+    for rid in frame.run_ids:
+        assert rid.encode() in body
+
+
+def test_attachments_survive_into_the_body(client):
+    blob = bytes(range(256))
+    frame = compile_frame(
+        client, [_payload(attachments={"shot": ("application/octet-stream", blob)})],
+        DEFAULT_COMPRESS_LEVEL,
+    )
+    body = _body(frame)
+    assert b"shot" in body and blob in body
+
+
+def test_compiling_off_the_main_thread_gives_the_same_bytes(client):
+    runs = [_payload(i) for i in range(3)]
+    import copy
+
+    main = compile_frame(client, copy.deepcopy(runs), DEFAULT_COMPRESS_LEVEL)
+    with ThreadPoolExecutor(2) as pool:
+        assert pool.submit(threading.get_ident).result() != threading.get_ident()
+        worker = pool.submit(compile_frame, client, copy.deepcopy(runs), DEFAULT_COMPRESS_LEVEL).result()
+    assert _body(worker) == _body(main)
+
+
+def test_a_higher_level_compresses_harder(client):
+    import copy
+
+    runs = [_payload(i) for i in range(6)]
+    low = compile_frame(client, copy.deepcopy(runs), 1)
+    high = compile_frame(client, copy.deepcopy(runs), 19)
+    assert high.sizes[1] < low.sizes[1]
+    assert low.sizes[0] == high.sizes[0]  # same body, different framing
+
+
+def test_a_run_without_dotted_order_is_refused(client):
+    bad = _payload()
+    del bad["dotted_order"]
+    with pytest.raises(ValueError, match="dotted_order"):
+        compile_frame(client, [bad], DEFAULT_COMPRESS_LEVEL)
+
+
+def test_sampling_is_refused_because_it_keeps_client_state(client):
+    client.tracing_sample_rate = 0.5
+    with pytest.raises(RuntimeError, match="tracing_sample_rate"):
+        compile_frame(client, [_payload()], DEFAULT_COMPRESS_LEVEL)
+
+
+def test_unavailable_reason_is_none_when_the_sdk_cooperates(client):
+    assert unavailable_reason(client) is None
+
+
+def test_a_moved_sdk_internal_is_reported_not_raised(client):
+    with patch.object(trace_frames, "_UNAVAILABLE", "no module named x"):
+        reason = unavailable_reason(client)
+    assert reason and "SDK internals moved" in reason
+
+
+def test_a_client_without_the_compressed_sender_is_reported():
+    class Old:
+        pass
+
+    assert "no _send_compressed_multipart_req" in unavailable_reason(Old())
+
+
+def test_the_stream_carries_the_log_context(client):
+    frame = compile_frame(client, [_payload()], DEFAULT_COMPRESS_LEVEL)
+    assert isinstance(frame.stream, io.BytesIO)
+    assert hasattr(frame.stream, "context")

--- a/tests/unit/test_trace_resume_hint.py
+++ b/tests/unit/test_trace_resume_hint.py
@@ -1,0 +1,91 @@
+"""The resume hint must redo about one ingest batch, not the whole span."""
+
+import datetime as dt
+from unittest.mock import patch
+
+import langsmith_migrator.cli.main as cli_main
+from langsmith_migrator.core.trace_domain import Reconciliation
+
+
+def _watermark(verified_runs, span_hours, batch_runs):
+    """Render the hint for a clean project and return (text, earliest, latest)."""
+    latest = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=1)
+    earliest = latest - dt.timedelta(hours=span_hours)
+    report = Reconciliation(
+        "S", "D", "", verified_runs, verified_runs, 0, 0, 0,
+        earliest=earliest.isoformat(), latest=latest.isoformat(), verified_runs=verified_runs,
+    )
+    printed = []
+    with patch.object(cli_main.console, "print", lambda *a, **k: printed.append(str(a[0]))):
+        cli_main._print_trace_watermark(report, batch_runs)
+    return "\n".join(printed), earliest, latest
+
+
+def _resume_instant(text):
+    """The hint now carries an absolute stamp, which cannot drift."""
+    return dt.datetime.fromisoformat(text.split("--max-age-stamp ")[1].split()[0])
+
+
+def test_the_overlap_is_one_batch_not_the_whole_span():
+    # 1000 runs spread over 10h, batches of 100 -> one batch occupied ~1h
+    text, earliest, latest = _watermark(1000, span_hours=10, batch_runs=100)
+    assert "one ingest batch" in text
+    resume = _resume_instant(text)
+    redone_hours = (latest - resume).total_seconds() / 3600
+    assert 0.9 < redone_hours < 1.1, f"redid {redone_hours}h, expected ~1h"
+    assert resume > earliest, "must not re-walk the whole verified span"
+
+
+def test_a_span_smaller_than_one_batch_resumes_at_the_earliest():
+    # Redoing everything *is* one batch here, so there is nothing to trim.
+    text, earliest, _ = _watermark(50, span_hours=10, batch_runs=100)
+    assert "the whole span" in text
+    assert _resume_instant(text) == earliest
+
+
+def test_a_denser_project_gets_a_smaller_overlap():
+    sparse = _resume_instant(_watermark(1000, span_hours=10, batch_runs=100)[0])
+    dense = _resume_instant(_watermark(10_000, span_hours=10, batch_runs=100)[0])
+    assert dense > sparse, "10x the run density should mean 10x less time redone"
+
+
+def test_a_project_with_blocked_runs_claims_no_watermark():
+    printed = []
+    with patch.object(cli_main.console, "print", lambda *a, **k: printed.append(str(a[0]))):
+        cli_main._print_trace_watermark(Reconciliation("S", "D", "", 2, 1, 0, 0, 1), 100)
+    text = "\n".join(printed)
+    assert "no verified watermark" in text
+    assert "--max-age-stamp" not in text
+
+
+def test_a_dry_run_explains_nothing_rather_than_blaming_fidelity():
+    """The suppression reason must match reality.
+
+    With --dry-run or --no-verify there is nothing verified; saying "degraded
+    or blocked runs" would send an operator hunting for problems that the very
+    same line reports as zero.
+    """
+    clean_but_unverified = Reconciliation("S", "D", "", 2, 2, 0, 0, 0)
+    printed = []
+    with patch.object(cli_main.console, "print", lambda *a, **k: printed.append(str(a[0]))):
+        cli_main._print_trace_watermark(clean_but_unverified, 100, verified=False)
+    assert printed == []
+
+
+def test_a_verified_run_with_blocked_runs_does_explain_itself():
+    printed = []
+    with patch.object(cli_main.console, "print", lambda *a, **k: printed.append(str(a[0]))):
+        cli_main._print_trace_watermark(Reconciliation("S", "D", "", 2, 1, 0, 0, 1), 100, verified=True)
+    assert "degraded or blocked runs" in "\n".join(printed)
+
+
+def test_window_durations_read_as_wall_clock():
+    """The pre-flight prints the window in units an operator thinks in."""
+    h = cli_main._human_duration
+    assert h(0.01) == "14m24s"
+    assert h(0.1) == "2h24m"
+    assert h(1.0) == "1d"
+    assert h(2.5) == "2d12h"
+    assert h((2 * 3600 + 5 * 60 + 4) / 86400) == "2h5m4s"   # the example asked for
+    assert h(1 / 86400) == "1s"
+    assert h(0) == "0s"


### PR DESCRIPTION
This is the trace migration tooling discussed in https://langchain.slack.com/archives/C0AS3TYQD0R

The PR adds a subcommand to migrate long-lived traces from one LangSmith instance to another. It uses the V1 `/runs/query` endpoint to retrieve runs and the `/runs/multipart` to push them up.

Example usage:
```bash
# Configure the necessary source/destination URLs and credentials
export LANGSMITH_OLD_API_KEY=<dev key>      # source
export LANGSMITH_OLD_BASE_URL=https://dev.api.smith.langchain.com
export LANGSMITH_NEW_API_KEY=<stage key>    # destination
export LANGSMITH_NEW_BASE_URL=https://beta.api.smith.langchain.com

# Kick off a run for the past 0.9 of a day, querying and then ingesting 0.1 day (or 2.4h) at a timeuv run langsmith-migrator --verbose traces \
           --project PROJECT_NAME_TO_BE_MIGRATED \
           --max-age-days 0.9 --window 0.1 \
           --source-workspace SOURCE_TENANT_UUID \
           --dest-workspace DEST_TENANT_UUID \
           --into-session-suffix "-$(date -u +%Y%m%dT%H%M%SZ)" # target unique destination session
```
To resume - simply re-run the same command (just use the previous destination suffix). The source will be re-examined and missing traces will be ingested.