### PR TITLE
Add storing of dumps to HDD and reading from HDD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`traces --to-archive DIR` / `--from-archive DIR`**: save traces to disk as
+  compressed files, and load them into a destination later. Useful for
+  air-gapped transfers, or for capturing once and loading into several places.
+
+  One file is written per project and time window:
+  `<archive-dir>/<workspace>-<id>/<project>-<id>/<start>__<end>.tar.zst`
+
+  - Files hold run data, not ready-made HTTP bodies, so the destination project
+    can be changed on load and the format does not depend on SDK internals.
+  - A file is written as `.partial` and renamed once finished, so `ls` shows
+    what completed. Renames happen in time order, so an interrupted export
+    leaves an unbroken sequence — never a gap in the middle.
+  - An empty window still gets a file, so "looked, found nothing" is different
+    from "not looked at yet".
+  - To resume, run the same command again; finished windows are skipped. One
+    Ctrl-C finishes the windows already in flight and loses nothing, a second
+    aborts. Exit code 130, and the command to continue is printed.
+  - Archives are read as untrusted input: member names must match known
+    patterns, decompressed size is capped, and an unknown `format_version` is
+    rejected.
+  - Files are `0o600` and directories `0o700`. **Not encrypted** — an archive is
+    plaintext trace data.
+  - Make sure you run using the same time window - or remove the archive
+    directory before running
+
+- **`traces --since` / `--until`**, both required, both absolute timestamps.
+  They replace `--max-age-days` / `--min-age-days` and avoid the problem of
+  ever-sliding time windows due to `now()` being always different.
+
+- **`traces --compress-level` / `--prefetch-windows`**: the upload body is now
+  zstd-compressed by the same worker threads that fetch the data, so
+  compression is off the critical path and the level can be chosen. Measured on
+  real payloads: level 3 with long-distance matching is 68x smaller, against 6x
+  for the level 1 the SDK uses on its own. `--prefetch-windows` (default 4)
+  fetches several windows at once; **uploads stay serial and oldest-first
+  regardless**, which is what stops a failure leaving a gap.
+  `--no-compress-upload` sends uncompressed.
+
 - **Long-lived trace migration (`traces`)**: New command that migrates traces
   whose `trace_tier` is `longlived` between deployments. Run `id`, `trace_id`,
   `parent_run_id`, `dotted_order` and all timestamps are preserved verbatim
@@ -41,6 +79,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   updated in place (or skipped with `--skip-existing`), and a server-side
   uniqueness conflict is treated as already-migrated. Also wired into
   `migrate-all` (Step 8) with a `--skip-model-pricing` flag.
+
+### Changed
+- **`traces --window` is in hours now, not days** (default 24, was 1). Sub-day
+  windows are the normal case — a busy project wants about 1.7 h — and writing
+  that as `0.07` of a day is unreadable. Fractions still work.
+- **An archive has a workspace directory above the project one**, named
+  `<workspace-name>-<workspace-id>`: the name so it is readable, the ID so two
+  workspaces with the same name cannot share a directory. `--from-archive`
+  accepts the archive root or a single workspace directory.
+- **Window labels in the output show the time, not just the date** —
+  `2026-09-01T22:00..23:00Z` rather than `2026-09-01..2026-09-01`, which looked
+  identical for every window in a day.
+- **The per-window progress line names its project**, because under `--verbose`
+  the project header has scrolled away by the time the summary prints.
+- Verbose query lines say `scan` or `fetch` instead of `query`. A fetch is one
+  request per ID batch, so its page counter always read `p1`.
+
+### Removed
+- **`traces --max-age-days` and `--min-age-days`.** A relative age means a
+  different moment each time it is read, which caused three bugs: window
+  filenames changed between runs, so a resumed export re-did everything instead
+  of skipping it; the two bounds were read moments apart, so a range that was an
+  exact multiple of `--window` grew a spurious sub-second window at the end; and
+  neither was visible in the output. Absolute `--since` / `--until` remove all
+  three, and the grid-snapping workaround the first two had needed.
+
+### Fixed
+- **Payload fetches shrink their ID batch on a 413/502/503 or read timeout**
+  instead of failing the project outright. 500 IDs of a heavy project is about
+  355 MB, which the gateway will not serve. The query timeout also went from
+  30 s to 120 s.
+- **A 429 gets its own retry budget.** It used to share three attempts with
+  server errors, so it gave up after ~6 s of backoff against a limit measured in
+  minutes, killing a whole project.
+- **A 409 on upload no longer reports runs that did land as blocked.** Uploads
+  are sent with `attempts=1`: a blind retry of a large batch the server accepted
+  slowly earns a 409, which made 1,025 written runs look rejected.
+- **`ChunkedEncodingError` is retried.** It is not a `ConnectionError` subclass,
+  so it was never in the retry list — and it is exactly what a full connection
+  pool produces. Pool size now matches the number of reader threads.
+- **Run data is copied before the upload body is built.** The SDK's serializer
+  removes `inputs`/`outputs`/`events` and more from the dict it is handed, so a
+  retry would have re-sent runs with no content.
+- **Both ends of the time range come from one clock reading**, and fields the
+  source does not have are left out when creating a destination project (a null
+  `start_time` was a 422).
+- **An export now reports a run the source listed but never returned**, rather
+  than counting it as saved — an export has no read-back check to catch it.
 
 ## [0.0.83] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -68,16 +68,14 @@ What `traces` guarantees:
 
 **Statelessness: there is no resume.** Work is derived from a destination diff per time
 window, not from a checkpoint. If a run is interrupted, just re-run the same command —
-finished windows produce an empty difference. `--max-age-days` sets the range to walk
-(default 180, the retention ceiling) and `--window` the size of one slice of it
-(default 1 day); widen `--window` when migrating many projects. `--max-age-days` is
-the easy way to *start* a migration; to **resume** one, prefer `--max-age-stamp` with
-an absolute instant, because a relative age denotes a different point in time every
-time it is evaluated — over a multi-hour run the same float silently slides forward.
-Each project reports a `verified complete from … to …` watermark and a ready-to-paste
-`--max-age-stamp` that redoes about one ingest batch, so no boundary run is skipped.
-Passing both bounds is an error rather than a silent preference. `langsmith-migrator
-resume` does not apply and will say so.
+finished windows produce an empty difference. `--since` and `--until` bound the range
+to walk and are both **required and absolute**; `--window` sets the size of one slice
+of it in **hours** (default 24) — widen it when migrating many projects. The bounds are stamps
+rather than relative ages because a relative age denotes a different point in time
+every time it is evaluated, so over a multi-hour run the same float silently slides
+forward. Each project reports a `verified complete from … to …` watermark and a
+ready-to-paste `--since` that redoes about one ingest batch, so no boundary run is
+skipped. `langsmith-migrator resume` does not apply and will say so.
 
 **Ordering dependency: run `model-pricing` before `traces`.** Token and cost rollups are
 not replayed — the destination recomputes them from each run's `usage_metadata` against
@@ -288,8 +286,10 @@ langsmith-migrator fleet --agents-owned-only    # Only agents you own or are dir
 # Long-lived traces (run model-pricing first)
 langsmith-migrator traces                       # Interactive project selection
 langsmith-migrator traces --all                 # All tracing projects
-langsmith-migrator traces --project "my-project" --max-age-days 90 --window 7
+langsmith-migrator traces --project "my-project" --since 2026-06-01 --until 2026-09-01 --window 168
 langsmith-migrator traces --emit-upgrade-list upgrade.csv  # Leave tiers alone, hand the list to an operator
+langsmith-migrator traces --to-archive /data/archive/run1 --project p --since 2026-06-01 --until 2026-09-01
+langsmith-migrator traces --from-archive /data/archive/run1 --all --since 2026-08-31 --until 2026-09-01
 
 # Utilities
 langsmith-migrator export-users --source -o users.csv  # Export active members to a members CSV
@@ -312,7 +312,7 @@ langsmith-migrator clean
 - `fleet`: migrate Fleet resources (agents, skills, MCP servers, integrations, auth providers, schedules, triggers, webhooks, usage limits, sandbox policies, secrets) with `--skip-*` flags for each resource type, and `--agent <name-or-id>` / `--agents-owned-only` to scope which agents (and their schedules/triggers/usage limits) are migrated
 - `issues`: migrate Engine issues-agent configs and detected issues as metadata (`--session` to scope to one tracing project)
 - `contexts`: migrate Context Hub agents and skills, replaying full commit history and tags by default (`--latest-only`, `--no-tags`, `--agents-only`, `--skills-only`, `--include-external`, `--same-instance`)
-- `traces`: migrate long-lived traces (`trace_tier == "longlived"`) with run IDs and timestamps preserved; stateless, so re-run rather than resume (`--max-age-days`, `--window`, `--prefetch-windows`, `--compress-level`, `--skip-attachments`, `--emit-upgrade-list`). Not part of `migrate-all`
+- `traces`: migrate long-lived traces (`trace_tier == "longlived"`) with run IDs and timestamps preserved; stateless, so re-run rather than resume (`--since`/`--until` required and absolute, `--window`, `--prefetch-windows`, `--compress-level`, `--skip-attachments`, `--emit-upgrade-list`). Can archive to disk and replay (`--to-archive`, `--from-archive`). Not part of `migrate-all`
 - `users`: migrate users/roles between instances, or run single-instance CSV access sync
 - `export-users`: export active org and workspace members to a members CSV for import via `users --members-csv`
 - `resume`: retry resumable items from a prior session and show grouped manual blockers
@@ -530,10 +530,9 @@ The prompt default is `No` (rules are created disabled).
 ```bash
 --project TEXT                  Tracing project (session) name or ID; repeatable
 --all                           Migrate all tracing projects without prompting
---max-age-days FLOAT            How far back to walk, the range (default: 180, the retention ceiling)
---max-age-stamp TEXT            Absolute lower bound instead of --max-age-days, e.g. 2026-08-27T18:00:00Z
-                                (mutually exclusive with --max-age-days; prefer it for long runs and resuming)
---window FLOAT                  Size in days of one slice of the range (default: 1)
+--since TEXT                    Oldest trace to take, absolute: 2026-08-27 or 2026-08-27T18:00:00Z (required)
+--until TEXT                    Youngest trace to take, same form (required)
+--window FLOAT                  Size in HOURS of one slice of the range; fractions fine (default: 24)
 --max-field-bytes INTEGER       Destination MAX_FIELD_SIZE_BYTES; not advertised, so it must be supplied (default: 25 MB)
 --no-verify                     Skip the confirming re-query after ingest (the pre-diff still runs)
 --verify-content-sample INTEGER Runs per window to content-check (default: 100)
@@ -541,6 +540,9 @@ The prompt default is `No` (rules are created disabled).
 --compress-level INTEGER        zstd level for the ingest body, 1-22 (default: 3)
 --no-compress-upload            Send the ingest body uncompressed
 --prefetch-windows INTEGER      Windows to retrieve concurrently, 1-32 (default: 4); ingest stays serial
+--to-archive DIR                Write windows to disk as .tar.zst instead of ingesting into a destination
+--from-archive DIR              Replay window files from a directory instead of reading the source deployment
+--allow-incomplete              Replay a truncated (.partial) window file
 --map-projects                  Launch interactive TUI to map source projects to destination projects
 --project-mapping TEXT          JSON string or file path with project ID mapping (headless, no TUI)
 --restore-session-tier/--no-restore-session-tier
@@ -550,7 +552,58 @@ The prompt default is `No` (rules are created disabled).
 --emit-upgrade-list FILE        Leave project tiers alone and write (dest_session_id, trace_id, start_time) per trace
 ```
 
-There are deliberately **no timestamp options**: run timestamps are copied verbatim.
+Both range bounds are **required and absolute** — a relative age means a
+different moment every time it is read, which breaks clean resumption.
+`--max-age-stamp` still works as another name for `--since`.
+
+The timestamps observed are the trace's (root run's) `start_time` - all
+children of the trace are selected regardless of their individual `start_time`-s.
+
+#### Archive to disk, replay later
+
+`--to-archive DIR` writes each project/window to one compressed `.tar.zst`
+instead of ingesting it; `--from-archive DIR` loads those files into a
+destination. This enables: staged or air-gapped transfer, re-ingest without
+re-reading the source, and capture-once-load-many.
+
+```bash
+# capture one project's history in 6-hour windows, into a dated directory
+langsmith-migrator traces --to-archive /data/archive/$(date -u +%Y%m%dT%H%M%SZ) \
+  --project gtm-agent --source-workspace WS_ID \
+  --since 2026-06-01 --until 2026-09-01 --window 6
+
+# load one day of it back, into projects suffixed with a stamp
+langsmith-migrator traces --from-archive /data/archive/20260901T120000Z \
+  --all --since 2026-08-31 --until 2026-09-01 \
+  --into-session-suffix "-replay-$(date -u +%H%M%S)"
+```
+
+```
+<archive>/<workspace-name>-<workspace-id>/<project-name>-<session-id>/
+    20260901T000000Z__20260901T060000Z.tar.zst     # one window, bounds in the name
+```
+
+- **`--window` (in hours) is the only control over file size.** It also bounds
+  how much one worker holds in memory. The bigger the window/byte size, the better
+  the compression ratio. OTOH big window increases the gap between and the size of
+  "checkpoints", making resumption after a failure slower.
+- **`ls` tells you what finished.** A window is written as `.partial` and renamed
+  only once complete, in time order — so an interrupted export leaves an
+  unbroken run of files, never a gap in the middle.
+- **To resume, re-run the identical command**; finished windows are skipped. To
+  re-capture one window, delete its file. DO NOT change the time window on re-run!
+- Compression measures 22x on small payloads and up to 190x on projects with
+  large repeated content.
+
+Two things to know before pointing this at real data:
+
+- **Pass `--source-workspace` for any unattended export.** No destination key or
+  `--dest-workspace` is needed, but on a key that sees several workspaces,
+  omitting it opens the interactive workspace mapper — which hangs when stdin is
+  not a terminal. Add `--non-interactive` to make that case fail fast instead.
+- **An archive is unencrypted trace data** — inputs, outputs and attachments in
+  plain text. Give every export its own directory; two exports writing into one
+  directory are going to clash.
 
 #### Throughput
 
@@ -563,8 +616,10 @@ Three settings govern speed, and only one of them trades anything away:
   `--window` if that is too much.
 - `--compress-level` (default 3) sets the zstd level for the ingest body.
   Measured per assembled request on real payloads: level 1 (what the SDK uses
-  on its own) 5.9x, level 3 with long-distance matching 68.5x at 1755 MB/s,
-  level 19 79.7x at 58 MB/s. Level 3 is effectively free; raise it only when
+  on its own) 5.9x, level 3 alone 30.6x, level 3 with long-distance matching
+  68.5x at ~1755 MB/s, level 19 79.7x at 58 MB/s. The long-match gain ranges
+  from 0.98x to 3.71x depending on how much a project repeats content across
+  runs. Level 3 is effectively free; raise it only when
   genuinely bandwidth-bound, since the frame is built by the retrieval workers
   and higher levels start costing real CPU.
 - Page size is not an option: `/runs/query` is asked for 1000 runs per page and

--- a/langsmith_migrator/cli/main.py
+++ b/langsmith_migrator/cli/main.py
@@ -3,6 +3,7 @@
 import csv
 import functools
 import logging
+import shlex
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -39,6 +40,7 @@ from ..core.migrators import (
     FleetWebhookMigrator,
 )
 from ..core.migrators.trace import TracePreflightError
