### PR TITLE
Fix dataset attachment migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Dataset attachment migration**: a source instance that returns
+  root-relative presigned attachment URLs (e.g.
+  `/api/v1/public/download?jwt=...`, as self-hosted/BYOC instances do) had
+  every attachment silently skipped, since the URL had no host to send the
+  request to. These are now resolved against the source instance and, like
+  trace attachment downloads, pinned to the source's own host with
+  redirects refused. Also, the destination's `/info` is now fetched (once
+  per migration, non-fatally) so the LangSmith SDK can see
+  `dataset_examples_multipart_enabled` and actually include attachments in
+  the upload instead of silently stripping them.
+
 ## [0.0.84] - 2026-09-09
 
 ### Added

--- a/langsmith_migrator/core/migrators/dataset.py
+++ b/langsmith_migrator/core/migrators/dataset.py
@@ -3,6 +3,7 @@
 from typing import Dict, List, Any, Optional, Generator, Tuple
 import requests
 import tempfile
+from urllib.parse import urljoin, urlparse
 import os
 import json
 import hashlib
@@ -176,6 +177,19 @@ class DatasetMigrator(BaseMigrator):
         for example in self.source.get_paginated("/examples", params=params):
             yield example
 
+    def _absolute_source_url(self, url: str) -> str:
+        """Resolve a root-relative presigned URL against the source instance.
+
+        Self-hosted LangSmith serves attachment downloads through its own API
+        (``/api/v1/public/download?jwt=...``) and returns that path without a
+        scheme or host. ``requests`` rejects such a URL outright, so the
+        attachment would be skipped. Absolute URLs (cloud blob stores) pass
+        through unchanged.
+        """
+        if urlparse(url).scheme:
+            return url
+        return urljoin(self.source.base_url, url)
+
     def download_attachments(self, attachments: Dict[str, Any]) -> Dict[str, Tuple[str, str, str]]:
         """
         Download attachments from source to temporary files.
@@ -207,6 +221,7 @@ class DatasetMigrator(BaseMigrator):
                 if not presigned_url:
                     self.log(f"No presigned URL for attachment '{key}', skipping", "warning")
                     continue
+                presigned_url = self._absolute_source_url(presigned_url)
 
                 # Suppress SSL warnings if verification is disabled
                 if not self.source.verify_ssl:
@@ -427,11 +442,15 @@ class DatasetMigrator(BaseMigrator):
         sdk_url = self.dest.base_url.replace("/api/v1", "")
         api_key = self.dest.headers.get("X-API-Key") or self.dest.headers.get("x-api-key", "")
 
-        # Create client kwargs
+        # Hand the SDK the destination's /info payload rather than an empty dict:
+        # create_examples() only sends attachments when it can see
+        # instance_flags.dataset_examples_multipart_enabled, and silently strips
+        # them otherwise. Fetching through our own client keeps SSL/CA/proxy
+        # settings consistent.
         client_kwargs = {
             "api_url": sdk_url,
             "api_key": api_key,
-            "info": {}  # Skip automatic /info fetch to avoid compatibility issues
+            "info": self.dest.get("/info"),
         }
 
         # Add custom session with SSL verification disabled if needed

--- a/langsmith_migrator/core/migrators/dataset.py
+++ b/langsmith_migrator/core/migrators/dataset.py
@@ -178,17 +178,25 @@ class DatasetMigrator(BaseMigrator):
             yield example
 
     def _absolute_source_url(self, url: str) -> str:
-        """Resolve a root-relative presigned URL against the source instance.
+        """Resolve a presigned attachment URL and pin it to the source host.
 
         Self-hosted LangSmith serves attachment downloads through its own API
         (``/api/v1/public/download?jwt=...``) and returns that path without a
-        scheme or host. ``requests`` rejects such a URL outright, so the
-        attachment would be skipped. Absolute URLs (cloud blob stores) pass
-        through unchanged.
+        scheme or host, so root-relative URLs are resolved against the source
+        instance's own base URL. Anything that resolves to a different host is
+        rejected outright rather than silently followed - this also covers a
+        protocol-relative URL (``//evil/x``), which parses with an empty
+        ``scheme`` but still carries its own ``netloc`` that ``urljoin`` would
+        otherwise honor verbatim. This mirrors the validation the trace
+        migrator applies to the same class of URL (see
+        ``TraceMigrator._fetch_blob``).
         """
-        if urlparse(url).scheme:
-            return url
-        return urljoin(self.source.base_url, url)
+        source = urlparse(self.source.base_url)
+        resolved = urljoin(self.source.base_url, url)
+        parsed = urlparse(resolved)
+        if parsed.scheme != source.scheme or parsed.netloc != source.netloc:
+            raise PermissionError("attachment_host_rejected")
+        return resolved
 
     def download_attachments(self, attachments: Dict[str, Any]) -> Dict[str, Tuple[str, str, str]]:
         """
@@ -233,7 +241,7 @@ class DatasetMigrator(BaseMigrator):
                         presigned_url,
                         verify=self.source.verify_ssl,
                         timeout=30,
-                        allow_redirects=True
+                        allow_redirects=False
                     )
                     head_response.raise_for_status()
 
@@ -267,7 +275,8 @@ class DatasetMigrator(BaseMigrator):
                     presigned_url,
                     verify=self.source.verify_ssl,
                     timeout=300,  # 5 minute timeout for large files
-                    stream=True
+                    stream=True,
+                    allow_redirects=False
                 ) as response:
                     response.raise_for_status()
 
@@ -320,6 +329,9 @@ class DatasetMigrator(BaseMigrator):
                 continue
             except requests.exceptions.RequestException as e:
                 self.log(f"Network error downloading attachment '{key}': {e}", "error")
+                continue
+            except PermissionError as e:
+                self.log(f"Attachment '{key}' rejected: {e}", "error")
                 continue
             except ValueError as e:
                 self.log(f"Validation error for attachment '{key}': {e}", "error")
@@ -414,6 +426,32 @@ class DatasetMigrator(BaseMigrator):
             self.log(f"Individual example creation failed: {e}", "error")
             return None
 
+    def _get_dest_info(self) -> Dict[str, Any]:
+        """Fetch and cache the destination instance's /info payload.
+
+        create_examples() only includes attachments in the multipart request
+        when it can see instance_flags.dataset_examples_multipart_enabled, so
+        the SDK client needs this. But /info isn't reachable on every
+        destination topology (e.g. hitting the backend service directly
+        instead of through the frontend route), and the SDK's own client
+        constructor doesn't tolerate a malformed payload - so a failed fetch
+        falls back to an empty dict (attachments then get silently stripped
+        by the SDK, same as before this existed) instead of failing the whole
+        batch, and is only attempted once per migrator instance rather than
+        once per batch.
+        """
+        if not hasattr(self, '_dest_info'):
+            try:
+                self._dest_info = self.dest.get("/info") or {}
+            except Exception as e:
+                self.log(
+                    f"Could not fetch destination /info ({e}); attachments may "
+                    "be stripped by the SDK for this migration",
+                    "warning"
+                )
+                self._dest_info = {}
+        return self._dest_info
+
     def create_examples_with_attachments(
         self,
         dataset_id: str,
@@ -450,7 +488,7 @@ class DatasetMigrator(BaseMigrator):
         client_kwargs = {
             "api_url": sdk_url,
             "api_key": api_key,
-            "info": self.dest.get("/info"),
+            "info": self._get_dest_info(),
         }
 
         # Add custom session with SSL verification disabled if needed

--- a/tests/unit/test_dataset_attachments.py
+++ b/tests/unit/test_dataset_attachments.py
@@ -1,0 +1,85 @@
+"""Attachment handling in DatasetMigrator: URL resolution and SDK client wiring."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from langsmith_migrator.core.migrators.dataset import DatasetMigrator
+
+SOURCE_BASE = "https://source.api.test.com/api/v1"
+DEST_BASE = "https://dest.api.test.com/api/v1"
+RELATIVE_PRESIGNED = "/api/v1/public/download?jwt=eyJhbGciOiJIUzI1NiJ9.payload.sig"
+DEST_INFO = {"version": "0.17.23", "instance_flags": {"dataset_examples_multipart_enabled": True}}
+
+
+@pytest.fixture
+def migrator(sample_config):
+    source = Mock()
+    source.base_url = SOURCE_BASE
+    source.verify_ssl = True
+    dest = Mock()
+    dest.base_url = DEST_BASE
+    dest.headers = {"X-API-Key": "dest-key"}
+    dest.get.return_value = DEST_INFO
+    return DatasetMigrator(source, dest, None, sample_config)
+
+
+def test_relative_presigned_url_is_resolved_against_source_host(migrator):
+    """Self-hosted LangSmith returns /api/v1/public/download?jwt=... with no scheme or host."""
+    resolved = migrator._absolute_source_url(RELATIVE_PRESIGNED)
+
+    assert resolved == f"https://source.api.test.com{RELATIVE_PRESIGNED}"
+
+
+def test_absolute_presigned_url_passes_through_unchanged(migrator):
+    absolute = "https://blobs.example.com/bucket/key?X-Amz-Signature=abc"
+
+    assert migrator._absolute_source_url(absolute) == absolute
+
+
+def test_download_attachments_requests_the_absolute_url(migrator, monkeypatch):
+    seen_urls = []
+
+    def fake_head(url, **kwargs):
+        seen_urls.append(("HEAD", url))
+        response = Mock()
+        response.headers = {"Content-Length": "5", "Content-Type": "text/plain"}
+        return response
+
+    def fake_get(url, **kwargs):
+        seen_urls.append(("GET", url))
+        response = Mock()
+        response.headers = {"Content-Length": "5", "Content-Type": "text/plain"}
+        response.iter_content.return_value = [b"hello"]
+        context = Mock()
+        context.__enter__ = Mock(return_value=response)
+        context.__exit__ = Mock(return_value=False)
+        return context
+
+    monkeypatch.setattr("langsmith_migrator.core.migrators.dataset.requests.head", fake_head)
+    monkeypatch.setattr("langsmith_migrator.core.migrators.dataset.requests.get", fake_get)
+
+    downloaded = migrator.download_attachments(
+        {"attachment.notes.txt": {"presigned_url": RELATIVE_PRESIGNED, "mime_type": "text/plain"}}
+    )
+
+    expected = f"https://source.api.test.com{RELATIVE_PRESIGNED}"
+    assert seen_urls == [("HEAD", expected), ("GET", expected)]
+    assert set(downloaded) == {"attachment.notes.txt"}
+
+
+def test_destination_sdk_client_receives_instance_info(migrator, monkeypatch):
+    """The SDK strips attachments unless it can see dataset_examples_multipart_enabled."""
+    captured_kwargs = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr("langsmith.Client", FakeClient)
+
+    migrator.create_examples_with_attachments("dataset-123", [])
+
+    migrator.dest.get.assert_called_once_with("/info")
+    assert captured_kwargs["info"] == DEST_INFO
+    assert captured_kwargs["api_url"] == "https://dest.api.test.com"