+from ..core.trace_archive import ArchiveSink, ArchiveSource, projected_file_count
 from ..core.trace_frames import DEFAULT_COMPRESS_LEVEL
 from ..core.migrators.user_role import (
     is_workspace_role_union_id,
@@ -57,6 +59,7 @@ from ..utils.chart_mode import (
     workspace_pair_allows_same_instance as _chart_workspace_pair_allows_same_instance,
 )
 from ..utils.config import Config
+from ..utils.retry import RateLimitError
 from ..utils.state import MigrationStatus, ResolutionOutcome, StateManager, VerificationState
 from ..utils.workspace import (
     discover_workspaces,
@@ -6247,27 +6250,34 @@ def contexts(
 @click.option("--project", "projects", multiple=True, help="Tracing project (session) name or ID; repeatable")
 @click.option("--all", "select_all", is_flag=True, help="Migrate all tracing projects without prompting")
 @click.option(
-    "--max-age-days",
-    type=float,
-    default=180.0,
-    show_default=True,
-    help="How far back to walk (the range). 180 days is the long-lived retention ceiling.",
-)
-@click.option(
+    "--since",
     "--max-age-stamp",
+    "since",
+    required=True,
     help=(
-        "Absolute lower bound instead of --max-age-days, e.g. 2026-08-27 or "
-        "2026-08-27T18:00:00Z. Prefer this for long runs and for resuming: a "
-        "relative age denotes a different instant every time it is evaluated."
+        "Oldest trace to take, as an absolute stamp: 2026-08-27 or "
+        "2026-08-27T18:00:00Z. Bounds a trace root's start_time. Absolute on "
+        "purpose - a relative age denotes a different instant every time it is "
+        "evaluated, which slides the whole window grid. (Former name: "
+        "--max-age-stamp.)"
     ),
 )
 @click.option(
+    "--until",
+    required=True,
+    help="Youngest trace to take, as an absolute stamp. Same form as --since.",
+)
+@click.option(
     "--window",
-    "window_days",
+    "window_hours",
     type=float,
-    default=1.0,
+    default=24.0,
     show_default=True,
-    help="Size in days of one slice of the range. Widen it for a many-project run.",
+    help=(
+        "Size in hours of one slice of the range. Fractions are fine (1.5). It "
+        "bounds how much a prepare worker holds in memory and, for an archive, "
+        "is the only control over file size - a heavy project wants ~1.7."
+    ),
 )
 @click.option(
     "--max-field-bytes",
@@ -6304,6 +6314,24 @@ def contexts(
         "plus the one being written, so shrink --window if it is too much."
     ),
 )
+@click.option(
+    "--to-archive",
+    type=click.Path(file_okay=False),
+    help=(
+        "Write windows to this directory as one .tar.zst per (project, window) "
+        "instead of ingesting into a destination. Give every run its own directory."
+    ),
+)
+@click.option(
+    "--from-archive",
+    type=click.Path(exists=True, file_okay=False),
+    help="Replay window files from this directory instead of reading the source deployment",
+)
+@click.option(
+    "--allow-incomplete",
+    is_flag=True,
+    help="Replay a truncated (.partial) window file; without this such a file is refused",
+)
 @click.option("--map-projects", is_flag=True, help="Interactively map source projects to destination projects")
 @click.option("--project-mapping", help='Headless project mapping: JSON object or file, {"src-id": "dest-id"}')
 @click.option(
@@ -6320,9 +6348,9 @@ def traces(
     ctx,
     projects,
     select_all,
-    max_age_days,
-    max_age_stamp,
-    window_days,
+    since,
+    until,
+    window_hours,
     max_field_bytes,
     no_verify,
     verify_content_sample,
@@ -6330,6 +6358,9 @@ def traces(
     compress_level,
     no_compress_upload,
     prefetch_windows,
+    to_archive,
+    from_archive,
+    allow_incomplete,
     map_projects,
     project_mapping,
     restore_session_tier,
@@ -6350,24 +6381,36 @@ def traces(
     state_manager = ctx.obj["state_manager"]
 
     display_banner()
+    if to_archive and from_archive:
+        console.print("[red]Error: --to-archive and --from-archive are mutually exclusive[/red]")
+        ctx.exit(1)
+        return
+    if to_archive and (into_session_suffix or emit_upgrade_list):
+        console.print("[red]Error: --to-archive writes no destination, so project-tier options do not apply[/red]")
+        ctx.exit(1)
+        return
+    if to_archive:
+        # An export writes to disk and never touches a destination, so it must
+        # not require destination credentials or a destination workspace. Both
+        # are satisfied with the source's, so the shared validation, connection
+        # test and workspace pairing still work unchanged.
+        if not config.destination.api_key:
+            config.destination.api_key = config.source.api_key
+            config.destination.base_url = config.source.base_url
+        dest_workspace = dest_workspace or source_workspace
     if not ensure_config(config):
         return
 
-    range_start = None
-    if max_age_stamp:
-        # Refuse rather than pick one: the two bounds disagree the moment the
-        # clock moves, and silently preferring either would be a trap.
-        if ctx.get_parameter_source("max_age_days").name != "DEFAULT":
-            console.print("[red]Error: --max-age-days and --max-age-stamp are mutually exclusive[/red]")
-            ctx.exit(1)
-            return
-        try:
-            range_start = _parse_age_stamp(max_age_stamp)
-        except ValueError as exc:
-            console.print(f"[red]Error: {exc}[/red]")
-            ctx.exit(1)
-            return
-        max_age_days = None
+    try:
+        range_start, range_end = _parse_stamp(since, "--since"), _parse_stamp(until, "--until")
+    except ValueError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        ctx.exit(1)
+        return
+    if range_start >= range_end:
+        console.print("[red]Error: --since must be earlier than --until[/red]")
+        ctx.exit(1)
+        return
 
     project_id_map = _load_project_mapping_arg(project_mapping)
     if project_id_map is _PROJECT_MAPPING_ERROR:
@@ -6404,7 +6447,11 @@ def traces(
     # re-ingesting preserved IDs into the same tenant duplicates rather than
     # replaces - whatever the session mapping says. Cross-workspace on one
     # deployment is fine.
-    if _is_same_deployment(config) and any(src == dst for src, dst in ws_pairs):
+    # Only applies when the *source deployment* is being read: an export writes
+    # no destination, and a replay reads a directory.
+    if not (to_archive or from_archive) and _is_same_deployment(config) and any(
+        src == dst for src, dst in ws_pairs
+    ):
         console.print(
             "[red]Refusing to migrate traces into the same deployment and workspace they were read from.[/red]\n"
             "[red]Runs keep their original IDs, so the destination would duplicate or overwrite the source.[/red]"
@@ -6418,37 +6465,82 @@ def traces(
     session_reports = []
     fidelity_notes = set()
     failed_projects = []
+    interrupted = False
+    archives_written = archives_skipped = 0
 
     for src_ws, dst_ws in ws_pairs:
+        if interrupted:
+            console.print("[yellow]Stopped; remaining workspace pairs were not started[/yellow]")
+            break
         if src_ws and dst_ws:
             orchestrator.set_workspace_context(src_ws, dst_ws)
             console.print(f"\n[bold cyan]Workspace: {src_ws} -> {dst_ws}[/bold cyan]")
 
+        archive_sink = (
+            ArchiveSink(
+                to_archive,
+                compress_level=compress_level,
+                dry_run=config.migration.dry_run,
+                workspace=_source_workspace_ref(orchestrator, src_ws),
+            )
+            if to_archive
+            else None
+        )
+        archive_source = (
+            ArchiveSource(
+                from_archive,
+                allow_incomplete=allow_incomplete,
+                range_start=range_start,
+                range_end=None,
+            )
+            if from_archive
+            else None
+        )
         migrator = TraceMigrator(
             orchestrator.source_client,
             orchestrator.dest_client,
             orchestrator.state,
             config,
-            max_age_days=max_age_days,
             range_start=range_start,
-            window_days=window_days,
+            range_end=range_end,
+            window_hours=window_hours,
             max_field_bytes=max_field_bytes,
-            verify=not no_verify,
-            verify_content_sample=verify_content_sample,
+            # An export has no destination to confirm against or compare with;
+            # verification belongs to replay, where one can answer.
+            verify=not (no_verify or to_archive),
+            verify_content_sample=0 if to_archive else verify_content_sample,
             skip_attachments=skip_attachments,
             restore_session_tier=restore_session_tier,
             into_session_suffix=into_session_suffix,
             emit_upgrade_list=emit_upgrade_list,
             compress_level=None if no_compress_upload else compress_level,
             prefetch_windows=prefetch_windows,
+            run_sink=archive_sink,
+            run_source=archive_source,
             project_id_map=project_id_map
             or _workspace_scoped_project_id_map(orchestrator, ws_result, src_ws)
             or (build_project_id_mapping_tui(orchestrator.source_client, orchestrator.dest_client) if map_projects else None),
         )
-        _print_trace_preflight(migrator, config, window_days, max_field_bytes, no_verify, into_session_suffix)
+        if archive_source is not None:
+            # Deferred: a replayed window is re-batched and compiled against the
+            # live destination, which is the migrator this source was handed to.
+            archive_source.bind(migrator)
+            # --since / --until select *which* archived windows are replayed.
+            # That is the lever for a destination that only accepts a recent
+            # ingest window.
+            archive_source.range_start = migrator.resolved_range_start()
+            archive_source.range_end = migrator.walk_end()
+        _print_trace_preflight(
+            migrator, config, window_hours, max_field_bytes, no_verify, into_session_suffix,
+            to_archive=to_archive, from_archive=from_archive,
+            projects=len(projects) or None,
+        )
 
         try:
-            migrator.canary()
+            # An export writes no runs anywhere, so there is no ingest window to
+            # prove and no scratch project to create.
+            if not to_archive:
+                migrator.canary()
         except Exception as exc:
             # Any pre-flight failure, not just a refused timestamp: a 403 on the
             # scratch project used to escape as a raw traceback with no recorded
@@ -6487,36 +6579,36 @@ def traces(
             console.print("[yellow]No tracing projects selected[/yellow]")
             continue
 
-        for source_session in selected:
-            label = _trace_session_label(source_session)
-            console.print(f"\n[bold]{label}[/bold] ({source_session['id']})")
-            try:
-                report = migrator.migrate_session(source_session)
-            except Exception as exc:
-                # Not just printed: a project that failed must leave a blocked
-                # outcome behind and fail the exit code, or a run that migrated
-                # nothing looks indistinguishable from a clean one.
-                blocked = isinstance(exc, TracePreflightError)
-                console.print(f"  [red]{'blocked' if blocked else 'failed'}: {exc}[/red]")
-                failed_projects.append((label, str(exc)))
-                _record_trace_session_failure(
-                    orchestrator, config, migrator, source_session,
-                    "trace_session_blocked" if blocked else "trace_session_failed", exc,
+        if archive_sink is not None:
+            # Resolved once for the whole run, and recorded in every manifest, so
+            # "meant to cover 180 days, stopped at day 47" is distinguishable
+            # from "meant to cover 47 days". A resumed run legitimately writes a
+            # later range_end, and the latest one is the authoritative target.
+            archive_sink.intent = {
+                "range_start": migrator.resolved_range_start().isoformat(),
+                "range_end": migrator.walk_end().isoformat(),
+                "window_hours": window_hours,
+                "projects": sorted(_trace_session_label(s) for s in selected),
+            }
+
+        try:
+            with migrator.graceful_stop():
+                _run_trace_projects(
+                    ctx, orchestrator, config, migrator, selected,
+                    session_reports, failed_projects,
+                    verified=not (no_verify or to_archive) and not config.migration.dry_run,
                 )
-                continue
-            if report is None:
-                console.print("  [yellow]skipped: supply an explicit --project-mapping for this project[/yellow]")
-                failed_projects.append((label, "unresolved destination project"))
-                continue
-            for reason in migrator.blocked_reasons:
-                console.print(f"  [red]blocked:[/red] {reason}")
-            del migrator.blocked_reasons[:]
-            session_reports.append((source_session.get("name"), report))
-            _record_trace_session_outcome(orchestrator, config, migrator, source_session, report)
-            _print_trace_reconciliation(
-                report, migrator.batch_limits()[0],
-                verified=not no_verify and not config.migration.dry_run,
-            )
+        except KeyboardInterrupt:
+            console.print("\n[yellow]Abandoned.[/yellow]")
+            interrupted = True
+        finally:
+            interrupted = interrupted or migrator.stop_requested
+            if archive_sink is not None:
+                for removed in archive_sink.discard_staged():
+                    console.print(f"[yellow]Discarded incomplete window {removed.name}[/yellow]")
+                archives_written += len(archive_sink.written)
+                archives_skipped += migrator.skipped_windows
+
         upgrade_rows.extend(migrator.upgrade_rows)
         fidelity_notes |= migrator.fidelity_reduced
 
@@ -6527,11 +6619,128 @@ def traces(
         _write_upgrade_list(emit_upgrade_list, upgrade_rows)
 
     _print_trace_summary(session_reports, fidelity_notes, no_verify, failed_projects)
+    if to_archive:
+        console.print(
+            f"Archive: {archives_written} window file(s) written, "
+            f"{archives_skipped} already captured and skipped, under {to_archive}"
+        )
+    if to_archive and (interrupted or failed_projects):
+        _print_archive_resume(
+            to_archive, projects,
+            window_hours=window_hours, since=since, until=until,
+            compress_level=compress_level,
+            prefetch_windows=prefetch_windows,
+            source_workspace=source_workspace, captured=archives_written,
+        )
     _display_resolution_summary(orchestrator)
     _exit_for_remediation_if_needed(ctx, config, orchestrator)
     orchestrator.cleanup()
+    if interrupted:
+        ctx.exit(130)
     if failed_projects:
         ctx.exit(1)
+
+
+def _source_workspace_ref(orchestrator, workspace_id):
+    """``{"id", "name"}`` for the source workspace an archive is filed under.
+
+    The name is what the operator reads, so a failure to resolve it must not
+    stop an export: it degrades to the ID, and then to nothing at all on a
+    deployment with no workspace endpoint.
+    """
+    try:
+        workspaces = _list_workspaces(orchestrator.source_client)
+    except Exception:
+        workspaces = []
+    if workspace_id:
+        match = next((w for w in workspaces if str(w.get("id")) == str(workspace_id)), None)
+        return {"id": str(workspace_id), "name": get_workspace_name(match) if match else None}
+    # No explicit --source-workspace: unambiguous only when there is one.
+    if len(workspaces) == 1:
+        return {"id": str(workspaces[0].get("id")), "name": get_workspace_name(workspaces[0])}
+    return None
+
+
+def _run_trace_projects(
+    ctx, orchestrator, config, migrator, selected, session_reports, failed_projects, *, verified: bool
+) -> None:
+    """Migrate each selected project, recording every outcome.
+
+    Extracted from ``traces`` so the graceful-stop context and the archive's
+    ``.partial`` cleanup can wrap the whole loop without reindenting it.
+    """
+    for source_session in selected:
+        label = _trace_session_label(source_session)
+        console.print(f"\n[bold]{label}[/bold] ({source_session['id']})")
+        try:
+            report = migrator.migrate_session(source_session)
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:
+            # Not just printed: a project that failed must leave a blocked
+            # outcome behind and fail the exit code, or a run that migrated
+            # nothing looks indistinguishable from a clean one.
+            blocked = isinstance(exc, TracePreflightError)
+            console.print(f"  [red]{'blocked' if blocked else 'failed'}: {exc}[/red]")
+            if isinstance(exc, RateLimitError):
+                console.print(
+                    "  [yellow]the source kept rate-limiting us; lower --prefetch-windows "
+                    "and re-run - captured windows are skipped[/yellow]"
+                )
+            failed_projects.append((label, str(exc)))
+            _record_trace_session_failure(
+                orchestrator, config, migrator, source_session,
+                "trace_session_blocked" if blocked else "trace_session_failed", exc,
+            )
+            continue
+        if report is None:
+            console.print("  [yellow]skipped: supply an explicit --project-mapping for this project[/yellow]")
+            failed_projects.append((label, "unresolved destination project"))
+            continue
+        for reason in migrator.blocked_reasons:
+            console.print(f"  [red]blocked:[/red] {reason}")
+        del migrator.blocked_reasons[:]
+        session_reports.append((source_session.get("name"), report))
+        _record_trace_session_outcome(orchestrator, config, migrator, source_session, report)
+        _print_trace_reconciliation(report, migrator.batch_limits()[0], verified=verified)
+
+
+# Only parameters that differ from these end up in a printed resume command, so
+# the line stays short enough to copy.
+_TRACE_DEFAULTS = {
+    "--window": 24.0, "--compress-level": DEFAULT_COMPRESS_LEVEL, "--prefetch-windows": 4,
+}
+
+
+def _print_archive_resume(archive, projects, *, captured: int, **params) -> None:
+    """Say exactly how to continue an interrupted export.
+
+    Rebuilt from an allow-list of parameters, never echoed from ``sys.argv``:
+    ``--api-key`` exists as a flag on this CLI, so the raw invocation can carry
+    a live credential into a terminal, a CI log, or a scrollback that outlives
+    the session. Credentials come from the environment on the resumed run, as
+    they did on the first.
+
+    The command is the *same* command - a window whose file is already on disk
+    is skipped - so there is no stamp to substitute and nothing to clean up.
+    """
+    parts = ["langsmith-migrator traces", f"--to-archive {shlex.quote(str(archive))}"]
+    parts += [f"--project {shlex.quote(str(name))}" for name in projects]
+    for flag, key in (
+        ("--window", "window_hours"), ("--since", "since"), ("--until", "until"),
+        ("--compress-level", "compress_level"), ("--prefetch-windows", "prefetch_windows"),
+        ("--source-workspace", "source_workspace"),
+    ):
+        value = params.get(key)
+        if value in (None, "", _TRACE_DEFAULTS.get(flag)):
+            continue
+        parts.append(f"{flag} {shlex.quote(str(value))}")
+    if captured:
+        console.print(f"\n[yellow]Interrupted after {captured} window file(s).[/yellow]")
+    else:
+        console.print("\n[yellow]Interrupted: 0 windows captured.[/yellow]")
+    console.print("To continue, re-run the same command - captured windows are skipped:")
+    console.print("  [bold]" + " \\\n    ".join(parts) + "[/bold]")
 
 
 def _select_trace_sessions(config: Config, migrator, projects, select_all: bool) -> list:
@@ -6541,6 +6750,24 @@ def _select_trace_sessions(config: Config, migrator, projects, select_all: bool)
     project on a busy deployment takes minutes, and naming one is the common
     case for a trace migration.
     """
+    if migrator.run_source is not migrator:
+        # An archive's project list is a directory listing, so name/ID selection
+        # is a filter over it rather than a lookup against a deployment.
+        available = migrator.run_source.sessions()
+        if not projects:
+            return _select_or_all(
+                config, available, select_all=select_all,
+                title="Select Archived Projects to Replay",
+                columns=[
+                    {"key": "name", "title": "Project", "width": 44},
+                    {"key": "id", "title": "ID", "width": 38},
+                ],
+            )
+        wanted = {str(v) for v in projects}
+        chosen = [s for s in available if str(s["id"]) in wanted or str(s.get("name")) in wanted]
+        for missing in wanted - {str(s["id"]) for s in chosen} - {str(s.get("name")) for s in chosen}:
+            console.print(f"[yellow]No archived project matched '{missing}'[/yellow]")
+        return chosen
     if projects:
         chosen = []
         for value in projects:
@@ -6568,9 +6795,9 @@ def _select_trace_sessions(config: Config, migrator, projects, select_all: bool)
     )
 
 
-def _human_duration(days: float) -> str:
-    """``0.01`` -> ``14m24s``. str(timedelta) would say ``0:14:24``."""
-    total = int(round(days * 86400))
+def _human_duration(hours: float) -> str:
+    """``0.24`` -> ``14m24s``. str(timedelta) would say ``0:14:24``."""
+    total = int(round(hours * 3600))
     if total <= 0:
         return "0s"
     d, rem = divmod(total, 86400)
@@ -6579,7 +6806,10 @@ def _human_duration(days: float) -> str:
     return "".join(f"{v}{u}" for v, u in ((d, "d"), (h, "h"), (m, "m"), (sec, "s")) if v)
 
 
-def _print_trace_preflight(migrator, config, window_days, max_field_bytes, no_verify, into_session_suffix):
+def _print_trace_preflight(
+    migrator, config, window_hours, max_field_bytes, no_verify, into_session_suffix,
+    *, to_archive=None, from_archive=None, projects=None,
+):
     """Report the destination's configuration before writing anything."""
     max_runs, max_bytes = migrator.batch_limits()
     table = Table(title="Destination pre-flight", show_header=True)
@@ -6591,9 +6821,9 @@ def _print_trace_preflight(migrator, config, window_days, max_field_bytes, no_ve
     table.add_row("Max field bytes", f"{max_field_bytes:,}", "--max-field-bytes (not advertised by the destination)")
     table.add_row(
         "Range / window",
-        f"{migrator.resolved_range_start().isoformat()} -> now\n"
-        f"window {window_days:g}d = {_human_duration(window_days)}",
-        ("--max-age-stamp" if migrator.range_start else "--max-age-days") + " / --window",
+        f"{migrator.resolved_range_start().isoformat()} ->\n{migrator.walk_end().isoformat()}\n"
+        f"window {window_hours:g}h = {_human_duration(window_hours)}",
+        "--since / --until / --window",
     )
     table.add_row("Trace tier", "longlived" if not migrator.emit_upgrade_list else "left as-is (--emit-upgrade-list)", "destination session")
     table.add_row(
@@ -6612,7 +6842,26 @@ def _print_trace_preflight(migrator, config, window_days, max_field_bytes, no_ve
         ),
         "--prefetch-windows (ingest stays serial and in order)",
     )
+    if to_archive:
+        table.add_row("Archive", str(to_archive), "--to-archive (no destination is written)")
+        table.add_row("Archive compression", f"zstd level {migrator.run_sink.compress_level}", "--compress-level")
+    if from_archive:
+        table.add_row("Replaying from", str(from_archive), "--from-archive (the source deployment is not read)")
     console.print(table)
+    if to_archive:
+        range_hours = (migrator.walk_end() - migrator.resolved_range_start()).total_seconds() / 3600
+        files = projected_file_count(range_hours, window_hours, projects or 1)
+        console.print(f"[dim]Projected window files: ~{files:,} ({_human_duration(window_hours)} each)[/dim]")
+        if files > 100_000:
+            suggested = range_hours * (projects or 1) / 100_000
+            console.print(
+                f"[yellow]That is a lot of files for one filesystem. --window {suggested:.3g} "
+                f"would keep it under 100,000. Continuing anyway.[/yellow]"
+            )
+        console.print(
+            "[yellow]An archive is plaintext trace data - inputs, outputs and attachments - with "
+            "no encryption at rest. Files are 0o600 and directories 0o700; nothing more.[/yellow]"
+        )
     if config.migration.dry_run:
         console.print("[yellow]Dry run: no session creation, no canary, no ingest[/yellow]")
     if no_verify:
@@ -6680,18 +6929,23 @@ def _print_trace_reconciliation(report, batch_runs: int, verified: bool = True) 
     _print_trace_watermark(report, batch_runs, verified)
 
 
-def _parse_age_stamp(value: str):
-    """Parse --max-age-stamp as an ISO date or datetime, naive read as UTC."""
+def _parse_stamp(value: str, flag: str):
+    """Parse a range bound as an ISO date or datetime; naive is read as UTC.
+
+    Only the lower bound is required to be in the past: an upper bound beyond
+    now simply selects everything written so far, and refusing it would make
+    "up to the present" unexpressible.
+    """
     import datetime as _dt
 
     try:
         stamp = _dt.datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
     except ValueError:
-        raise ValueError(f"--max-age-stamp is not an ISO date/datetime: {value!r}") from None
+        raise ValueError(f"{flag} is not an ISO date/datetime: {value!r}") from None
     if stamp.tzinfo is None:
         stamp = stamp.replace(tzinfo=_dt.timezone.utc)
-    if stamp >= _dt.datetime.now(_dt.timezone.utc):
-        raise ValueError(f"--max-age-stamp must be in the past, got {stamp.isoformat()}")
+    if flag == "--since" and stamp >= _dt.datetime.now(_dt.timezone.utc):
+        raise ValueError(f"{flag} must be in the past, got {stamp.isoformat()}")
     return stamp
 
 
@@ -6728,9 +6982,7 @@ def _print_trace_watermark(report, batch_runs: int, verified: bool = True) -> No
         f"({report.verified_runs} run(s))"
     )
     overlap = "the whole span" if fraction == 1.0 else f"~{batch_runs} run(s), one ingest batch"
-    # An absolute stamp, not a relative age: a float age would denote a
-    # different instant by the time a long run finishes.
-    console.print(f"  [dim]to continue from here: --max-age-stamp {resume.isoformat()} (redoing {overlap})[/dim]")
+    console.print(f"  [dim]to continue from here: --since {resume.isoformat()} (redoing {overlap})[/dim]")
 
 
 def _print_trace_summary(session_reports, fidelity_notes, no_verify, failed_projects=()) -> None:

--- a/langsmith_migrator/core/migrators/trace.py
+++ b/langsmith_migrator/core/migrators/trace.py
@@ -28,12 +28,12 @@ from __future__ import annotations
 
 import json
 import re
+import signal
 import threading
 import time
 import uuid
-from dataclasses import dataclass
-from dataclasses import field as _field
-from datetime import datetime, timezone
+from contextlib import contextmanager
+from datetime import datetime
 from collections import deque
 from concurrent.futures import Future, ThreadPoolExecutor
 from tempfile import SpooledTemporaryFile
@@ -50,22 +50,23 @@ from ..trace_frames import (
     compile_frame,
     unavailable_reason,
 )
+from ..trace_ports import RunSink, RunSource, SlicePrepared
 from ..trace_domain import (
     ATTACHMENT_PREFIX,
     LONGLIVED,
     RUN_QUERY_SELECT,
     S3_URL_PAYLOAD_FIELDS,
     Reconciliation,
-    SlicePlan,
     Window,
     batch_traces,
     digest_mismatches,
     group_into_traces,
     is_long_lived,
     iter_windows,
+    payload_bytes,
     payload_digest,
     plan_slice,
-    resolve_range_start,
+    as_utc,
     resolve_window_bounds,
     to_ingest_payload,
     verified_bounds,
@@ -86,6 +87,13 @@ _ID_CHUNK_MIN = 25
 # at or under the limit so a request never depends on that leniency.
 _PAGE_LIMIT = 1000
 _PAGE_CAP_RE = re.compile(r"maximum allowed value of (\d+)")
+_READ_TIMEOUT_RE = re.compile("read timed out", re.IGNORECASE)
+
+# Payload fetches ask for hundreds of heavy runs at once - one chunk of a heavy
+# project measured 355 MB - which the client's 30 s default cannot serve. Long
+# enough for a legitimately large response, short enough that the chunk halving
+# still reacts within a few minutes rather than a quarter of an hour.
+_QUERY_TIMEOUT = 120
 
 # Not advertised by /info (only the batch limits are), so it matches the
 # backend's own MAX_ATTACHMENT_SIZE_BYTES default and is a guard, not a truth.
@@ -128,9 +136,18 @@ def _response_too_large(error: Exception) -> bool:
     response body rather than saying so, and it does it fast - there is nothing
     to distinguish it from a genuine outage except that retrying at the same
     size keeps failing, which the retry layer has already established.
+
+    A read timeout is the same problem stated differently: the server took the
+    request and never finished the body. ``requests`` reports it as ``Timeout``
+    or, when the stall strikes while the body is being consumed, as a
+    ``ConnectionError`` wrapping urllib3's own read timeout - so the class alone
+    is not a reliable discriminator and the message has to be read too.
     """
-    status = getattr(error, "status_code", None)
-    return status in (413, 502, 503)
+    if getattr(error, "status_code", None) in (413, 502, 503):
+        return True
+    return isinstance(error, requests.exceptions.Timeout) or bool(
+        _READ_TIMEOUT_RE.search(str(error))
+    )
 
 
 def _page_limit_cap(error: Exception) -> Optional[int]:
@@ -155,31 +172,6 @@ def _raise_if_tier_denied(error: Exception) -> None:
 
 
 
-@dataclass
-class SlicePrepared:
-    """One slice's work, built off the main thread and committed on it.
-
-    Findings accumulate here rather than on the migrator so a worker never
-    writes shared state; ``commit_slice`` merges them in window order.
-    """
-
-    window: Window
-    src_id: str
-    dst_id: str
-    plan: SlicePlan
-    population: List[Dict[str, Any]]
-    # (payloads, pre-compiled frame). The payloads are kept so a rejected batch
-    # can still be split to isolate one bad run; that is what bounds peak
-    # memory to prefetch x window, and why --window is the knob for it.
-    batches: List[Tuple[List[Dict[str, Any]], Optional[CompiledFrame]]] = _field(default_factory=list)
-    digests: Dict[str, Dict[str, str]] = _field(default_factory=dict)
-    degraded: Dict[str, Set[str]] = _field(default_factory=dict)
-    fidelity_notes: Set[str] = _field(default_factory=set)
-    upgrade_rows: List[Tuple[str, str, str]] = _field(default_factory=list)
-    # (issue_class, code, summary, evidence), replayed through record_issue.
-    issues: List[Tuple[str, str, str, Dict[str, Any]]] = _field(default_factory=list)
-
-
 class TracePreflightError(RuntimeError):
     """A destination precondition failed; nothing may be migrated."""
 
@@ -194,9 +186,9 @@ class TraceMigrator(BaseMigrator):
         state,
         config,
         *,
-        max_age_days: Optional[float] = 180.0,
-        range_start: Optional[datetime] = None,
-        window_days: float = 1.0,
+        range_start: datetime,
+        range_end: datetime,
+        window_hours: float = 24.0,
         max_field_bytes: int = 25 * 1024 * 1024,
         verify: bool = True,
         verify_content_sample: int = 100,
@@ -207,17 +199,22 @@ class TraceMigrator(BaseMigrator):
         project_id_map: Optional[Dict[str, str]] = None,
         compress_level: Optional[int] = DEFAULT_COMPRESS_LEVEL,
         prefetch_windows: int = 4,
+        run_sink: Optional[RunSink] = None,
+        run_source: Optional[RunSource] = None,
     ):
         super().__init__(source_client, dest_client, state, config)
-        self.max_age_days = max_age_days
-        self.range_start = range_start
-        # Resolved exactly once. Recomputing "now - max_age_days" per call gave
-        # a slightly different instant each time, which is the same drift an
-        # absolute --max-age-stamp exists to avoid.
-        self._resolved_start = resolve_range_start(
-            datetime.now(timezone.utc), max_age_days, range_start
-        )
-        self.window_days = window_days
+        # This class *is* the LangSmith source and sink; an archive supplies the
+        # file ones. Both halves are swappable independently, which is what lets
+        # an export need no destination and a replay need no source deployment.
+        self.run_sink: RunSink = run_sink or self
+        self.run_source: RunSource = run_source or self
+        # Both bounds absolute, so nothing here reads a clock: two runs of the
+        # same command walk exactly the same windows.
+        self._resolved_start = as_utc(range_start)
+        self._resolved_end = as_utc(range_end)
+        if self._resolved_start >= self._resolved_end:
+            raise ValueError("the range start must precede its end")
+        self.window_hours = window_hours
         self.max_field_bytes = max_field_bytes
         self.verify = verify
         self.verify_content_sample = verify_content_sample
@@ -241,6 +238,16 @@ class TraceMigrator(BaseMigrator):
         self._page_limit = {"source": _PAGE_LIMIT, "dest": _PAGE_LIMIT}
         # Shrinks itself when a project's payloads make the response too big.
         self._id_chunk = _ID_CHUNK
+        # Set before any worker starts. The default 30 s is a payload fetch's
+        # normal case here, not its worst.
+        for client in (source_client, dest_client):
+            if getattr(client, "timeout", 0) and client.timeout < _QUERY_TIMEOUT:
+                client.timeout = _QUERY_TIMEOUT
+        # Set by graceful_stop's first signal; stops scheduling, drains the rest.
+        self.stop_requested = False
+        self.skipped_windows = 0
+        # dest_session_id -> (its tier before we touched it, the source's tier).
+        self._prior_tier: Dict[str, Tuple[Optional[str], Optional[str]]] = {}
 
         # None = send uncompressed through the SDK's public path. Resolved
         # once, after the client exists, so a missing SDK internal or a
@@ -262,6 +269,13 @@ class TraceMigrator(BaseMigrator):
         # destination host, not the source's.
         self._source_blob_host = urlparse(self._host(config.source.base_url)).netloc
         self._dest_blob_host = urlparse(self._host(config.destination.base_url)).netloc
+
+        if self.run_sink is not self:
+            self.dest_ls_client = None
+            self._ingest_errors: List[Exception] = []
+            self._ingest_responses: List[Tuple[int, str]] = []
+            self.compress_level = None
+            return
 
         self._dest_session_http = requests.Session()
         if not config.destination.verify_ssl:
@@ -302,6 +316,64 @@ class TraceMigrator(BaseMigrator):
         """Absolute lower bound of this run's walk, fixed for the whole run."""
         return self._resolved_start
 
+    def walk_end(self) -> datetime:
+        """Absolute upper bound of this run's walk."""
+        return self._resolved_end
+
+    # ------------------------------------------------------------------
+    # RunSource / RunSink for the LangSmith side
+    # ------------------------------------------------------------------
+    def sessions(self) -> List[Dict[str, Any]]:
+        return self.list_source_sessions()
+
+    def windows(self, session: Dict[str, Any]) -> Iterator[Window]:
+        return iter_windows(self.resolved_range_start(), self.walk_end(), self.window_hours)
+
+    def open_target(self, session: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Resolve the destination project and make sure its tier is right.
+
+        The prior tier is remembered here rather than by the caller, so
+        ``close_target`` can put it back without the driver knowing a tier
+        exists at all.
+        """
+        target = self.resolve_dest_session(session)
+        if not target:
+            return None
+        self._prior_tier[str(target["id"])] = (target.get("trace_tier"), session.get("trace_tier"))
+        self.ensure_long_lived(target)
+        return target
+
+    def has_window(self, target: Dict[str, Any], window: Window) -> bool:
+        """Always false: a project has no window-level record, and can always
+        gain runs - from a concurrent dual-write, or another operator."""
+        return False
+
+    def existing_ids(self, target: Dict[str, Any], window: Window) -> Set[str]:
+        # With --emit-upgrade-list the destination sessions stay at their
+        # existing tier, so filtering on tier there would read every migrated
+        # run as missing.
+        if self.config.migration.dry_run:
+            return set()
+        return self.long_lived_run_ids(
+            self.dest, str(target["id"]), window, tier_filter=not self.emit_upgrade_list
+        )
+
+    def stage(self, target: Dict[str, Any], window: Window, prepared: SlicePrepared) -> None:
+        """Nothing to stage: the frames were compiled during ``prepare``."""
+        return None
+
+    def commit(
+        self, target: Dict[str, Any], window: Window, prepared: SlicePrepared, staged: Any
+    ) -> List[Tuple[str, str]]:
+        failures: List[Tuple[str, str]] = []
+        for batch, frame in prepared.batches:
+            failures.extend(self.ingest(batch, frame=frame))
+        return failures
+
+    def close_target(self, target: Dict[str, Any], recon: Optional[Reconciliation] = None) -> None:
+        prior, source_tier = self._prior_tier.pop(str(target["id"]), (None, None))
+        self._settle_tier(target, prior, source_tier, recon)
+
     # ------------------------------------------------------------------
     # Plumbing
     # ------------------------------------------------------------------
@@ -317,12 +389,7 @@ class TraceMigrator(BaseMigrator):
     def _shape(runs: Sequence[Dict[str, Any]]) -> Tuple[int, int, int]:
         """``(runs, distinct traces, serialized bytes)`` for a page or a batch."""
         traces = {str(r.get("trace_id")) for r in runs}
-        size = sum(
-            len(json.dumps({k: v for k, v in r.items() if k != "attachments"}, default=str))
-            + sum(len(data) for _, data in (r.get("attachments") or {}).values())
-            for r in runs
-        )
-        return len(runs), len(traces), size
+        return len(runs), len(traces), sum(payload_bytes(r) for r in runs)
 
     @staticmethod
     def _host(base_url: str) -> str:
@@ -380,12 +447,18 @@ class TraceMigrator(BaseMigrator):
             seen += len(runs)
             if self.config.migration.verbose and runs:
                 n, traces, size = self._shape(runs)
-                # Kept under 80 columns: a wrapped progress line is worse
-                # than a terse one.
+                # Named per phase, because only the identity scan paginates: a
+                # fetch is one request per ID chunk, so a page number would
+                # restart at p1 on every one of them and a running total could
+                # only ever restate ``runs``. The scan's column is kept blank
+                # there so the two line shapes still align. Under 80 columns: a
+                # wrapped progress line is worse than a terse one.
+                scan = ids is None
                 self.console.print(
-                    f"[dim]  query {side:<6} p{page_num:<4}"
-                    f"runs {n:>4} | traces {traces:>4} | {self._human(size):>9} | "
-                    f"total {seen:>6}[/dim]"
+                    f"[dim]  {'scan' if scan else 'fetch':<5} {side:<6} "
+                    f"{f'p{page_num}' if scan else '':<4}"
+                    f"runs {n:>4} | traces {traces:>4} | {self._human(size):>9}"
+                    f"{f' | total {seen:>6}' if scan else ''}[/dim]"
                 )
             yield from runs
             cursor = (response.get("cursors") or {}).get("next")
@@ -433,16 +506,19 @@ class TraceMigrator(BaseMigrator):
                         client, session_id, window, select=RUN_QUERY_SELECT, ids=ids[start : start + chunk]
                     )
                 )
-            except APIError as exc:
+            except (APIError, requests.exceptions.RequestException) as exc:
                 if not _response_too_large(exc) or chunk <= _ID_CHUNK_MIN:
                     raise
                 # Retries at this size are already exhausted, so the size is
                 # the problem. Halve it and keep it for the rest of the run.
                 self._id_chunk = max(_ID_CHUNK_MIN, chunk // 2)
-                self.log(
-                    f"  {chunk} IDs per request was refused ({exc.status_code}); "
-                    f"continuing at {self._id_chunk}",
-                    "warning",
+                # Printed unconditionally: it changes request sizes for the rest
+                # of the run and is the explanation for a slow one. Each halving
+                # is a distinct size, so this cannot repeat itself.
+                self.console.print(
+                    f"[yellow]  {chunk} IDs per request was refused "
+                    f"({getattr(exc, 'status_code', None) or type(exc).__name__}); "
+                    f"continuing at {self._id_chunk}[/yellow]"
                 )
                 continue
             yield from page
@@ -532,10 +608,6 @@ class TraceMigrator(BaseMigrator):
     # ------------------------------------------------------------------
     # Write path
     # ------------------------------------------------------------------
-    @classmethod
-    def _size_of(cls, payload: Dict[str, Any]) -> int:
-        return cls._shape([payload])[2]
-
     def _oversized_fields(self, payload: Dict[str, Any]) -> List[str]:
         """Fields the destination would silently replace with a placeholder.
 
@@ -762,17 +834,25 @@ class TraceMigrator(BaseMigrator):
         if self.config.migration.dry_run:
             return {"id": f"dry-run-{source_id}", "name": target_name, "trace_tier": LONGLIVED}
 
-        # Explicit tier, never omitted: a nil tier resolves to the destination
-        # tenant's default, and the tier cannot be repaired after ingest.
+        # Unset fields are omitted rather than sent as null: an archive knows a
+        # project's name and ID and nothing else, and the endpoint answers 422 to
+        # "start_time": null. The tier is always sent - a nil tier resolves to
+        # the destination tenant's default, which cannot be repaired after ingest.
         payload = {
-            "name": target_name,
-            "description": source_session.get("description"),
-            "metadata": source_session.get("metadata"),
-            "extra": source_session.get("extra"),
-            "start_time": source_session.get("start_time"),
-            "end_time": source_session.get("end_time"),
-            "trace_tier": source_session.get("trace_tier") if self.emit_upgrade_list else LONGLIVED,
+            key: value
+            for key, value in (
+                ("name", target_name),
+                ("description", source_session.get("description")),
+                ("metadata", source_session.get("metadata")),
+                ("extra", source_session.get("extra")),
+                ("start_time", source_session.get("start_time")),
+                ("end_time", source_session.get("end_time")),
+            )
+            if value is not None
         }
+        payload["trace_tier"] = (
+            source_session.get("trace_tier") if self.emit_upgrade_list else LONGLIVED
+        )
         # Reusing the source ID is convenient, not load-bearing: a rejection
         # just means the session gets mapped instead.
         with_id = payload if self.into_session_suffix else {**payload, "id": source_id}
@@ -913,21 +993,32 @@ class TraceMigrator(BaseMigrator):
         writes converge on the same value and a lost update just means one more
         rejection before it sticks.
         """
-        src_id, dst_id = str(source_session["id"]), str(dest_session["id"])
+        return self.run_source.prepare(
+            source_session,
+            dest_session,
+            window,
+            lambda: self.run_sink.existing_ids(dest_session, window),
+        )
+
+    def prepare(
+        self,
+        source_session: Dict[str, Any],
+        target: Dict[str, Any],
+        window: Window,
+        existing_ids,
+    ) -> SlicePrepared:
+        """``RunSource.prepare`` for the LangSmith side.
+
+        The diff is taken *before* anything is fetched, so a re-run of a
+        finished window costs the identity scan and nothing else. For an export
+        the oracle answers empty, which is what an archive is for.
+        """
+        src_id, dst_id = str(source_session["id"]), str(target["id"])
         population = self.slice_runs(self.source, src_id, window)
         if not population:
             return SlicePrepared(window, src_id, dst_id, plan_slice(set(), set()), [])
         source_ids = {str(r["id"]) for r in population}
-
-        # With --emit-upgrade-list the destination sessions stay at their
-        # existing tier, so filtering on tier there would read every migrated
-        # run as missing.
-        dest_ids = (
-            set()
-            if self.config.migration.dry_run
-            else self.long_lived_run_ids(self.dest, dst_id, window, tier_filter=not self.emit_upgrade_list)
-        )
-        prepared = SlicePrepared(window, src_id, dst_id, plan_slice(source_ids, dest_ids), population)
+        prepared = SlicePrepared(window, src_id, dst_id, plan_slice(source_ids, existing_ids()), population)
 
         if self.emit_upgrade_list:
             # Derived from the window's source population, not the diff: built
@@ -959,10 +1050,12 @@ class TraceMigrator(BaseMigrator):
         if not prepared.plan.to_ingest:
             return
         payloads: List[Dict[str, Any]] = []
+        fetched: Set[str] = set()
         for run in self.fetch_runs(
             self.source, prepared.src_id, prepared.window, sorted(prepared.plan.to_ingest)
         ):
             run_id = str(run["id"])
+            fetched.add(run_id)
             overrides, issues = self.materialise(run)
             payload_obj, dropped = to_ingest_payload(run, prepared.dst_id, overrides)
             payload = payload_obj.as_dict()
@@ -988,16 +1081,31 @@ class TraceMigrator(BaseMigrator):
                 prepared.digests[run_id] = self._digest_of(run, overrides)
             payloads.append(payload)
 
-        max_runs, max_bytes = self.batch_limits()
+        # The identity scan listed these; the payload fetch did not return them.
+        # On the migrate path the confirming re-query would eventually notice; an
+        # export has no destination to confirm against, so a run silently absent
+        # from the archive would still be reported as captured.
+        absent = prepared.plan.to_ingest - fetched
+        if absent:
+            prepared.degraded.setdefault("run_not_returned_by_source", set()).update(absent)
+            prepared.fidelity_notes.add("the source did not return every run it listed")
+
+        max_runs, max_bytes = self.run_sink.batch_limits()
         for batch in batch_traces(
-            group_into_traces(payloads), max_runs=max_runs, max_bytes=max_bytes, size_of=self._size_of
+            group_into_traces(payloads), max_runs=max_runs, max_bytes=max_bytes, size_of=payload_bytes
         ):
-            frame = (
-                None
-                if self.compress_level is None or self.config.migration.dry_run
-                else compile_frame(self.dest_ls_client, batch, self.compress_level)
-            )
-            prepared.batches.append((batch, frame))
+            prepared.batches.append((batch, self.compile_batch(batch)))
+
+    def compile_batch(self, batch: List[Dict[str, Any]]) -> Optional[CompiledFrame]:
+        """The compressed ingest body for one batch, or None when unused.
+
+        Called from a prefetch worker on both paths - the API source builds its
+        own batches, the archive source re-batches a replayed window - which is
+        the whole point of compiling here rather than on the serial send.
+        """
+        if self.compress_level is None or self.config.migration.dry_run:
+            return None
+        return compile_frame(self.dest_ls_client, batch, self.compress_level)
 
     def commit_slice(self, prepared: SlicePrepared) -> Reconciliation:
         """Write one prepared slice, confirm it, and account for it.
@@ -1007,6 +1115,11 @@ class TraceMigrator(BaseMigrator):
         """
         src_id, dst_id, window, plan = prepared.src_id, prepared.dst_id, prepared.window, prepared.plan
         if not prepared.population:
+            # Still committed: for an archive an empty window is a *file*, and
+            # "we looked here and found nothing" is a different fact from "we
+            # never looked". Only a file can carry the difference, and without
+            # it the sorted-files-are-contiguous coverage proof is false.
+            self.run_sink.commit(prepared.target or {"id": dst_id}, window, prepared, prepared.staged)
             return Reconciliation(src_id, dst_id, window.label(), 0, 0, 0, 0, 0)
 
         self.upgrade_rows.extend(prepared.upgrade_rows)
@@ -1017,10 +1130,11 @@ class TraceMigrator(BaseMigrator):
         degraded = prepared.degraded
         blocked: Set[str] = set()
         rejected: Dict[str, Set[str]] = {}
-        for batch, frame in prepared.batches:
-            for run_id, error in self.ingest(batch, frame=frame):
-                blocked.add(run_id)
-                rejected.setdefault(str(error), set()).add(run_id)
+        for run_id, error in self.run_sink.commit(
+            prepared.target or {"id": dst_id}, window, prepared, prepared.staged
+        ):
+            blocked.add(run_id)
+            rejected.setdefault(str(error), set()).add(run_id)
         # Grouped by cause: twenty runs refused for one reason is one fact, not
         # twenty truncated lines.
         for error, ids in rejected.items():
@@ -1068,9 +1182,10 @@ class TraceMigrator(BaseMigrator):
 
     def migrate_slice(
         self, source_session: Dict[str, Any], dest_session: Dict[str, Any], window: Window
-    ) -> Reconciliation:
-        """Prepare and commit one slice, without look-ahead."""
-        return self.commit_slice(self.prepare_slice(source_session, dest_session, window))
+    ) -> Optional[Reconciliation]:
+        """Prepare and commit one slice, without look-ahead. None when skipped."""
+        prepared = self._prepare_and_stage(source_session, dest_session, window)
+        return None if prepared is None else self.commit_slice(prepared)
 
     @staticmethod
     def _digest_of(run: Dict[str, Any], overrides: Dict[str, Any]) -> Dict[str, str]:
@@ -1183,42 +1298,43 @@ class TraceMigrator(BaseMigrator):
     # ------------------------------------------------------------------
     # Per-session driver
     # ------------------------------------------------------------------
-    def migrate_session(self, source_session: Dict[str, Any], now: Optional[datetime] = None) -> Optional[Reconciliation]:
+    def migrate_session(self, source_session: Dict[str, Any]) -> Optional[Reconciliation]:
         """Raise tier -> migrate windows oldest-first -> verify -> restore.
 
-        The tier is settled in a ``finally``: once an existing project has been
-        raised, walking away without deciding what to do about it would leave a
-        project long-lived indefinitely on any mid-run failure, silently
-        changing retention for traffic that has nothing to do with this
-        migration.
+        ``close_target`` is called in a ``finally``: once an existing project
+        has been raised, walking away without deciding what to do about it
+        would leave a project long-lived indefinitely on any mid-run failure,
+        silently changing retention for traffic unrelated to this migration.
         """
-        dest_session = self.resolve_dest_session(source_session)
-        if not dest_session:
+        target = self.run_sink.open_target(source_session)
+        if not target:
             return None
-        prior_tier = dest_session.get("trace_tier")
-        self.ensure_long_lived(dest_session)
 
         recon = None
+        project = source_session.get("name") or str(source_session["id"])
         try:
             slices = []
-            end = now or datetime.now(timezone.utc)
-            windows = iter_windows(self.resolved_range_start(), end, self.window_days)
-            for sliced in self._walk_windows(source_session, dest_session, windows):
+            windows = self.run_source.windows(source_session)
+            for sliced in self._walk_windows(source_session, target, windows):
                 slices.append(sliced)
                 if sliced.source_total:
                     # Per-slice detail is verbose-only: the range can be 180
                     # windows wide, and the per-session total is always printed.
+                    # Named per line, not just under the project header: in
+                    # verbose mode the query and ingest lines of a single window
+                    # push that header off the screen.
                     self.log(
-                        f"  {sliced.window}: source {sliced.source_total} = ingested {sliced.ingested}"
+                        f"  {project} {sliced.window}:"
+                        f" source {sliced.source_total} = ingested {sliced.ingested}"
                         f" + already present {sliced.already_present}"
                         f" + degraded {sliced.degraded} + blocked {sliced.blocked}"
                         + (f" | verified {sliced.earliest} .. {sliced.latest}" if sliced.earliest else ""),
                         "info",
                     )
-            recon = Reconciliation.of(str(source_session["id"]), str(dest_session["id"]), slices)
+            recon = Reconciliation.of(str(source_session["id"]), str(target["id"]), slices)
             return recon
         finally:
-            self._settle_tier(dest_session, prior_tier, source_session.get("trace_tier"), recon)
+            self.run_sink.close_target(target, recon)
 
     def _walk_windows(
         self, source_session: Dict[str, Any], dest_session: Dict[str, Any], windows
@@ -1237,7 +1353,11 @@ class TraceMigrator(BaseMigrator):
         """
         if self.prefetch_windows <= 1:
             for window in windows:
-                yield self.migrate_slice(source_session, dest_session, window)
+                if self.stop_requested:
+                    return
+                recon = self.migrate_slice(source_session, dest_session, window)
+                if recon is not None:
+                    yield recon
             return
 
         pending: Deque[Future] = deque()
@@ -1247,9 +1367,11 @@ class TraceMigrator(BaseMigrator):
             def submit_next() -> None:
                 # Main thread only: ``windows`` is a generator, and advancing
                 # one from several threads is not safe.
-                window = next(windows, None)
+                window = None if self.stop_requested else next(windows, None)
                 if window is not None:
-                    pending.append(pool.submit(self.prepare_slice, source_session, dest_session, window))
+                    pending.append(
+                        pool.submit(self._prepare_and_stage, source_session, dest_session, window)
+                    )
 
             for _ in range(self.prefetch_windows):
                 submit_next()
@@ -1260,7 +1382,56 @@ class TraceMigrator(BaseMigrator):
                 # Peak residency is therefore prefetch_windows in flight plus
                 # the one being written.
                 submit_next()
-                yield self.commit_slice(prepared)
+                if prepared is not None:
+                    yield self.commit_slice(prepared)
+
+    def _prepare_and_stage(
+        self, source_session: Dict[str, Any], target: Dict[str, Any], window: Window
+    ) -> Optional[SlicePrepared]:
+        """One window's worker-side work: skip, read, stage. Never the publish.
+
+        Staging here rather than in ``commit_slice`` is what keeps the archive's
+        tar+zstd encode off the serial path - a heavy window is ~18 s of
+        compression, which across thousands of windows would add hours.
+        """
+        if self.run_sink.has_window(target, window):
+            self.skipped_windows += 1
+            return None
+        prepared = self.prepare_slice(source_session, target, window)
+        prepared.target = target
+        prepared.staged = self.run_sink.stage(target, window, prepared)
+        return prepared
+
+    @contextmanager
+    def graceful_stop(self):
+        """Make the first Ctrl-C lose nothing, and the second abandon at once.
+
+        The first signal stops scheduling new windows; the walk then drains what
+        is already in flight and commits it in order, so the loss is zero rather
+        than one window. The handler is restored as it fires, so a second Ctrl-C
+        raises ``KeyboardInterrupt`` the way it normally would.
+        """
+        previous: Dict[int, Any] = {}
+
+        def handle(signum, frame):  # pragma: no cover - signal delivery
+            for sig, old in previous.items():
+                signal.signal(sig, old)
+            self.stop_requested = True
+            self.console.print(
+                "\n[yellow]Stop requested: finishing the windows already in flight. "
+                "Ctrl-C again to abandon them.[/yellow]"
+            )
+
+        try:
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                previous[sig] = signal.signal(sig, handle)
+        except ValueError:  # not the main thread; nothing to install
+            previous.clear()
+        try:
+            yield
+        finally:
+            for sig, old in previous.items():
+                signal.signal(sig, old)
 
     def _settle_tier(
         self,

--- a/langsmith_migrator/core/trace_archive.py
+++ b/langsmith_migrator/core/trace_archive.py
@@ -1,0 +1,590 @@
+"""Long-lived traces on disk: one solid ``.tar.zst`` per ``(project, window)``.
+
+Why payloads and not compiled ingest frames: the ``session_id`` lives inside a
+compiled multipart body once per run, so remapping the destination project would
+mean decompress -> parse multipart -> patch -> re-encode. Payloads make it one
+field assignment, and keep the archive readable without the SDK internals the
+ingest path borrows. Re-compiling on replay costs ~1500 MB/s against a network
+three orders of magnitude slower.
+
+Why one solid stream and not per-record compression: measured on real trace
+bodies, compressing per run costs **17.4x more bytes** than compressing the
+whole file at once (4.0x against 69.7x). That single number rules out any
+container that compresses row-by-row, and is why tar members - which are pure
+framing, uncompressed by themselves - are the record format.
+
+Completeness is a file-level property, twice over: a window is written as
+``.partial`` and renamed only after its ``MANIFEST.json`` is appended as the
+final member. So ``ls`` answers "is this window done" without decompressing, and
+the manifest answers it again for anything that reads the file.
+
+An archive is **plaintext production trace data**. Files are 0o600 and
+directories 0o700; there is no encryption at rest, and the CLI says so.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import math
+import os
+import re
+import shutil
+import tarfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple
+
+import zstandard as zstd
+
+from .trace_domain import (
+    Window,
+    batch_traces,
+    group_into_traces,
+    payload_bytes,
+    plan_slice,
+)
+
+# 2: intent.window_days became intent.window_hours.
+# 3: window files gained a source-workspace directory above the project one.
+FORMAT_VERSION = 3
+
+# The archive compresses a whole window file rather than a ~20 MB ingest frame,
+# so it can afford a larger match window than the ingest path's 24. Measured
+# 69.7x -> 70.8x on a 45 MB sample and flat beyond; a multi-GB window has more
+# cross-run redundancy to reach for, so re-measure before treating 25 as final.
+WINDOW_LOG = 25
+
+# A window is held whole in memory on both sides, so this is simultaneously the
+# memory ceiling and the decompression-bomb guard. A window larger than this
+# cannot be replayed in one piece anyway - shrink --window instead.
+MAX_WINDOW_BYTES = 8 * 1024**3
+
+# Refuse to start a window with less than this free. A floor, not a quota: it
+# stops "disk filled at hour six" from truncating a file, nothing more.
+FREE_SPACE_FLOOR = 1024**3
+
+_MANIFEST = "MANIFEST.json"
+_PROJECT = "PROJECT.json"
+_STAMP = "%Y%m%dT%H%M%SZ"
+_PARTIAL = ".partial"
+_SUFFIX = ".tar.zst"
+
+# Tar member names are untrusted: an archive is a file some other process wrote.
+# Nothing derived from one ever reaches the filesystem - members are read into
+# memory via extractfile() - and these are what a name must match to be read at
+# all. Attachment members are numbered rather than named so that an attachment
+# called "../x" cannot exist in the first place.
+_RUN_JSON = re.compile(r"^([0-9a-fA-F-]{36})\.json$")
+_RUN_BLOB = re.compile(r"^([0-9a-fA-F-]{36})/(\d{1,4})$")
+
+_WINDOW_FILE = re.compile(r"^(\d{8}T\d{6}Z)__(\d{8}T\d{6}Z)$")
+
+
+class ArchiveError(RuntimeError):
+    """An archive could not be written, or could not be trusted to be read."""
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _stamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime(_STAMP)
+
+
+def window_label(window: Window) -> str:
+    """``20260801T000000Z__20260802T000000Z``.
+
+    Both bounds, because sorting by the first gives the contiguity proof and
+    the second lets ``end_k == start_k+1`` be checked straight off a directory
+    listing - no manifest, no ``--window`` to remember.
+    """
+    return f"{_stamp(window.start)}__{_stamp(window.end)}"
+
+
+def parse_window_label(label: str) -> Optional[Window]:
+    match = _WINDOW_FILE.match(label)
+    if not match:
+        return None
+    try:
+        bounds = [
+            datetime.strptime(part, _STAMP).replace(tzinfo=timezone.utc)
+            for part in match.groups()
+        ]
+    except ValueError:
+        return None
+    return Window(bounds[0], bounds[1]) if bounds[0] < bounds[1] else None
+
+
+def _slug(value: str, limit: int, fallback: str = "project") -> str:
+    """A single path component that cannot traverse, whatever went in."""
+    cleaned = re.sub(r"[^A-Za-z0-9._-]", "_", value or "")[:limit].strip("._-")
+    return cleaned or fallback
+
+
+def project_dir_name(session: Dict[str, Any]) -> str:
+    """``<slug>-<session id>``. The ID keeps it unique when slugs collide."""
+    return f"{_slug(str(session.get('name') or ''), 80)}-{_slug(str(session.get('id')), 40)}"
+
+
+def workspace_dir_name(workspace: Optional[Dict[str, Any]]) -> str:
+    """``<slug>-<workspace id>``, the same shape as the project level below it.
+
+    The name because an archive is read by people and a bare UUID tells them
+    nothing; the ID because two workspaces can share a display name and must not
+    then share a directory. The ID is in every manifest as well, so the pairing
+    is recoverable from the data and not only from the path.
+    """
+    ws = workspace or {}
+    name = _slug(str(ws.get("name") or ""), 80, "workspace")
+    return f"{name}-{_slug(str(ws['id']), 40, 'id')}" if ws.get("id") else name
+
+
+def _mkdir(path: Path) -> None:
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+
+def _open_private(path: Path):
+    return os.fdopen(os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600), "wb")
+
+
+def _contained(root: Path, child: Path) -> Path:
+    """Reject any path that resolves outside the archive directory."""
+    resolved, base = child.resolve(), root.resolve()
+    if resolved != base and base not in resolved.parents:
+        raise ArchiveError(f"refusing a path outside the archive directory: {child}")
+    return resolved
+
+
+# ----------------------------------------------------------------------
+# Writing
+# ----------------------------------------------------------------------
+def _tar_bytes(tar: tarfile.TarFile, name: str, data: bytes) -> int:
+    info = tarfile.TarInfo(name)
+    info.size = len(data)
+    info.mode = 0o600
+    tar.addfile(info, io.BytesIO(data))
+    return len(data)
+
+
+def _encode_payload(payload: Dict[str, Any]) -> Tuple[bytes, List[bytes]]:
+    """Split one payload into its JSON member and its attachment members.
+
+    Attachment names are arbitrary source strings, so they stay *inside* the
+    JSON - as an ordered ``[[name, content_type], ...]`` list - and the blob
+    members are numbered by position. A name is therefore never a path
+    component, on write or on read.
+    """
+    attachments = payload.get("attachments") or {}
+    ordered = sorted(attachments.items())
+    body = {k: v for k, v in payload.items() if k != "attachments"}
+    if ordered:
+        body["attachments"] = [[name, content_type] for name, (content_type, _) in ordered]
+    return (
+        json.dumps(body, default=str, separators=(",", ":")).encode(),
+        [data for _, (_, data) in ordered],
+    )
+
+
+class ArchiveSink:
+    """``RunSink`` writing one ``.tar.zst`` per window. Makes no destination claim.
+
+    A complete window file asserts that the source's window was read and
+    written - which is what ``has_window`` reports, and what makes a re-run skip
+    it. It asserts nothing about any deployment: verification belongs to replay,
+    where a real destination can answer.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        compress_level: int,
+        dry_run: bool = False,
+        workspace: Optional[Dict[str, Any]] = None,
+    ):
+        self.root = Path(root)
+        # {"id", "name"} of the *source* workspace, or None when the deployment
+        # has no workspace concept to report.
+        self.workspace = workspace
+        self.compress_level = compress_level
+        # A dry run scans and fetches exactly as a real one does, but must not
+        # leave files behind - otherwise the preview *is* the export.
+        self.dry_run = dry_run
+        # Filled by the caller once project selection resolves: the *intended*
+        # extent of this export, so the full expected window list is
+        # reconstructible from any single file and a short archive cannot pass
+        # for a complete small one.
+        self.intent: Dict[str, Any] = {}
+        self.written: List[Path] = []
+        self.staged: List[Path] = []
+
+    # -- RunSink ----------------------------------------------------------
+    def open_target(self, session: Dict[str, Any]) -> Dict[str, Any]:
+        directory = _contained(
+            self.root, self.root / workspace_dir_name(self.workspace) / project_dir_name(session)
+        )
+        record = {"id": str(session["id"]), "name": session.get("name"), "dir": str(directory)}
+        if self.dry_run:
+            return record
+        _mkdir(directory)
+        marker = directory / _PROJECT
+        if not marker.exists():
+            with _open_private(marker) as handle:
+                handle.write(json.dumps({k: record[k] for k in ("id", "name")}, indent=1).encode())
+        return record
+
+    def batch_limits(self) -> Tuple[int, int]:
+        """No destination caps apply; the replay side re-batches to its own."""
+        return 10**9, MAX_WINDOW_BYTES
+
+    def has_window(self, target: Dict[str, Any], window: Window) -> bool:
+        return self._final(target, window).exists()
+
+    def existing_ids(self, target: Dict[str, Any], window: Window) -> Set[str]:
+        """Always empty: a window file holds all of a window or none of it."""
+        return set()
+
+    def stage(self, target: Dict[str, Any], window: Window, prepared) -> Optional[Path]:
+        """Worker thread: write the whole file, manifest last, leave it ``.partial``.
+
+        The encode runs here rather than on the commit path deliberately - a
+        heavy window is tens of GB and ~18 s of compression, which on the serial
+        path would add hours to a multi-thousand-window export.
+        """
+        if self.dry_run:
+            return None
+        partial = Path(str(self._final(target, window)) + _PARTIAL)
+        free = shutil.disk_usage(partial.parent).free
+        if free < FREE_SPACE_FLOOR:
+            raise ArchiveError(
+                f"only {free:,} bytes free under {partial.parent}; refusing to start a window"
+            )
+        payloads = [p for batch, _ in prepared.batches for p in batch]
+        run_ids = [str(p["id"]) for p in payloads]
+        counts = {"payloads": 0, "attachments": 0}
+        # write_checksum belongs in the params, not the compressor, and it is
+        # why the manifest carries no digest of its own: zstd verifies the frame.
+        params = zstd.ZstdCompressionParameters.from_level(
+            self.compress_level, enable_ldm=True, window_log=WINDOW_LOG, write_checksum=1
+        )
+        with _open_private(partial) as raw:
+            # closefd=False: the frame is flushed when this context exits, but
+            # the fd has to outlive it so the fsync below can reach it.
+            with zstd.ZstdCompressor(compression_params=params).stream_writer(raw, closefd=False) as stream:
+                with tarfile.open(fileobj=stream, mode="w|") as tar:
+                    for payload in payloads:
+                        body, blobs = _encode_payload(payload)
+                        counts["payloads"] += _tar_bytes(tar, f"{payload['id']}.json", body)
+                        for index, blob in enumerate(blobs):
+                            counts["attachments"] += _tar_bytes(tar, f"{payload['id']}/{index}", blob)
+                    _tar_bytes(tar, _MANIFEST, self._manifest(target, window, prepared, run_ids, counts))
+            raw.flush()
+            os.fsync(raw.fileno())
+        self.staged.append(partial)
+        return partial
+
+    def commit(
+        self, target: Dict[str, Any], window: Window, prepared, staged: Optional[Path]
+    ) -> List[Tuple[str, str]]:
+        """Main thread, in window order: publish the window by renaming it.
+
+        Ordering is what makes an interrupted export leave a contiguous prefix.
+        Unordered renames could publish a later window while an earlier one is
+        missing, and an interior hole in an archive nobody re-runs is invisible.
+        """
+        if staged is None:  # dry run
+            return []
+        final = self._final(target, window)
+        os.replace(staged, final)
+        if staged in self.staged:
+            self.staged.remove(staged)
+        self.written.append(final)
+        return []
+
+    def close_target(self, target: Dict[str, Any], recon: Any = None) -> None:
+        return None
+
+    # -- internals --------------------------------------------------------
+    def _final(self, target: Dict[str, Any], window: Window) -> Path:
+        return Path(target["dir"]) / f"{window_label(window)}{_SUFFIX}"
+
+    def _manifest(self, target, window, prepared, run_ids, counts) -> bytes:
+        written = set(run_ids)
+        return json.dumps(
+            {
+                "format_version": FORMAT_VERSION,
+                "workspace": self.workspace or {},
+                "project": {"id": target["id"], "name": target.get("name")},
+                "window": {"start": _iso(window.start), "end": _iso(window.end)},
+                # Both counts, because a window with 10,000 short-lived runs and
+                # no long-lived ones is also empty - and an archive that cannot
+                # distinguish that from "we never looked" is not a coverage proof.
+                "run_count": len(run_ids),
+                "runs_scanned": len(prepared.population),
+                "run_ids": sorted(run_ids),
+                "bytes": counts,
+                # Only codes for runs actually in the file: a run dropped at
+                # export is absent, and the export's own reconciliation already
+                # counted it.
+                "degraded": {
+                    code: sorted(ids & written)
+                    for code, ids in (prepared.degraded or {}).items()
+                    if ids & written
+                },
+                "intent": self.intent,
+            },
+            indent=1,
+        ).encode()
+
+    def discard_staged(self) -> List[Path]:
+        """Remove any ``.partial`` this process left behind, and name them."""
+        removed = []
+        for path in list(self.staged):
+            try:
+                path.unlink()
+                removed.append(path)
+            except OSError:
+                pass
+            self.staged.remove(path)
+        return removed
+
+
+# ----------------------------------------------------------------------
+# Reading
+# ----------------------------------------------------------------------
+@dataclass(frozen=True)
+class ArchiveWindow:
+    """One decoded window file."""
+
+    path: Path
+    window: Window
+    manifest: Dict[str, Any]
+    payloads: List[Dict[str, Any]]
+    dropped: Tuple[str, ...] = ()
+
+
+def read_window(path: Path, *, allow_incomplete: bool = False) -> ArchiveWindow:
+    """Decode one window file, treating every member name as untrusted.
+
+    Members are read into memory with ``extractfile``; ``extract``/``extractall``
+    are never used, so no name from the tar reaches the filesystem. Names must
+    match one of the three known shapes, sizes are capped in aggregate, and an
+    unknown ``format_version`` is refused rather than partially read.
+    """
+    incomplete = str(path).endswith(_PARTIAL)
+    if incomplete and not allow_incomplete:
+        raise ArchiveError(f"{path.name} is incomplete (no manifest); pass --allow-incomplete to read it")
+
+    bodies: Dict[str, Dict[str, Any]] = {}
+    blobs: Dict[str, Dict[int, bytes]] = {}
+    manifest: Optional[Dict[str, Any]] = None
+    total = 0
+    with open(path, "rb") as raw:
+        with zstd.ZstdDecompressor().stream_reader(raw) as stream:
+            with tarfile.open(fileobj=stream, mode="r|") as tar:
+                for member in tar:
+                    if not member.isfile():
+                        raise ArchiveError(f"{path.name}: unexpected member type {member.name!r}")
+                    total += member.size
+                    if total > MAX_WINDOW_BYTES:
+                        raise ArchiveError(
+                            f"{path.name} decompresses past {MAX_WINDOW_BYTES:,} bytes; refusing to read it"
+                        )
+                    handle = tar.extractfile(member)
+                    data = handle.read() if handle else b""
+                    if member.name == _MANIFEST:
+                        manifest = json.loads(data)
+                        continue
+                    if member.name == _PROJECT:
+                        continue
+                    run_json = _RUN_JSON.match(member.name)
+                    if run_json:
+                        bodies[run_json.group(1)] = json.loads(data)
+                        continue
+                    run_blob = _RUN_BLOB.match(member.name)
+                    if run_blob:
+                        blobs.setdefault(run_blob.group(1), {})[int(run_blob.group(2))] = data
+                        continue
+                    raise ArchiveError(f"{path.name}: unexpected member {member.name!r}")
+
+    if manifest is None:
+        if not incomplete:
+            raise ArchiveError(f"{path.name} has no {_MANIFEST}; it was truncated")
+        manifest = {}
+    version = manifest.get("format_version", FORMAT_VERSION if incomplete else None)
+    if version != FORMAT_VERSION:
+        raise ArchiveError(f"{path.name}: unsupported format_version {version!r} (this build reads {FORMAT_VERSION})")
+
+    window = parse_window_label(path.name.split(_SUFFIX)[0])
+    bounds = manifest.get("window") or {}
+    if bounds.get("start") and bounds.get("end"):
+        window = Window(
+            datetime.fromisoformat(bounds["start"]), datetime.fromisoformat(bounds["end"])
+        )
+    if window is None:
+        raise ArchiveError(f"{path.name}: no window bounds in the name or the manifest")
+
+    payloads, dropped = [], []
+    for run_id, body in bodies.items():
+        names = body.pop("attachments", None) or []
+        if names:
+            parts = blobs.get(run_id) or {}
+            if len(parts) != len(names):
+                # A run without all its attachments must not be presented as
+                # whole. A complete file missing one is a defect, not a truncation.
+                if not incomplete:
+                    raise ArchiveError(f"{path.name}: run {run_id} is missing attachment members")
+                dropped.append(run_id)
+                continue
+            body["attachments"] = {
+                name: (content_type, parts[index])
+                for index, (name, content_type) in enumerate(names)
+            }
+        payloads.append(body)
+    return ArchiveWindow(path, window, manifest, payloads, tuple(sorted(dropped)))
+
+
+class ArchiveSource:
+    """``RunSource`` reading window files back out of an archive directory.
+
+    Both sides of the port enumerate ``(project, window)``: the API source
+    derives windows from the walk plan, this one from directory entries. Same
+    shape, same driver - which is what makes ``RunSource`` a port rather than
+    two unrelated readers.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        allow_incomplete: bool = False,
+        range_start: Optional[datetime] = None,
+        range_end: Optional[datetime] = None,
+    ):
+        self.root = Path(root)
+        self.allow_incomplete = allow_incomplete
+        # Windows wholly outside these bounds are not replayed. Lets a replay be
+        # confined to part of an archive - e.g. only what a destination that
+        # enforces a +/-24h ingest window will still accept.
+        self.range_start = range_start
+        self.range_end = range_end
+        # A replayed window is re-batched to *this* destination's caps, which
+        # need not match the ones in force when it was captured.
+        self._batch_limits: Callable[[], Tuple[int, int]] = lambda: (100, 20_971_520)
+        self._compile_batch: Callable[[List[Dict[str, Any]]], Any] = lambda batch: None
+
+    def bind(self, sink) -> None:
+        """Take the live destination's batch caps and frame compiler.
+
+        Deferred rather than passed in: the sink is the migrator, which needs
+        this source at construction time.
+        """
+        self._batch_limits = sink.batch_limits
+        self._compile_batch = sink.compile_batch
+
+    # -- RunSource --------------------------------------------------------
+    def sessions(self) -> List[Dict[str, Any]]:
+        """Every project in the archive, found by its ``PROJECT.json`` marker.
+
+        Located by search rather than by walking a fixed depth, so pointing
+        ``--from-archive`` at one workspace directory works as well as at the
+        archive root.
+        """
+        found = []
+        for marker in sorted(self.root.rglob(_PROJECT)):
+            directory = marker.parent
+            if not self._window_paths(directory):
+                continue
+            record = json.loads(marker.read_text())
+            found.append({"id": record["id"], "name": record.get("name"), "dir": str(directory)})
+        return found
+
+    def windows(self, session: Dict[str, Any]) -> Iterator[Window]:
+        for path in self._window_paths(Path(session["dir"])):
+            window = self._require_window(path)
+            if self.range_start and window.end <= self.range_start:
+                continue
+            if self.range_end and window.start >= self.range_end:
+                continue
+            yield window
+
+    def prepare(self, session, target, window, existing_ids: Callable[[], Set[str]]):
+        from .trace_ports import SlicePrepared
+
+        decoded = read_window(self._path_for(session, window), allow_incomplete=self.allow_incomplete)
+        ids = {str(p["id"]) for p in decoded.payloads}
+        plan = plan_slice(ids, existing_ids() if ids else set())
+        # Stands in for the API source's identity scan, off the same runs.
+        population = [
+            {"id": str(p["id"]), "trace_id": str(p.get("trace_id")), "start_time": p.get("start_time")}
+            for p in decoded.payloads
+        ]
+        prepared = SlicePrepared(window, str(session["id"]), str(target["id"]), plan, population)
+        if decoded.dropped:
+            prepared.issues.append((
+                "degraded",
+                "archived_run_incomplete",
+                f"{len(decoded.dropped)} run(s) in {decoded.path.name} were truncated in the "
+                "archive and are missing attachment members; they were not replayed",
+                {"window": window.label(), "run_ids": list(decoded.dropped[:20])},
+            ))
+        # Restricted to what is actually being ingested, so the reconciliation
+        # parts stay a partition of the source total.
+        prepared.degraded = {
+            code: set(run_ids) & plan.to_ingest
+            for code, run_ids in (decoded.manifest.get("degraded") or {}).items()
+            if set(run_ids) & plan.to_ingest
+        }
+        if prepared.degraded:
+            prepared.fidelity_notes.add("some archived runs were captured with reduced fidelity")
+
+        outgoing = []
+        for payload in decoded.payloads:
+            if str(payload["id"]) not in plan.to_ingest:
+                continue
+            # The whole of "optionally change the destination project".
+            payload["session_id"] = str(target["id"])
+            outgoing.append(payload)
+        max_runs, max_bytes = self._batch_limits()
+        for batch in batch_traces(
+            group_into_traces(outgoing), max_runs=max_runs, max_bytes=max_bytes, size_of=payload_bytes
+        ):
+            prepared.batches.append((batch, self._compile_batch(batch)))
+        return prepared
+
+    # -- internals --------------------------------------------------------
+    def _window_paths(self, directory: Path) -> List[Path]:
+        suffixes = (_SUFFIX, _SUFFIX + _PARTIAL) if self.allow_incomplete else (_SUFFIX,)
+        return sorted(
+            path
+            for path in directory.iterdir()
+            if path.is_file()
+            and path.name.endswith(suffixes)
+            and _WINDOW_FILE.match(path.name.split(_SUFFIX)[0])
+        )
+
+    @staticmethod
+    def _require_window(path: Path) -> Window:
+        window = parse_window_label(path.name.split(_SUFFIX)[0])
+        if window is None:
+            raise ArchiveError(f"{path.name} is not a readable window label")
+        return window
+
+    def _path_for(self, session: Dict[str, Any], window: Window) -> Path:
+        base = Path(session["dir"]) / f"{window_label(window)}{_SUFFIX}"
+        if base.exists():
+            return base
+        partial = Path(str(base) + _PARTIAL)
+        if self.allow_incomplete and partial.exists():
+            return partial
+        raise ArchiveError(f"no window file for {window_label(window)} under {session['dir']}")
+
+
+def projected_file_count(range_hours: float, window_hours: float, projects: int) -> int:
+    """Window files an export of this shape would create."""
+    if window_hours <= 0:
+        return 0
+    return max(0, math.ceil(range_hours / window_hours)) * max(1, projects)

--- a/langsmith_migrator/core/trace_domain.py
+++ b/langsmith_migrator/core/trace_domain.py
@@ -82,7 +82,11 @@ RUN_QUERY_SELECT: Tuple[str, ...] = tuple(
 
 
 def _iso(value: datetime) -> str:
-    return value.astimezone(timezone.utc).isoformat()
+    return _as_utc(value).isoformat()
+
+
+def _as_utc(value: datetime) -> datetime:
+    return value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
 
 
 @dataclass(frozen=True)
@@ -93,37 +97,55 @@ class Window:
     end: datetime
 
     def label(self) -> str:
-        return f"{self.start.date()}..{self.end.date()}"
+        """Human-readable bounds in UTC, e.g. ``2026-09-01T10:00..11:42Z``.
+
+        Carries the time, not just the date: ``--window`` is in hours, so
+        sub-day windows are the norm and a date-only label made every window of
+        one day print identically. The end's date is omitted when it matches the
+        start's - the common case, and it keeps the label inside a column.
+        Seconds appear only when a bound actually has them, so a window narrower
+        than a minute still labels distinctly without widening every other line.
+        """
+        start, end = _as_utc(self.start), _as_utc(self.end)
+        fmt = "%Y-%m-%dT%H:%M:%S" if (start.second or end.second) else "%Y-%m-%dT%H:%M"
+        tail = end.strftime(fmt.split("T")[1] if start.date() == end.date() else fmt)
+        return f"{start.strftime(fmt)}..{tail}Z"
 
 
-def iter_windows(start: datetime, end: datetime, window_days: float) -> Iterator[Window]:
+def iter_windows(start: datetime, end: datetime, window_hours: float) -> Iterator[Window]:
     """Yield half-open windows covering ``[start, end)``, oldest first.
+
+    Hours rather than days because the useful range is sub-day: a heavy project
+    needs roughly 1.7 h to keep one prepare slice in memory, which as a fraction
+    of a day (0.07) is a number nobody can read.
 
     Bounds are absolute on purpose. Deriving them from ``now`` inside here
     meant the same relative age denoted a different instant every time it was
     evaluated, so a watermark expressed in days silently drifted while a long
     migration was still running.
     """
-    if window_days <= 0:
-        raise ValueError("window_days must be positive")
+    if window_hours <= 0:
+        raise ValueError("window_hours must be positive")
     if start >= end:
         raise ValueError("range start must precede its end")
-    step = timedelta(days=window_days)
+    step = timedelta(hours=window_hours)
     while start < end:
         boundary = min(start + step, end)
         yield Window(start, boundary)
         start = boundary
 
 
-def resolve_range_start(
-    now: datetime, max_age_days: Optional[float], stamp: Optional[datetime]
-) -> datetime:
-    """The absolute lower bound of the walk, from whichever bound was given."""
-    if stamp is not None:
-        return stamp.astimezone(timezone.utc) if stamp.tzinfo else stamp.replace(tzinfo=timezone.utc)
-    if not max_age_days or max_age_days <= 0:
-        raise ValueError("max_age_days must be positive")
-    return now - timedelta(days=max_age_days)
+def as_utc(stamp: datetime) -> datetime:
+    """Normalise a bound to aware UTC, reading a naive value as UTC.
+
+    Both ends of the walk are absolute stamps, so there is no clock reading in
+    window derivation at all: the same command covers the same span whenever it
+    runs. Relative ages (``--max-age-days`` / ``--min-age-days``) were removed
+    for exactly that reason - each evaluation of "now - N days" denoted a
+    different instant, which slid the whole window grid and gave an archive's
+    files a new name on every run.
+    """
+    return stamp.astimezone(timezone.utc) if stamp.tzinfo else stamp.replace(tzinfo=timezone.utc)
 
 
 def resolve_window_bounds(window: Window) -> Tuple[str, str]:
@@ -264,6 +286,17 @@ def group_into_traces(runs: Iterable[Dict[str, Any]]) -> List[List[Dict[str, Any
     for group in traces.values():
         group.sort(key=lambda r: r.get("dotted_order") or "")
     return [traces[key] for key in sorted(traces, key=lambda t: traces[t][0].get("dotted_order") or "")]
+
+
+def payload_bytes(run: Dict[str, Any]) -> int:
+    """Serialized size of one run, attachments counted as their raw bytes.
+
+    The batching limits and the archive's byte accounting are both expressed in
+    these units, so they have to agree on what a run costs.
+    """
+    return len(json.dumps({k: v for k, v in run.items() if k != "attachments"}, default=str)) + sum(
+        len(data) for _, data in (run.get("attachments") or {}).values()
+    )
 
 
 def batch_traces(

--- a/langsmith_migrator/core/trace_frames.py
+++ b/langsmith_migrator/core/trace_frames.py
@@ -72,8 +72,14 @@ def compile_frame(
     filesystem-attachment check (attachments are already in-memory bytes), and
     the create/update merge (this path only creates).
 
-    NB: ``_run_transform`` mutates each payload in place - ``id`` becomes a
-    ``UUID`` - so digests must be taken before compiling.
+    The caller's payloads are left intact. Both SDK steps mutate what they are
+    given - ``_run_transform`` rewrites ``id`` to a ``UUID``, and
+    ``serialize_run_dict`` **pops** ``inputs``, ``outputs``, ``events``,
+    ``extra``, ``error``, ``serialized`` and ``attachments`` out of the dict -
+    so each payload is shallow-copied first. Without that, a caller holding the
+    payloads for a retry would re-send stripped skeletons, and any size measured
+    afterwards would be of the skeleton. The copy is a key table, not the
+    values, so it costs nothing against the payload bytes.
     """
     run_ids = tuple(str(p["id"]) for p in payloads)
     # multipart_ingest validates this before serializing; this path skips it, so
@@ -85,7 +91,7 @@ def compile_frame(
         # must not touch. Nothing sets it here; fail loudly if that changes.
         raise RuntimeError("frame compilation requires tracing_sample_rate to be unset")
 
-    transformed = [client._run_transform(p) for p in payloads]
+    transformed = [client._run_transform(dict(p)) for p in payloads]
     client._insert_runtime_env(transformed)  # no-op under omit_traced_runtime_info
     ops = combine_serialized_queue_operations(
         [serialize_run_dict("post", run) for run in transformed]

--- a/langsmith_migrator/core/trace_ports.py
+++ b/langsmith_migrator/core/trace_ports.py
@@ -1,0 +1,116 @@
+"""The seam between the trace migrator and each side it talks to.
+
+Two protocols, each with two implementations: ``TraceMigrator`` itself is the
+LangSmith source and sink, and ``core/trace_archive.py`` supplies the file ones.
+The method split is not arbitrary - it mirrors the concurrency the migrator
+already has, and the pairing is load-bearing:
+
+* ``prepare`` and ``stage`` run in a prefetch worker, so they must touch no
+  shared state. That is where the expensive work belongs: the source fetch, and
+  the archive's tar+zstd encode.
+* ``commit`` runs on the main thread in strict window order. For the LangSmith
+  sink that is the non-idempotent POST; for the file sink it is the rename that
+  publishes a finished window. Ordering makes an interrupted run leave a
+  contiguous prefix rather than an arbitrary subset with an interior hole.
+
+A sink that answers ``has_window`` truthfully is what makes a re-run skip work
+instead of redoing it: for a destination project it is always ``False`` (a
+project has no window-level record and can always gain runs), for an archive it
+is "the file exists and is complete".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterator, List, Optional, Protocol, Set, Tuple
+
+from .trace_domain import SlicePlan, Window
+from .trace_frames import CompiledFrame
+
+# A tracing project as both sides pass it around: the API's own session dict.
+Session = Dict[str, Any]
+
+
+@dataclass
+class SlicePrepared:
+    """One slice's work, built in a worker and committed on the main thread.
+
+    Findings accumulate here rather than on the migrator so a worker never
+    writes shared state; the commit stage merges them in window order.
+    """
+
+    window: Window
+    src_id: str
+    dst_id: str
+    plan: SlicePlan
+    population: List[Dict[str, Any]]
+    # The sink's target, and whatever ``stage`` produced for it (a ``.partial``
+    # path for the archive, nothing for a live destination). Both ride along so
+    # the ordered commit needs no side table keyed by window.
+    target: Optional[Dict[str, Any]] = None
+    staged: Any = None
+    # (payloads, pre-compiled frame). The payloads are kept so a rejected batch
+    # can still be split to isolate one bad run; that is what bounds peak
+    # memory to prefetch x window, and why --window is the knob for it.
+    batches: List[Tuple[List[Dict[str, Any]], Optional[CompiledFrame]]] = field(default_factory=list)
+    digests: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    degraded: Dict[str, Set[str]] = field(default_factory=dict)
+    fidelity_notes: Set[str] = field(default_factory=set)
+    upgrade_rows: List[Tuple[str, str, str]] = field(default_factory=list)
+    # (issue_class, code, summary, evidence), replayed through record_issue.
+    issues: List[Tuple[str, str, str, Dict[str, Any]]] = field(default_factory=list)
+
+
+class RunSource(Protocol):
+    """Where runs are read from: a deployment, or an archive directory."""
+
+    def sessions(self) -> List[Session]:
+        """Every project this source can offer."""
+
+    def windows(self, session: Session) -> Iterator[Window]:
+        """The project's windows, oldest first."""
+
+    def prepare(
+        self,
+        session: Session,
+        target: Session,
+        window: Window,
+        existing_ids: Callable[[], Set[str]],
+    ) -> "SlicePrepared":
+        """One window's work, ready to commit. Worker thread; no shared state.
+
+        ``existing_ids`` is the sink's answer to "which of these do you already
+        hold", subtracted before anything is fetched so a re-run of a finished
+        window costs the identity scan and nothing else. It is a callable rather
+        than a set because a source window that turns out to be empty must not
+        cost a destination request at all.
+        """
+
+
+class RunSink(Protocol):
+    """Where runs are written to: a deployment, or an archive directory."""
+
+    def open_target(self, session: Session) -> Optional[Session]:
+        """Resolve (or create) the target for one source project."""
+
+    def batch_limits(self) -> Tuple[int, int]:
+        """Runs-per-batch and bytes-per-batch this sink wants."""
+
+    def has_window(self, target: Session, window: Window) -> bool:
+        """Whether this window is already fully written."""
+
+    def existing_ids(self, target: Session, window: Window) -> Set[str]:
+        """Run IDs the target already holds for this window."""
+
+    def stage(self, target: Session, window: Window, prepared) -> Any:
+        """Worker thread: everything the write needs, short of publishing it."""
+
+    def commit(self, target: Session, window: Window, prepared, staged) -> List[Tuple[str, str]]:
+        """Main thread, in window order. Returns ``[(run_id, error)]``."""
+
+    def close_target(self, target: Session, recon: Any = None) -> None:
+        """Release the target after its last window, told how it went.
+
+        The LangSmith sink uses ``recon`` to decide whether a tier it raised may
+        be put back; an archive has nothing to settle.
+        """

--- a/langsmith_migrator/utils/retry.py
+++ b/langsmith_migrator/utils/retry.py
@@ -10,6 +10,13 @@ from typing import Callable, Optional
 # Maximum backoff delay in seconds to prevent indefinite waits
 MAX_BACKOFF_SECONDS = 60.0
 
+# A 429 gets its own, larger budget than a server error, because it is the one
+# failure where the server states exactly how long to wait. Sharing the general
+# three attempts meant a burst of rate limits under concurrent readers gave up
+# after ~6 s of backoff against a limit measured in minutes - observed killing a
+# whole project one window into a trace export at --prefetch-windows 6.
+RATE_LIMIT_RETRIES = 6
+
 
 class RateLimitError(Exception):
     """Rate limit exceeded error."""
@@ -87,6 +94,24 @@ def retry_upstream_rejections(max_retries: int = 3, delay: float = 1.0, backoff:
     return decorator
 
 
+def _await_rate_limit(func: Callable, args, kwargs, delay: float, backoff: float):
+    """Call ``func``, waiting out 429s on their own budget.
+
+    Wraps the call rather than restructuring the attempt loop below, so a
+    rate limit does not consume an attempt that a server error needs. Once the
+    budget is spent the ``RateLimitError`` propagates to that loop, which still
+    treats it as the retryable error it always was.
+    """
+    wait = delay
+    for _ in range(RATE_LIMIT_RETRIES):
+        try:
+            return func(*args, **kwargs)
+        except RateLimitError as e:
+            time.sleep(min(e.retry_after or wait * 2, MAX_BACKOFF_SECONDS))
+            wait = min(wait * backoff, MAX_BACKOFF_SECONDS)
+    return func(*args, **kwargs)
+
+
 def retry_on_failure(max_retries: int = 3, delay: float = 1.0, backoff: float = 2.0):
     """
     Decorator to retry failed API calls with exponential backoff.
@@ -106,17 +131,14 @@ def retry_on_failure(max_retries: int = 3, delay: float = 1.0, backoff: float = 
 
             for attempt in range(max_retries):
                 try:
-                    return func(*args, **kwargs)
-                except RateLimitError as e:
-                    # Always retry rate limits
-                    last_exception = e
-                    # Use Retry-After if provided, otherwise use exponential backoff
-                    if e.retry_after:
-                        wait_time = min(e.retry_after, MAX_BACKOFF_SECONDS)
-                    else:
-                        wait_time = min(current_delay * 2, MAX_BACKOFF_SECONDS)
-                    time.sleep(wait_time)
-                    current_delay = min(current_delay * backoff, MAX_BACKOFF_SECONDS)
+                    return _await_rate_limit(func, args, kwargs, current_delay, backoff)
+                except RateLimitError:
+                    # _await_rate_limit has already spent RATE_LIMIT_RETRIES
+                    # honouring the server's own Retry-After. Reaching here means
+                    # the limit is sustained rather than a burst, so more of the
+                    # same backoff will not help - and multiplying the two
+                    # budgets would wait for minutes before saying so.
+                    raise
                 except UpstreamRejectionError as e:
                     # An intermediary refused this before LangSmith saw it. Often
                     # transient, so retry rather than killing the caller's work item.

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -8,6 +8,7 @@ import requests
 from langsmith_migrator.utils.retry import (
     APIError,
     AuthenticationError,
+    RATE_LIMIT_RETRIES,
     ConflictError,
     RateLimitError,
     UpstreamRejectionError,
@@ -38,7 +39,8 @@ def _counting_raiser(exc: Exception):
     [
         UpstreamRejectionError("proxy said no", status_code=403),
         UpstreamRejectionError("proxy said no", status_code=401),
-        RateLimitError("slow down"),
+        pytest.param(RateLimitError("slow down"), id="rate-limit", marks=pytest.mark.skip(
+            reason="covered by test_rate_limits_get_their_own_larger_budget")),
         APIError("server blew up", status_code=503),
         requests.exceptions.ConnectionError("dns failed"),
         requests.exceptions.ReadTimeout("too slow"),
@@ -113,3 +115,15 @@ def test_backoff_is_capped(monkeypatch):
         call()
 
     assert all(delay <= 60.0 for delay in slept)
+
+
+def test_rate_limits_get_their_own_larger_budget():
+    """A 429 names its own wait, so it is not rationed against a server error's
+    three attempts - a burst under concurrent readers used to give up after ~6s.
+    """
+    call, calls = _counting_raiser(RateLimitError("slow down", retry_after=0))
+
+    with pytest.raises(RateLimitError):
+        call()
+
+    assert calls["count"] == RATE_LIMIT_RETRIES + 1

--- a/tests/test_trace_archive.py
+++ b/tests/test_trace_archive.py
@@ -1,0 +1,391 @@
+"""The archive's contracts, all of which are cheap to get wrong.
+
+Completeness here is a *file-level* property - a window is renamed into place
+only after its manifest is appended - so these pin the file states, the
+contiguity that ordered renames buy, and the fact that every member name coming
+out of a tarball is treated as untrusted.
+"""
+
+import io
+import json
+import os
+import tarfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import zstandard as zstd
+
+from langsmith_migrator.core.trace_archive import (
+    FORMAT_VERSION,
+    ArchiveError,
+    ArchiveSink,
+    ArchiveSource,
+    parse_window_label,
+    project_dir_name,
+    projected_file_count,
+    read_window,
+    window_label,
+    workspace_dir_name,
+)
+from langsmith_migrator.core.trace_domain import Window, plan_slice
+from langsmith_migrator.core.trace_ports import SlicePrepared
+
+NOW = datetime(2026, 9, 1, tzinfo=timezone.utc)
+WINDOW = Window(NOW - timedelta(days=1), NOW)
+PROJECT = {"id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "name": "gtm-agent"}
+
+
+def _run(n: int, **extra):
+    run_id = f"{n:08d}-1111-1111-1111-111111111111"
+    return {
+        "id": run_id,
+        "trace_id": run_id,
+        "name": "n",
+        "run_type": "chain",
+        "start_time": "2026-08-31T10:00:00+00:00",
+        "dotted_order": f"20260831T100000000000Z{run_id}",
+        "session_id": "source-session",
+        "inputs": {"i": n},
+        **extra,
+    }
+
+
+def _prepared(window, runs, **kw):
+    ids = {str(r["id"]) for r in runs}
+    prepared = SlicePrepared(window, "src", PROJECT["id"], plan_slice(ids, set()), list(runs), **kw)
+    prepared.batches = [(list(runs), None)] if runs else []
+    return prepared
+
+
+def _export(root, runs, window=WINDOW, *, level=3, commit=True):
+    sink = ArchiveSink(root, compress_level=level)
+    sink.intent = {"range_start": "s", "range_end": "e", "window_hours": 24.0, "projects": ["gtm-agent"]}
+    target = sink.open_target(PROJECT)
+    prepared = _prepared(window, runs)
+    staged = sink.stage(target, window, prepared)
+    if commit:
+        sink.commit(target, window, prepared, staged)
+    return sink, target, prepared, staged
+
+
+# --------------------------------------------------------------------------
+# Round trip
+# --------------------------------------------------------------------------
+def test_a_window_round_trips_payloads_and_attachments_byte_for_byte(tmp_path):
+    blob = os.urandom(3 * 1024 * 1024)
+    runs = [_run(1), _run(2, attachments={"a/../weird name.bin": ("image/png", blob)})]
+    _, target, _, _ = _export(tmp_path, runs)
+
+    decoded = read_window(next(Path(target["dir"]).glob("*.tar.zst")))
+    by_id = {p["id"]: p for p in decoded.payloads}
+    assert set(by_id) == {r["id"] for r in runs}
+    assert by_id[runs[1]["id"]]["attachments"] == {"a/../weird name.bin": ("image/png", blob)}
+    assert by_id[runs[0]["id"]]["inputs"] == {"i": 1}
+    assert decoded.window == WINDOW
+
+
+def test_an_attachment_name_never_becomes_a_path_component(tmp_path):
+    """Names ride inside the JSON; blob members are numbered by position."""
+    _, target, _, _ = _export(tmp_path, [_run(1, attachments={"../../etc/passwd": ("text/plain", b"x")})])
+    with open(next(Path(target["dir"]).glob("*.tar.zst")), "rb") as raw:
+        with zstd.ZstdDecompressor().stream_reader(raw) as stream:
+            names = tarfile.open(fileobj=stream, mode="r|").getnames()
+    assert all(".." not in name for name in names), names
+    assert f"{_run(1)['id']}/0" in names
+
+
+def test_replay_rewrites_the_session_and_rebatches_to_the_live_caps(tmp_path):
+    _export(tmp_path, [_run(i) for i in range(1, 6)])
+    source = ArchiveSource(tmp_path)
+    session = source.sessions()[0]
+    source._batch_limits = lambda: (2, 10**9)
+
+    prepared = source.prepare(session, {"id": "NEW"}, WINDOW, lambda: set())
+    assert [len(batch) for batch, _ in prepared.batches] == [2, 2, 1]
+    assert {p["session_id"] for batch, _ in prepared.batches for p in batch} == {"NEW"}
+
+
+def test_replay_sends_only_what_the_destination_lacks(tmp_path):
+    _export(tmp_path, [_run(1), _run(2)])
+    source = ArchiveSource(tmp_path)
+    session = source.sessions()[0]
+
+    prepared = source.prepare(session, {"id": "NEW"}, WINDOW, lambda: {_run(1)["id"]})
+    assert [p["id"] for batch, _ in prepared.batches for p in batch] == [_run(2)["id"]]
+    assert prepared.plan.already_present == {_run(1)["id"]}
+
+
+def test_replaying_a_fully_present_window_asks_the_destination_once_and_sends_nothing(tmp_path):
+    _export(tmp_path, [_run(1)])
+    source = ArchiveSource(tmp_path)
+    session = source.sessions()[0]
+    calls = []
+
+    prepared = source.prepare(
+        session, {"id": "NEW"}, WINDOW, lambda: calls.append(1) or {_run(1)["id"]}
+    )
+    assert prepared.batches == []
+    assert len(calls) == 1
+
+
+# --------------------------------------------------------------------------
+# Completeness, and what an interruption leaves
+# --------------------------------------------------------------------------
+def test_a_staged_window_is_partial_and_invisible_until_it_is_renamed(tmp_path):
+    sink, target, prepared, staged = _export(tmp_path, [_run(1)], commit=False)
+    assert staged.name.endswith(".tar.zst.partial")
+    assert sink.has_window(target, WINDOW) is False
+
+    sink.commit(target, WINDOW, prepared, staged)
+    assert sink.has_window(target, WINDOW) is True
+    assert not staged.exists()
+
+
+def test_a_complete_tarball_left_partial_is_re_captured_not_trusted(tmp_path):
+    """The crash between stream close and rename. Wasteful once, never wrong."""
+    sink, target, _, staged = _export(tmp_path, [_run(1)], commit=False)
+    assert staged.exists() and sink.has_window(target, WINDOW) is False
+    with pytest.raises(ArchiveError, match="incomplete"):
+        read_window(staged)
+    assert read_window(staged, allow_incomplete=True).payloads
+
+
+def test_discarding_staged_windows_names_every_file_it_removed(tmp_path):
+    sink, target, _, staged = _export(tmp_path, [_run(1)], commit=False)
+    assert sink.discard_staged() == [staged]
+    assert not staged.exists()
+    assert sink.discard_staged() == []
+
+
+def test_an_empty_window_still_produces_a_file_so_contiguity_holds(tmp_path):
+    """"We looked here and found nothing" is not "we never looked"."""
+    sink = ArchiveSink(tmp_path, compress_level=3)
+    sink.intent = {}
+    target = sink.open_target(PROJECT)
+    prepared = SlicePrepared(WINDOW, "src", PROJECT["id"], plan_slice(set(), set()), [])
+    sink.commit(target, WINDOW, prepared, sink.stage(target, WINDOW, prepared))
+
+    assert sink.has_window(target, WINDOW) is True
+    decoded = read_window(next(Path(target["dir"]).glob("*.tar.zst")))
+    assert decoded.payloads == [] and decoded.manifest["run_count"] == 0
+
+
+def test_runs_scanned_separates_a_quiet_window_from_a_wrong_tier_one(tmp_path):
+    """A window of 10,000 short-lived runs is empty too, but differently."""
+    sink = ArchiveSink(tmp_path, compress_level=3)
+    sink.intent = {}
+    target = sink.open_target(PROJECT)
+    scanned = SlicePrepared(WINDOW, "src", PROJECT["id"], plan_slice(set(), set()), [_run(1)])
+    sink.commit(target, WINDOW, scanned, sink.stage(target, WINDOW, scanned))
+
+    manifest = read_window(next(Path(target["dir"]).glob("*.tar.zst"))).manifest
+    assert (manifest["run_count"], manifest["runs_scanned"]) == (0, 1)
+
+
+def test_window_labels_sort_in_time_order_and_carry_both_bounds(tmp_path):
+    labels = [window_label(Window(NOW - timedelta(hours=h + 1), NOW - timedelta(hours=h))) for h in (0, 5, 30)]
+    assert sorted(labels) == labels[::-1]
+    assert parse_window_label(labels[0]) == Window(NOW - timedelta(hours=1), NOW)
+    assert parse_window_label("nonsense") is None
+    assert parse_window_label(window_label(Window(NOW, NOW))) is None  # not half-open
+
+
+def test_the_intent_lets_a_short_archive_be_told_from_a_complete_small_one(tmp_path):
+    sink, target, _, _ = _export(tmp_path, [_run(1)])
+    intent = read_window(next(Path(target["dir"]).glob("*.tar.zst"))).manifest["intent"]
+    assert set(intent) == {"range_start", "range_end", "window_hours", "projects"}
+
+
+# --------------------------------------------------------------------------
+# Hostile and awkward input
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("name", ["../../escape", "..", "/absolute", "-leading", "a" * 400, ""])
+def test_a_hostile_project_name_cannot_escape_the_archive_directory(tmp_path, name):
+    sink = ArchiveSink(tmp_path, compress_level=3)
+    target = sink.open_target({"id": PROJECT["id"], "name": name})
+    resolved = Path(target["dir"]).resolve()
+    assert tmp_path.resolve() in resolved.parents
+    assert len(resolved.name) < 160
+
+
+def test_project_directories_are_owner_only(tmp_path):
+    _, target, _, _ = _export(tmp_path, [_run(1)])
+    assert oct(Path(target["dir"]).stat().st_mode)[-3:] == "700"
+    for path in Path(target["dir"]).iterdir():
+        assert oct(path.stat().st_mode)[-3:] == "600", path
+
+
+def _handmade(path: Path, members: dict, *, level=3):
+    with open(path, "wb") as raw:
+        with zstd.ZstdCompressor(level=level).stream_writer(raw, closefd=False) as stream:
+            with tarfile.open(fileobj=stream, mode="w|") as tar:
+                for name, data in members.items():
+                    info = tarfile.TarInfo(name)
+                    info.size = len(data)
+                    tar.addfile(info, io.BytesIO(data))
+
+
+def _manifest(**over):
+    base = {
+        "format_version": FORMAT_VERSION,
+        "project": PROJECT,
+        "window": {"start": WINDOW.start.isoformat(), "end": WINDOW.end.isoformat()},
+        "run_count": 0,
+        "runs_scanned": 0,
+        "run_ids": [],
+        "bytes": {},
+        "degraded": {},
+        "intent": {},
+    }
+    base.update(over)
+    return json.dumps(base).encode()
+
+
+def test_an_unexpected_member_name_is_refused_rather_than_read(tmp_path):
+    path = tmp_path / f"{window_label(WINDOW)}.tar.zst"
+    _handmade(path, {"../../etc/passwd": b"x", "MANIFEST.json": _manifest()})
+    with pytest.raises(ArchiveError, match="unexpected member"):
+        read_window(path)
+
+
+def test_an_unknown_format_version_is_refused_not_partially_read(tmp_path):
+    path = tmp_path / f"{window_label(WINDOW)}.tar.zst"
+    _handmade(path, {"MANIFEST.json": _manifest(format_version=99)})
+    with pytest.raises(ArchiveError, match="format_version"):
+        read_window(path)
+
+
+def test_a_manifestless_file_is_reported_as_truncated(tmp_path):
+    path = tmp_path / f"{window_label(WINDOW)}.tar.zst"
+    _handmade(path, {f"{_run(1)['id']}.json": b"{}"})
+    with pytest.raises(ArchiveError, match="truncated"):
+        read_window(path)
+
+
+def test_a_run_missing_its_attachment_members_is_never_presented_as_whole(tmp_path):
+    path = tmp_path / f"{window_label(WINDOW)}.tar.zst"
+    body = json.dumps({**_run(1), "attachments": [["a.bin", "text/plain"]]}).encode()
+    _handmade(path, {f"{_run(1)['id']}.json": body, "MANIFEST.json": _manifest()})
+    with pytest.raises(ArchiveError, match="missing attachment"):
+        read_window(path)
+
+
+def test_a_decompression_bomb_aborts_instead_of_filling_memory(tmp_path, monkeypatch):
+    monkeypatch.setattr("langsmith_migrator.core.trace_archive.MAX_WINDOW_BYTES", 4096)
+    path = tmp_path / f"{window_label(WINDOW)}.tar.zst"
+    _handmade(path, {f"{_run(1)['id']}.json": b"0" * 65536, "MANIFEST.json": _manifest()})
+    with pytest.raises(ArchiveError, match="decompresses past"):
+        read_window(path)
+
+
+def test_a_full_disk_fails_before_a_window_file_is_opened(tmp_path, monkeypatch):
+    import shutil as _shutil
+
+    monkeypatch.setattr(
+        "langsmith_migrator.core.trace_archive.shutil.disk_usage",
+        lambda _p: _shutil._ntuple_diskusage(0, 0, 1024),
+    )
+    with pytest.raises(ArchiveError, match="refusing to start a window"):
+        _export(tmp_path, [_run(1)])
+    assert not list(tmp_path.rglob("*.tar.zst*"))
+
+
+# --------------------------------------------------------------------------
+# Enumeration
+# --------------------------------------------------------------------------
+def test_only_complete_windows_are_offered_for_replay_unless_asked(tmp_path):
+    sink, target, prepared, staged = _export(tmp_path, [_run(1)], commit=False)
+    assert ArchiveSource(tmp_path).sessions() == []
+    assert len(ArchiveSource(tmp_path, allow_incomplete=True).sessions()) == 1
+
+    sink.commit(target, WINDOW, prepared, staged)
+    assert len(ArchiveSource(tmp_path).sessions()) == 1
+
+
+def test_a_replay_range_confines_which_windows_are_read(tmp_path):
+    """The lever for a destination that only accepts a recent ingest window."""
+    older = Window(NOW - timedelta(days=3), NOW - timedelta(days=2))
+    _export(tmp_path, [_run(1)], window=older)
+    _export(tmp_path, [_run(2)], window=WINDOW)
+    session = ArchiveSource(tmp_path).sessions()[0]
+
+    assert len(list(ArchiveSource(tmp_path).windows(session))) == 2
+    recent = ArchiveSource(tmp_path, range_start=NOW - timedelta(days=1))
+    assert [w.start for w in recent.windows(session)] == [WINDOW.start]
+
+
+def test_project_dir_names_are_unique_per_session_even_when_slugs_collide():
+    a = project_dir_name({"id": "1111", "name": "a/b"})
+    b = project_dir_name({"id": "2222", "name": "a:b"})
+    assert a != b and a.startswith("a_b-") and b.startswith("a_b-")
+
+
+def test_the_projected_file_count_is_range_over_window_times_projects():
+    assert projected_file_count(180 * 24, 24.0, 50) == 9_000
+    assert projected_file_count(180 * 24, 2.4, 50) == 90_000
+    assert projected_file_count(180 * 24, 0, 50) == 0
+
+
+# --------------------------------------------------------------------------
+# Workspace level
+# --------------------------------------------------------------------------
+WORKSPACE = {"id": "11112222-3333-4444-5555-666677778888", "name": "LangChain Team"}
+
+
+def test_window_files_are_filed_under_the_source_workspace_name(tmp_path):
+    sink = ArchiveSink(tmp_path, compress_level=3, workspace=WORKSPACE)
+    sink.intent = {}
+    target = sink.open_target(PROJECT)
+    prepared = _prepared(WINDOW, [_run(1)])
+    sink.commit(target, WINDOW, prepared, sink.stage(target, WINDOW, prepared))
+
+    written = sink.written[0].relative_to(tmp_path).parts
+    assert written[0] == f"LangChain_Team-{WORKSPACE['id']}"
+    assert written[1].startswith("gtm-agent-")
+    assert len(written) == 3
+
+
+@pytest.mark.parametrize("name", ["../../escape", "..", "/absolute", "-x", "a" * 300, ""])
+def test_a_hostile_workspace_name_cannot_escape_the_archive_directory(tmp_path, name):
+    sink = ArchiveSink(tmp_path, compress_level=3, workspace={"id": "ws-1", "name": name})
+    resolved = Path(sink.open_target(PROJECT)["dir"]).resolve()
+    assert tmp_path.resolve() in resolved.parents
+
+
+def test_two_workspaces_sharing_a_display_name_get_separate_directories(tmp_path):
+    """The ID suffix is what keeps them apart; the manifest records it too, so
+    the pairing survives even if someone renames a directory."""
+    twin = {"id": "99998888-7777-6666-5555-444433332222", "name": "LangChain Team"}
+    for ws in (WORKSPACE, twin):
+        sink = ArchiveSink(tmp_path, compress_level=3, workspace=ws)
+        sink.intent = {}
+        target = sink.open_target({"id": ws["id"], "name": "shared"})
+        prepared = _prepared(WINDOW, [_run(1)])
+        sink.commit(target, WINDOW, prepared, sink.stage(target, WINDOW, prepared))
+
+    assert sorted(p.name for p in tmp_path.iterdir() if p.is_dir()) == [
+        f"LangChain_Team-{WORKSPACE['id']}", f"LangChain_Team-{twin['id']}"
+    ]
+    ids = {read_window(f).manifest["workspace"]["id"] for f in tmp_path.rglob("*.tar.zst")}
+    assert ids == {WORKSPACE["id"], twin["id"]}
+
+
+def test_a_workspace_without_a_name_or_id_still_yields_one_safe_component(tmp_path):
+    assert workspace_dir_name({"id": "abc", "name": None}) == "workspace-abc"
+    assert workspace_dir_name({"id": None, "name": "Team A"}) == "Team_A"
+    assert workspace_dir_name(None) == "workspace"
+
+
+def test_replay_finds_projects_under_the_workspace_level(tmp_path):
+    sink = ArchiveSink(tmp_path, compress_level=3, workspace=WORKSPACE)
+    sink.intent = {}
+    target = sink.open_target(PROJECT)
+    prepared = _prepared(WINDOW, [_run(1)])
+    sink.commit(target, WINDOW, prepared, sink.stage(target, WINDOW, prepared))
+
+    # from the archive root...
+    assert [s["name"] for s in ArchiveSource(tmp_path).sessions()] == ["gtm-agent"]
+    # ...and from one workspace directory
+    one = tmp_path / f"LangChain_Team-{WORKSPACE['id']}"
+    assert [s["name"] for s in ArchiveSource(one).sessions()] == ["gtm-agent"]

--- a/tests/test_trace_export.py
+++ b/tests/test_trace_export.py
@@ -1,0 +1,298 @@
+"""Export drives the migrator's existing walk, so its guarantees must survive.
+
+The two that matter and are easy to lose: the tar+zstd encode has to happen in
+the prefetch workers (or a heavy export gains hours of serial compression), and
+the rename has to happen on the main thread in window order (or an interrupted
+export leaves an interior hole that nothing re-derives).
+"""
+
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from langsmith_migrator.core.api_client import EnhancedAPIClient
+from langsmith_migrator.core.migrators.trace import TraceMigrator
+from langsmith_migrator.core.trace_archive import (
+    ArchiveSink,
+    ArchiveSource,
+    read_window,
+    window_label,
+)
+from langsmith_migrator.core.trace_domain import iter_windows
+
+NOW = datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc)
+PROJECT = {"id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "name": "gtm-agent", "trace_tier": "longlived"}
+
+
+def _client():
+    client = Mock(spec=EnhancedAPIClient)
+    client.session = Mock()
+    client.session.headers = {}
+    return client
+
+
+def _run(day, n):
+    run_id = f"{day:04d}{n:04d}-1111-1111-1111-111111111111"
+    stamp = (NOW - timedelta(days=day)).isoformat()
+    return {
+        "id": run_id, "trace_id": run_id, "trace_tier": "longlived",
+        "name": "n", "run_type": "chain", "start_time": stamp,
+        "dotted_order": f"20260901T120000000000Z{run_id}", "inputs": {"n": n},
+    }
+
+
+def _exporter(tmp_path, sample_config, *, days=4, prefetch=4, runs_per_window=2, delay=None):
+    """A migrator whose sink is an archive and whose source returns fixed runs."""
+    sink = ArchiveSink(tmp_path, compress_level=1)
+    sink.intent = {"range_start": "s", "range_end": "e", "window_hours": 24.0, "projects": ["gtm-agent"]}
+    with patch("langsmith_migrator.core.migrators.trace.Client"):
+        m = TraceMigrator(
+            _client(), _client(), None, sample_config,
+            range_start=NOW - timedelta(days=days), range_end=NOW,
+            window_hours=24.0, prefetch_windows=prefetch, verify=False,
+            verify_content_sample=0, run_sink=sink,
+        )
+
+    order = [w.start for w in iter_windows(m.resolved_range_start(), NOW, 24.0)]
+
+    def slice_runs(_client_, _session, window, **_kw):
+        if delay:
+            # Earliest windows made slowest, so completion order fights
+            # commit order.
+            time.sleep(delay * (len(order) - order.index(window.start)))
+        day = (NOW - window.start).days
+        return [_run(day, n) for n in range(runs_per_window)]
+
+    m.slice_runs = Mock(side_effect=slice_runs)
+    m.fetch_runs = Mock(side_effect=lambda _c, _s, _w, ids: [
+        r for r in slice_runs(None, None, _w) if str(r["id"]) in set(ids)
+    ])
+    m.materialise = Mock(return_value=({}, []))
+    return m, sink
+
+
+def _labels(directory: Path):
+    return sorted(p.name for p in Path(directory).glob("*.tar.zst"))
+
+
+# --------------------------------------------------------------------------
+def test_an_export_writes_one_complete_file_per_window(tmp_path, sample_config):
+    m, sink = _exporter(tmp_path, sample_config, days=4)
+    report = m.migrate_session(PROJECT)
+
+    assert report.source_total == 8 and report.ingested == 8 and report.blocked == 0
+    target = Path(sink.written[0]).parent
+    assert len(_labels(target)) == 4
+    for path in Path(target).glob("*.tar.zst"):
+        assert len(read_window(path).payloads) == 2
+
+
+def test_the_encode_runs_in_the_prefetch_workers_not_on_the_commit_path(tmp_path, sample_config):
+    m, sink = _exporter(tmp_path, sample_config, prefetch=4)
+    threads = set()
+    original = sink.stage
+    sink.stage = lambda *a: (threads.add(threading.current_thread().name), original(*a))[1]
+
+    m.migrate_session(PROJECT)
+    assert threads and all(name.startswith("trace-prepare") for name in threads), threads
+
+
+def test_renames_happen_on_the_main_thread_in_window_order(tmp_path, sample_config):
+    m, sink = _exporter(tmp_path, sample_config, days=6, prefetch=4, delay=0.03)
+    seen, threads = [], set()
+    original = sink.commit
+
+    def commit(target, window, prepared, staged):
+        seen.append(window.start)
+        threads.add(threading.current_thread().name)
+        return original(target, window, prepared, staged)
+
+    sink.commit = commit
+    m.migrate_session(PROJECT)
+
+    assert seen == sorted(seen), seen
+    assert threads == {threading.current_thread().name}
+
+
+def test_an_interruption_mid_walk_leaves_a_contiguous_prefix(tmp_path, sample_config):
+    """Ordering makes an interior hole unrepresentable, not merely recoverable."""
+    m, sink = _exporter(tmp_path, sample_config, days=6, prefetch=3)
+    original = sink.commit
+    calls = {"n": 0}
+
+    def commit(target, window, prepared, staged):
+        calls["n"] += 1
+        if calls["n"] == 4:
+            raise RuntimeError("boom")
+        return original(target, window, prepared, staged)
+
+    sink.commit = commit
+    with pytest.raises(RuntimeError):
+        m.migrate_session(PROJECT)
+
+    target = Path(sink.written[0]).parent
+    expected = [w.start for w in iter_windows(m._resolved_start, NOW, 24.0)]
+    assert [read_window(p).window.start for p in sorted(Path(target).glob("*.tar.zst"))] == expected[:3]
+    # every .partial sits strictly beyond the prefix
+    for partial in Path(target).glob("*.partial"):
+        assert read_window(partial, allow_incomplete=True).window.start > expected[2]
+
+
+def test_a_graceful_stop_drains_what_is_in_flight_and_loses_nothing(tmp_path, sample_config):
+    """First Ctrl-C: stop scheduling, finish the rest. Loss is zero."""
+    m, sink = _exporter(tmp_path, sample_config, days=8, prefetch=2)
+    original = sink.commit
+
+    def commit(target, window, prepared, staged):
+        if len(sink.written) == 1:
+            m.stop_requested = True
+        return original(target, window, prepared, staged)
+
+    sink.commit = commit
+    m.migrate_session(PROJECT)
+
+    target = Path(sink.written[0]).parent
+    # what was scheduled before the stop is complete, and nothing is left over
+    assert len(_labels(target)) == len(sink.written) < 8
+    assert list(Path(target).glob("*.partial")) == []
+    assert [read_window(p).window.start for p in sorted(Path(target).glob("*.tar.zst"))] == sorted(
+        read_window(p).window.start for p in Path(target).glob("*.tar.zst")
+    )
+
+
+def test_a_re_run_skips_captured_windows_without_reading_the_source(tmp_path, sample_config):
+    m, sink = _exporter(tmp_path, sample_config, days=3)
+    m.migrate_session(PROJECT)
+    first = m.slice_runs.call_count
+
+    again, _ = _exporter(tmp_path, sample_config, days=3)
+    report = again.migrate_session(PROJECT)
+    assert again.slice_runs.call_count == 0
+    assert again.skipped_windows == 3
+    assert report is None or report.source_total == 0
+    assert first == 3
+
+
+def test_deleting_one_window_file_re_captures_exactly_that_window(tmp_path, sample_config):
+    m, sink = _exporter(tmp_path, sample_config, days=4)
+    m.migrate_session(PROJECT)
+    target = Path(sink.written[0]).parent
+    removed = sorted(Path(target).glob("*.tar.zst"))[1]
+    removed.unlink()
+
+    again, _ = _exporter(tmp_path, sample_config, days=4)
+    again.migrate_session(PROJECT)
+    assert again.slice_runs.call_count == 1
+    assert again.skipped_windows == 3
+    assert removed.exists()
+
+
+def test_every_manifest_from_one_run_records_the_same_range_end(tmp_path, sample_config):
+    m, sink = _exporter(tmp_path, sample_config, days=4)
+    m.migrate_session(PROJECT)
+    ends = {read_window(p).manifest["intent"]["range_end"] for p in sink.written}
+    assert len(ends) == 1
+
+
+def test_the_same_bounds_always_give_the_same_windows(tmp_path, sample_config):
+    """Both bounds are absolute stamps, so window derivation reads no clock.
+
+    Relative ages were removed for this: "now - N days" denoted a different
+    instant on every evaluation, which slid the grid, gave an archive's files a
+    new name each run so nothing was ever skipped, and - when the two bounds
+    were read a moment apart - pushed a sub-second window past the last real one.
+    """
+    start = datetime(2026, 8, 30, 3, 17, tzinfo=timezone.utc)
+    end = datetime(2026, 9, 1, 3, 17, tzinfo=timezone.utc)
+    grids = []
+    for _ in range(2):
+        with patch("langsmith_migrator.core.migrators.trace.Client"):
+            m = TraceMigrator(
+                _client(), _client(), None, sample_config, range_start=start, range_end=end,
+                window_hours=12.0, run_sink=ArchiveSink(tmp_path, compress_level=1),
+            )
+        grids.append([window_label(w) for w in m.windows(PROJECT)])
+    assert grids[0] == grids[1]
+    windows = list(m.windows(PROJECT))
+    assert len(windows) == 4
+    assert (windows[0].start, windows[-1].end) == (start, end)
+    assert all(w.end - w.start == timedelta(days=0.5) for w in windows)
+
+
+def test_a_naive_bound_is_read_as_utc(sample_config):
+    with patch("langsmith_migrator.core.migrators.trace.Client"):
+        m = TraceMigrator(
+            _client(), _client(), None, sample_config,
+            range_start=datetime(2026, 8, 30, 3, 17), range_end=datetime(2026, 8, 31, 3, 17),
+        )
+    assert m.resolved_range_start().tzinfo == timezone.utc
+    assert m.walk_end() == datetime(2026, 8, 31, 3, 17, tzinfo=timezone.utc)
+
+
+def test_a_run_the_source_lists_but_never_returns_is_reported_not_counted(tmp_path, sample_config):
+    """An export has no confirming re-query, so this is the only place it shows."""
+    m, sink = _exporter(tmp_path, sample_config, days=1, runs_per_window=3)
+    m.fetch_runs = Mock(side_effect=lambda _c, _s, w, ids: [_run(1, 0)])
+
+    report = m.migrate_session(PROJECT)
+    assert (report.source_total, report.ingested, report.degraded) == (3, 1, 2)
+    assert "the source did not return every run it listed" in m.fidelity_reduced
+    written = read_window(sink.written[0]).manifest
+    assert written["run_count"] == 1 and written["runs_scanned"] == 3
+
+
+def test_an_export_needs_no_destination_client(tmp_path, sample_config):
+    m, _ = _exporter(tmp_path, sample_config)
+    assert m.dest_ls_client is None and m.compress_level is None
+
+
+def test_a_replay_reads_back_what_an_export_wrote(tmp_path, sample_config):
+    """The round trip, through both adapters and the same walk."""
+    m, sink = _exporter(tmp_path, sample_config, days=3)
+    m.migrate_session(PROJECT)
+
+    source = ArchiveSource(tmp_path)
+    session = source.sessions()[0]
+    sent = []
+    with patch("langsmith_migrator.core.migrators.trace.Client"):
+        replay = TraceMigrator(
+            _client(), _client(), None, sample_config,
+            range_start=NOW - timedelta(days=3), range_end=NOW,
+            window_hours=24.0, prefetch_windows=2, verify=False, verify_content_sample=0,
+            compress_level=None, run_source=source,
+        )
+    source.bind(replay)
+    replay.resolve_dest_session = Mock(return_value={"id": "NEW", "trace_tier": "longlived"})
+    replay.ensure_long_lived = Mock()
+    replay.existing_ids = Mock(return_value=set())
+    replay.ingest = Mock(side_effect=lambda batch, frame=None: sent.extend(batch) or [])
+
+    report = replay.migrate_session(session)
+    assert report.source_total == 6 and report.ingested == 6
+    assert {p["session_id"] for p in sent} == {"NEW"}
+    assert len(sent) == 6
+
+
+def test_an_end_before_the_start_is_refused(sample_config):
+    with pytest.raises(ValueError, match="must precede"):
+        with patch("langsmith_migrator.core.migrators.trace.Client"):
+            TraceMigrator(
+                _client(), _client(), None, sample_config,
+                range_start=NOW, range_end=NOW - timedelta(days=1),
+            )
+
+
+def test_a_dry_run_previews_an_export_without_writing_anything(tmp_path, sample_config):
+    """Otherwise the preview *is* the export."""
+    sample_config.migration.dry_run = True
+    m, sink = _exporter(tmp_path, sample_config, days=3)
+    sink.dry_run = True
+
+    report = m.migrate_session(PROJECT)
+    assert report.source_total == 6
+    assert list(tmp_path.rglob("*")) == []
+    assert sink.written == [] and sink.staged == []

--- a/tests/test_trace_migrator.py
+++ b/tests/test_trace_migrator.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
 
 from langsmith_migrator.core.api_client import APIError, EnhancedAPIClient
 from langsmith_migrator.core.migrators.trace import (
@@ -36,6 +37,8 @@ def _client() -> Mock:
 
 
 def _migrator(sample_config, state=None, **kwargs):
+    kwargs.setdefault("range_start", NOW - timedelta(days=180))
+    kwargs.setdefault("range_end", NOW)
     with patch("langsmith_migrator.core.migrators.trace.Client"):
         migrator = TraceMigrator(_client(), _client(), state, sample_config, **kwargs)
     migrator.dest_ls_client = Mock()
@@ -369,6 +372,22 @@ def test_the_body_is_compressed_by_default(sample_config, capsys):
     assert "10.0x" in capsys.readouterr().out
 
 
+def test_the_reported_batch_size_is_the_real_one_after_compiling(sample_config, capsys):
+    """The size on the MULTIPART line is the operator's view of what is being
+    written; compilation must not shrink the payloads it is measured from."""
+    m = _migrator(sample_config)
+    payloads = [
+        {"id": "a", "trace_id": "t", "dotted_order": "o", "name": "n", "run_type": "chain",
+         "start_time": "2026-08-26T12:00:00+00:00", "inputs": {"q": "x" * 20_000}}
+    ]
+    m._ingest_responses.append((202, ""))
+    m.ingest(payloads, frame=None)
+    out = capsys.readouterr().out
+    # 20 KB of inputs must still be visible in the reported size, not stripped
+    assert "20." in out or "19." in out, out
+    assert payloads[0]["inputs"]["q"], "inputs were stripped from the caller's payload"
+
+
 def test_no_compress_upload_uses_the_sdk_path(sample_config):
     m = _migrator(sample_config, compress_level=None)
     m.dest_ls_client.multipart_ingest.side_effect = lambda create: m._ingest_responses.append((202, ""))
@@ -598,7 +617,7 @@ def test_the_tier_is_not_restored_while_a_session_is_incomplete(sample_config):
     m.migrate_slice = Mock(side_effect=lambda s, d, w: __import__(
         "langsmith_migrator.core.trace_domain", fromlist=["Reconciliation"]
     ).Reconciliation("src", DEST, w.label(), 1, 0, 0, 0, 1))
-    m.migrate_session({"id": "src", "name": "p", "trace_tier": "shortlived"}, now=NOW)
+    m.migrate_session({"id": "src", "name": "p", "trace_tier": "shortlived"})
     m.restore_tier.assert_not_called()
 
 
@@ -615,7 +634,7 @@ def _dest_get(run_payload):
 
 
 def test_the_canary_blocks_when_the_timestamp_is_rewritten(sample_config, migration_state):
-    m = _migrator(sample_config, migration_state, max_age_days=180)
+    m = _migrator(sample_config, migration_state)
     m.ingest = Mock(return_value=[])
     m.dest.get.side_effect = _dest_get({"start_time": datetime.now(timezone.utc).isoformat()})
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
@@ -625,7 +644,7 @@ def test_the_canary_blocks_when_the_timestamp_is_rewritten(sample_config, migrat
 
 
 def test_the_canary_blocks_when_the_run_never_appears(sample_config, migration_state):
-    m = _migrator(sample_config, migration_state, max_age_days=180)
+    m = _migrator(sample_config, migration_state)
     m.ingest = Mock(return_value=[])
     m.dest.get.side_effect = _dest_get(None)
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
@@ -640,7 +659,7 @@ def test_each_preflight_writes_its_own_canary(sample_config):
     requests are not supported"), after which the read-back found the previous
     invocation's canary and the gate passed having verified nothing.
     """
-    m = _migrator(sample_config, max_age_days=180)
+    m = _migrator(sample_config)
     sent = []
     m.ingest = lambda batch, frame=None: sent.extend(batch) or []
     m.dest.get.side_effect = _dest_get(lambda: {"start_time": sent[-1]["start_time"]})
@@ -655,7 +674,7 @@ def test_each_preflight_writes_its_own_canary(sample_config):
 
 
 def test_a_conflicted_canary_blocks_instead_of_passing(sample_config, migration_state):
-    m = _migrator(sample_config, migration_state, max_age_days=180)
+    m = _migrator(sample_config, migration_state)
     m.ingest = Mock(return_value=[("id", "HTTP 409: duplicate run create")])
     m.dest.get.side_effect = _dest_get({"start_time": "whatever"})
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
@@ -849,12 +868,33 @@ def test_each_query_page_reports_runs_traces_and_size(sample_config, capsys):
         [_run("a", trace="t1"), _run("b", trace="t1"), _run("c", trace="t2")], [_run("d", trace="t3")]
     )
     list(m._query_runs(m.source, "src", WINDOW, select=["id"]))
-    lines = [ln for ln in capsys.readouterr().out.splitlines() if "query source" in ln]
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if "scan " in ln]
     assert len(lines) == 2
     assert "runs" in lines[0] and "traces" in lines[0]
     assert "3" in lines[0] and "2" in lines[0]  # 3 runs across 2 traces
-    assert "total" in lines[1]
+    assert "p1" in lines[0] and "p2" in lines[1] and "total" in lines[1]
     # a wrapped progress line is worse than a terse one
+    assert all(len(ln) <= 80 for ln in lines), lines
+
+
+def test_payload_fetches_are_labelled_by_phase_not_by_page(sample_config, capsys):
+    """Each chunk is its own request, so a per-call page counter restarted at
+    ``p1`` for every one of them and read as a call going backwards."""
+    sample_config.migration.verbose = True
+    m = _migrator(sample_config)
+    m._id_chunk = 2
+    m.source.post.side_effect = lambda _e, body: {
+        "runs": [_run(i) for i in body["id"]], "cursors": {},
+    }
+
+    fetched = list(m.fetch_runs(m.source, "src", WINDOW, ["a", "b", "c", "d", "e"]))
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if "fetch " in ln]
+    assert len(fetched) == 5
+    assert len(lines) == 3
+    # no page number (it would restart at p1 per chunk) and no running total
+    # (it could only restate `runs`), so the chunk size is stated exactly once
+    assert not any("scan" in ln or "p1" in ln or "total" in ln for ln in lines), lines
+    assert [ln.split("runs")[1].split("|")[0].strip() for ln in lines] == ["2", "2", "1"]
     assert all(len(ln) <= 80 for ln in lines), lines
 
 
@@ -945,7 +985,7 @@ def test_a_raised_tier_is_restored_after_a_clean_migration(sample_config):
     src, dest = _raisable(m)
     m.migrate_slice = Mock(side_effect=lambda s, d, w: Reconciliation("src", DEST, w.label(), 0, 0, 0, 0, 0))
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
-        m.migrate_session(src, now=NOW)
+        m.migrate_session(src)
     m.restore_tier.assert_called_once_with(dest, "shortlived")
 
 
@@ -957,7 +997,7 @@ def test_a_raised_tier_is_settled_even_when_the_migration_raises(sample_config, 
     m.migrate_slice = Mock(side_effect=RuntimeError("source query blew up"))
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
         with pytest.raises(RuntimeError, match="blew up"):
-            m.migrate_session(src, now=NOW)
+            m.migrate_session(src)
     # deliberately left raised so a re-run still ingests long-lived...
     m.restore_tier.assert_not_called()
     # ...but never silently
@@ -971,7 +1011,7 @@ def test_an_incomplete_migration_leaves_the_tier_raised_and_says_so(sample_confi
     src, dest = _raisable(m)
     m.migrate_slice = Mock(side_effect=lambda s, d, w: Reconciliation("src", DEST, w.label(), 1, 0, 0, 0, 1))
     with patch("langsmith_migrator.core.migrators.trace.time.sleep"):
-        m.migrate_session(src, now=NOW)
+        m.migrate_session(src)
     m.restore_tier.assert_not_called()
     assert any(i.code == "dest_tier_left_raised" and "blocked runs" in i.summary
                for i in migration_state.issue_log)
@@ -983,7 +1023,7 @@ def test_a_tier_we_never_raised_is_never_touched(sample_config, migration_state)
     m.restore_tier = Mock()
     m.migrate_slice = Mock(side_effect=RuntimeError("boom"))
     with pytest.raises(RuntimeError):
-        m.migrate_session({"id": "src", "name": "p", "trace_tier": "shortlived"}, now=NOW)
+        m.migrate_session({"id": "src", "name": "p", "trace_tier": "shortlived"})
     m.restore_tier.assert_not_called()
     assert not any(i.code == "dest_tier_left_raised" for i in migration_state.issue_log)
 
@@ -1132,3 +1172,42 @@ def test_the_migrator_records_no_remediation_advice(migration_state, sample_conf
         m.migrate_slice({"id": "src"}, {"id": DEST}, WINDOW)
     assert migration_state.issue_log
     assert not any(i.next_action for i in migration_state.issue_log)
+
+
+def test_a_read_timeout_halves_the_id_chunk_like_a_502_does(sample_config):
+    """The server took the request and never finished the body: same problem as
+    a 502 on an oversized response, and requests reports it under two classes.
+    """
+    from langsmith_migrator.core.migrators.trace import _response_too_large
+
+    assert _response_too_large(requests.exceptions.ReadTimeout("read timed out"))
+    assert _response_too_large(
+        requests.exceptions.ConnectionError("HTTPSConnectionPool(...): Read timed out. (read timeout=30)")
+    )
+    assert not _response_too_large(requests.exceptions.ConnectionError("dns failure"))
+
+    m = _migrator(sample_config)
+    calls = {"n": 0}
+
+    def post(_endpoint, body):
+        calls["n"] += 1
+        if len(body.get("id") or []) > 250:
+            raise requests.exceptions.ConnectionError("HTTPSConnectionPool: Read timed out.")
+        return {"runs": [{"id": i} for i in body["id"]], "cursors": {}}
+
+    m.source.post.side_effect = post
+    fetched = list(m.fetch_runs(m.source, "src", WINDOW, [str(i) for i in range(500)]))
+    assert len(fetched) == 500 and m._id_chunk == 250
+
+
+def test_a_destination_project_is_created_without_fields_the_source_lacks(sample_config):
+    """An archive knows a project's name and ID and nothing else, and the
+    endpoint answers 422 to "start_time": null."""
+    m = _migrator(sample_config)
+    m._dest_sessions_named = Mock(return_value=[])
+    sent = []
+    m.dest.post = Mock(side_effect=lambda _e, body: sent.append(body) or {"id": "new"})
+
+    m.resolve_dest_session({"id": "src-id", "name": "from-archive"})
+    assert "start_time" not in sent[0] and "description" not in sent[0]
+    assert sent[0]["trace_tier"] == "longlived" and sent[0]["name"] == "from-archive"

--- a/tests/test_trace_prefetch.py
+++ b/tests/test_trace_prefetch.py
@@ -27,6 +27,8 @@ def _client():
 
 
 def _migrator(sample_config, **kwargs):
+    kwargs.setdefault("range_start", NOW - timedelta(days=6))
+    kwargs.setdefault("range_end", NOW)
     with patch("langsmith_migrator.core.migrators.trace.Client"):
         m = TraceMigrator(_client(), _client(), None, sample_config, **kwargs)
     m.dest_ls_client = Mock()
@@ -44,16 +46,15 @@ def _labels(n_windows):
     """Window labels in the order they must be committed."""
     from langsmith_migrator.core.trace_domain import iter_windows
 
-    return [w.label() for w in iter_windows(NOW - timedelta(days=n_windows), NOW, 1.0)]
+    return [w.label() for w in iter_windows(NOW - timedelta(days=n_windows), NOW, 24.0)]
 
 
 def _drive(m, n_windows=6):
     """Walk n windows of one day each, recording commit order."""
-    end = NOW
-    m.range_start = end - timedelta(days=n_windows)
-    m._resolved_start = m.range_start
-    m.window_days = 1.0
-    return m.migrate_session({"id": "src", "name": "p", "trace_tier": "longlived"}, now=end)
+    m._resolved_start = NOW - timedelta(days=n_windows)
+    m._resolved_end = NOW
+    m.window_hours = 24.0
+    return m.migrate_session({"id": "src", "name": "p", "trace_tier": "longlived"})
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/test_trace_domain.py
+++ b/tests/unit/test_trace_domain.py
@@ -51,7 +51,7 @@ def _run(**kw):
 # Windows
 # --------------------------------------------------------------------------
 def test_windows_are_half_open_and_oldest_first():
-    windows = list(iter_windows(NOW - timedelta(days=3), NOW, window_days=1))
+    windows = list(iter_windows(NOW - timedelta(days=3), NOW, window_hours=24))
     assert [w.start for w in windows] == sorted(w.start for w in windows)
     assert windows[0].start == NOW - timedelta(days=3)
     assert windows[-1].end == NOW
@@ -61,7 +61,7 @@ def test_windows_are_half_open_and_oldest_first():
 
 
 def test_final_window_is_clipped_to_now():
-    windows = list(iter_windows(NOW - timedelta(days=2.5), NOW, window_days=1))
+    windows = list(iter_windows(NOW - timedelta(days=2.5), NOW, window_hours=24))
     assert windows[-1].end == NOW
     assert sum((w.end - w.start).total_seconds() for w in windows) == pytest.approx(2.5 * 86400)
 
@@ -85,33 +85,14 @@ def test_an_empty_or_inverted_range_is_rejected(start, end, window):
         list(iter_windows(start, end, window))
 
 
-@pytest.mark.parametrize("max_age_days", [0, -1, None])
-def test_resolve_range_start_rejects_a_nonpositive_age(max_age_days):
-    from langsmith_migrator.core.trace_domain import resolve_range_start
+def test_a_naive_bound_is_read_as_utc():
+    """Both ends of the walk are absolute stamps; relative ages were removed
+    because each evaluation of "now - N days" denoted a different instant."""
+    from langsmith_migrator.core.trace_domain import as_utc
 
-    with pytest.raises(ValueError):
-        resolve_range_start(NOW, max_age_days, None)
-
-
-def test_an_absolute_stamp_wins_over_a_relative_age():
-    """The whole point: an absolute bound cannot drift as the clock moves."""
-    from langsmith_migrator.core.trace_domain import resolve_range_start
-
-    stamp = datetime(2026, 8, 20, 6, 0, tzinfo=timezone.utc)
-    assert resolve_range_start(NOW, 180.0, stamp) == stamp
-    # evaluated an hour later, the same stamp still means the same instant
-    assert resolve_range_start(NOW + timedelta(hours=1), 180.0, stamp) == stamp
-    # whereas the relative age does not
-    a = resolve_range_start(NOW, 1.0, None)
-    b = resolve_range_start(NOW + timedelta(hours=1), 1.0, None)
-    assert a != b
-
-
-def test_a_naive_stamp_is_read_as_utc():
-    from langsmith_migrator.core.trace_domain import resolve_range_start
-
-    naive = datetime(2026, 8, 20, 6, 0)
-    assert resolve_range_start(NOW, None, naive) == datetime(2026, 8, 20, 6, 0, tzinfo=timezone.utc)
+    assert as_utc(datetime(2026, 8, 20, 6, 0)) == datetime(2026, 8, 20, 6, 0, tzinfo=timezone.utc)
+    aware = datetime(2026, 8, 20, 6, 0, tzinfo=timezone.utc)
+    assert as_utc(aware) is aware or as_utc(aware) == aware
 
 
 def test_bounds_carry_no_run_level_upper_bound_and_a_skew_buffer():
@@ -384,3 +365,28 @@ def test_verified_run_count_only_counts_clean_slices():
     total = Reconciliation.of("S", "D", slices)
     assert total.verified_runs == 4
     assert (total.earliest, total.latest) == ("2026-08-20T00:00:00+00:00", "2026-08-20T12:00:00+00:00")
+
+
+def test_a_window_label_carries_the_time_not_only_the_date():
+    """--window is in hours, so a date-only label made every window of one day
+    print identically - which is what an operator reads to tell them apart."""
+    start = datetime(2026, 9, 1, 22, 0, tzinfo=timezone.utc)
+    assert Window(start, start + timedelta(hours=1)).label() == "2026-09-01T22:00..23:00Z"
+    # the end's date appears only when it differs
+    assert Window(start, start + timedelta(hours=12)).label() == "2026-09-01T22:00..2026-09-02T10:00Z"
+    # fractional hours land on the minute
+    assert Window(start, start + timedelta(hours=1.7)).label() == "2026-09-01T22:00..23:42Z"
+
+
+def test_sub_minute_windows_still_label_distinctly():
+    """Seconds appear only when a bound has them, so the narrow case stays
+    unambiguous without widening every other line."""
+    start = datetime(2026, 9, 1, 22, 0, tzinfo=timezone.utc)
+    labels = [w.label() for w in iter_windows(start, start + timedelta(seconds=36), 0.005)]
+    assert labels == ["2026-09-01T22:00:00..22:00:18Z", "2026-09-01T22:00:18..22:00:36Z"]
+    assert len(set(labels)) == 2
+
+
+def test_a_naive_window_bound_is_labelled_as_utc():
+    naive = datetime(2026, 9, 1, 22, 0)
+    assert Window(naive, naive + timedelta(hours=1)).label() == "2026-09-01T22:00..23:00Z"

--- a/tests/unit/test_trace_frames.py
+++ b/tests/unit/test_trace_frames.py
@@ -98,6 +98,30 @@ def test_a_higher_level_compresses_harder(client):
     assert low.sizes[0] == high.sizes[0]  # same body, different framing
 
 
+def test_the_callers_payloads_survive_compilation(client):
+    """serialize_run_dict pops inputs/outputs/extra/... out of the dict it is
+    given. If that reached the caller's copy, a retry would re-send skeletons
+    and any size measured afterwards would be of the skeleton."""
+    import copy
+
+    pay = _payload(attachments={"blob": ("application/octet-stream", b"\x00" * 512)})
+    pay["extra"] = {"m": 1}
+    pay["events"] = [{"e": 1}]
+    pay["serialized"] = {"s": 1}
+    before = copy.deepcopy(pay)
+    compile_frame(client, [pay], DEFAULT_COMPRESS_LEVEL)
+    assert pay == before, f"stripped: {[k for k in before if k not in pay]}"
+
+
+def test_recompiling_the_same_payload_gives_the_same_frame(client):
+    """The binary split recompiles its halves; it must not get a lesser body."""
+    pay = _payload(blob=400)
+    first = compile_frame(client, [pay], DEFAULT_COMPRESS_LEVEL)
+    second = compile_frame(client, [pay], DEFAULT_COMPRESS_LEVEL)
+    assert first.sizes == second.sizes
+    assert _body(first) == _body(second)
+
+
 def test_a_run_without_dotted_order_is_refused(client):
     bad = _payload()
     del bad["dotted_order"]

--- a/tests/unit/test_trace_resume_hint.py
+++ b/tests/unit/test_trace_resume_hint.py
@@ -23,7 +23,7 @@ def _watermark(verified_runs, span_hours, batch_runs):
 
 def _resume_instant(text):
     """The hint now carries an absolute stamp, which cannot drift."""
-    return dt.datetime.fromisoformat(text.split("--max-age-stamp ")[1].split()[0])
+    return dt.datetime.fromisoformat(text.split("--since ")[1].split()[0])
 
 
 def test_the_overlap_is_one_batch_not_the_whole_span():
@@ -55,7 +55,7 @@ def test_a_project_with_blocked_runs_claims_no_watermark():
         cli_main._print_trace_watermark(Reconciliation("S", "D", "", 2, 1, 0, 0, 1), 100)
     text = "\n".join(printed)
     assert "no verified watermark" in text
-    assert "--max-age-stamp" not in text
+    assert "--since" not in text
 
 
 def test_a_dry_run_explains_nothing_rather_than_blaming_fidelity():
@@ -81,11 +81,11 @@ def test_a_verified_run_with_blocked_runs_does_explain_itself():
 
 def test_window_durations_read_as_wall_clock():
     """The pre-flight prints the window in units an operator thinks in."""
-    h = cli_main._human_duration
-    assert h(0.01) == "14m24s"
-    assert h(0.1) == "2h24m"
-    assert h(1.0) == "1d"
-    assert h(2.5) == "2d12h"
-    assert h((2 * 3600 + 5 * 60 + 4) / 86400) == "2h5m4s"   # the example asked for
-    assert h(1 / 86400) == "1s"
+    h = cli_main._human_duration   # takes hours, since --window does
+    assert h(0.24) == "14m24s"
+    assert h(2.4) == "2h24m"
+    assert h(24.0) == "1d"
+    assert h(60.0) == "2d12h"
+    assert h(2 + 5 / 60 + 4 / 3600) == "2h5m4s"
+    assert h(1 / 3600) == "1s"
     assert h(0) == "0s"


### PR DESCRIPTION
## Long-lived traces: save to disk, load later

Adds `traces --to-archive DIR`, which writes traces to compressed files on disk
instead of sending them to a destination, and `traces --from-archive DIR`, which
loads those files into a destination later. Exporting needs no destination
credentials at all, so this covers air-gapped or staged transfers, re-loading
without re-reading the source, and capturing once to load into several places.
Each file holds one project and one time window
(`<workspace>/<project>/<start>__<end>.tar.zst`) and always contains whole
traces, so it can be loaded on its own. A file is written as `.partial` and
renamed only when it is complete, in time order — so `ls` shows what finished,
and an interrupted export leaves an unbroken run of files rather than a gap in
the middle. To resume, run the same command again: finished windows are skipped.

To make that resumption actually work, the time range is now given as two
required absolute timestamps, `--since` and `--until`, replacing the relative
`--max-age-days` / `--min-age-days`. A relative age means a different moment
every time it is read, which shifted the window boundaries between runs so no
window was ever recognised as already done. `--window` is now in hours rather
than days, since the useful range is well under a day. Also included: several
throughput improvements (zstd compression of the upload body, done by the
threads that fetch the data; concurrent window fetching with uploads still
strictly serial and oldest-first) and fixes for four real failures found testing
against dev and staging — a rate limit that killed a project after ~6 seconds, a
read timeout on large payload fetches, a `409` that reported successfully-written
runs as blocked, and an untracked `ChunkedEncodingError` under concurrent reads.

Tested end to end from dev to staging: 25,900 runs exported and re-loaded with
attachments byte-identical, compression between 22x and 222x on real projects,
and resumption verified by interrupting mid-run and by deleting single window
files. 833 unit tests pass.