--- a/tests/unit/test_dataset_attachments.py
+++ b/tests/unit/test_dataset_attachments.py
@@ -31,23 +31,37 @@ def test_relative_presigned_url_is_resolved_against_source_host(migrator):
     assert resolved == f"https://source.api.test.com{RELATIVE_PRESIGNED}"
 
 
-def test_absolute_presigned_url_passes_through_unchanged(migrator):
-    absolute = "https://blobs.example.com/bucket/key?X-Amz-Signature=abc"
+def test_same_host_absolute_url_passes_through(migrator):
+    same_host = f"https://source.api.test.com{RELATIVE_PRESIGNED}"
 
-    assert migrator._absolute_source_url(absolute) == absolute
+    assert migrator._absolute_source_url(same_host) == same_host
 
 
-def test_download_attachments_requests_the_absolute_url(migrator, monkeypatch):
-    seen_urls = []
+def test_foreign_host_absolute_url_is_rejected(migrator):
+    """A presigned URL pointing at any other host must never be fetched."""
+    with pytest.raises(PermissionError):
+        migrator._absolute_source_url("https://evil.example.com/steal-me")
+
+
+def test_protocol_relative_url_is_rejected(migrator):
+    """`//host/path` parses with an empty scheme but still names its own host -
+    it must not be treated as a same-host relative path just because
+    urlparse().scheme is falsy."""
+    with pytest.raises(PermissionError):
+        migrator._absolute_source_url("//evil.example.com/steal-me")
+
+
+def test_download_attachments_requests_the_resolved_url_without_redirects(migrator, monkeypatch):
+    seen_calls = []
 
     def fake_head(url, **kwargs):
-        seen_urls.append(("HEAD", url))
+        seen_calls.append(("HEAD", url, kwargs.get("allow_redirects")))
         response = Mock()
         response.headers = {"Content-Length": "5", "Content-Type": "text/plain"}
         return response
 
     def fake_get(url, **kwargs):
-        seen_urls.append(("GET", url))
+        seen_calls.append(("GET", url, kwargs.get("allow_redirects")))
         response = Mock()
         response.headers = {"Content-Length": "5", "Content-Type": "text/plain"}
         response.iter_content.return_value = [b"hello"]
@@ -64,8 +78,27 @@ def test_download_attachments_requests_the_absolute_url(migrator, monkeypatch):
     )
 
     expected = f"https://source.api.test.com{RELATIVE_PRESIGNED}"
-    assert seen_urls == [("HEAD", expected), ("GET", expected)]
+    assert seen_calls == [("HEAD", expected, False), ("GET", expected, False)]
     assert set(downloaded) == {"attachment.notes.txt"}
+
+
+def test_download_attachments_skips_rejected_host_without_making_requests(migrator, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.dataset.requests.head",
+        lambda *a, **k: calls.append("HEAD"),
+    )
+    monkeypatch.setattr(
+        "langsmith_migrator.core.migrators.dataset.requests.get",
+        lambda *a, **k: calls.append("GET"),
+    )
+
+    downloaded = migrator.download_attachments(
+        {"attachment.notes.txt": {"presigned_url": "https://evil.example.com/x", "mime_type": "text/plain"}}
+    )
+
+    assert downloaded == {}
+    assert calls == []
 
 
 def test_destination_sdk_client_receives_instance_info(migrator, monkeypatch):
@@ -83,3 +116,31 @@ def test_destination_sdk_client_receives_instance_info(migrator, monkeypatch):
     migrator.dest.get.assert_called_once_with("/info")
     assert captured_kwargs["info"] == DEST_INFO
     assert captured_kwargs["api_url"] == "https://dest.api.test.com"
+
+
+def test_destination_info_is_fetched_once_and_cached(migrator, monkeypatch):
+    """/info must not be re-fetched (and re-retried) on every batch."""
+    monkeypatch.setattr("langsmith.Client", Mock())
+
+    migrator.create_examples_with_attachments("dataset-123", [])
+    migrator.create_examples_with_attachments("dataset-123", [])
+
+    migrator.dest.get.assert_called_once_with("/info")
+
+
+def test_destination_info_fetch_failure_falls_back_to_empty_dict(migrator, monkeypatch):
+    """A destination where /info isn't reachable must not fail the whole batch -
+    it should fall back to {} so examples still land, just without the
+    attachments multipart flag."""
+    captured_kwargs = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr("langsmith.Client", FakeClient)
+    migrator.dest.get.side_effect = Exception("404 Not Found")
+
+    migrator.create_examples_with_attachments("dataset-123", [])
+
+    assert captured_kwargs["info"] == {}


### PR DESCRIPTION
## Summary
- Fixes attachments not downloading from self-hosted source instances
- Fixes attachments being silently dropped when uploading to the destination

## Test plan
- [x] Added unit tests covering both fixes
- [x] Full unit test suite passes